### PR TITLE
extract_toc: skip static content

### DIFF
--- a/extract_toc/extract_toc.py
+++ b/extract_toc/extract_toc.py
@@ -8,10 +8,12 @@ and place it in its own article.toc variable.
 
 from os import path
 from bs4 import BeautifulSoup
-from pelican import signals, readers
+from pelican import signals, readers, contents
 
 
 def extract_toc(content):
+    if isinstance(content, contents.Static):
+        return
     soup = BeautifulSoup(content._content)
     filename = content.source_path
     extension = path.splitext(filename)[1][1:]


### PR DESCRIPTION
Static content (e.g. FILES_TO_COPY) doesn't have any content for extract_toc to handle. Instead of trying to parse the content anyway (which results in a critical error), extract_toc should just ignore the content.
