### PR TITLE
Added an initial version of the 'git_date' plugin.

### DIFF
--- a/git_date/Readme.rst
+++ b/git_date/Readme.rst
@@ -1,0 +1,18 @@
+Date Metadata from GIT
+----------------------
+
+This plugin allows to use git timestamps as `date` metadata. This enables you to
+avoid explicitly defining timestamps for each of your posts if your content is
+stored in a git repository. 
+
+This plugin will overwrite explicitly set `date` metadata.
+
+
+Settings
+========
+
+You can set `GIT_TIME_LAST_MODIFIED` to `True` or `False` in your pelican
+configuration (Default: False). When choosing `True`, timestamps of contents
+will be computed from timestamps of the commit containing the *last
+modification* of the file. When choosing `False`, timestamps of the *first
+commit* containing the file will be used. 

--- a/git_date/__init__.py
+++ b/git_date/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+from .git_date import *

--- a/git_date/git_date.py
+++ b/git_date/git_date.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+from pelican import signals
+from pelican.utils import strftime
+
+from datetime import datetime
+import os
+import subprocess
+
+
+def git_mtime(filename, use_last_modification=True, git_binary="git"):
+    """Determines the git modification time of a file and returns it as a
+    datetime.datetime object.
+
+    If use_last_modification is True, then the date and time of the last
+    modification will be returned. Otherwise the date and time of the first
+    commit containing the file will be returned.
+
+    The optional argument 'git_binary' can be used to specify the git binary to
+    use.
+    """
+
+    call = [git_binary, "log", r"--pretty=format:%at ", filename]
+    repository= os.path.dirname(filename)
+    try:
+        output = subprocess.check_output(call, cwd=repository).decode('utf-8').splitlines()
+    except Exception as e:
+        print("ERROR: Could not get git time information for {0}: {1}".format(filename, str(e)))
+        return None
+
+    dates = [ datetime.fromtimestamp(int(x)) for x in output ]
+    sorted_dates = sorted(dates)
+
+    if len(sorted_dates) > 0:
+        return sorted_dates[-1] if use_last_modification else sorted_dates[0]
+    return None
+
+
+def generate_date(content):
+    mode = content.settings.get('GIT_TIME_LAST_MODIFIED', False)
+    date = git_mtime(content.source_path, mode)
+
+    if not date:
+        # This happens usually when the file is not checked into git yet. It
+        # is probably a new file and 'now' should be the correct time
+        date = datetime.now()
+
+    content.metadata['date'] = date
+    content.date = date
+    content.locale_date = strftime(content.date, content.date_format)
+
+def register():
+    signals.content_object_init.connect(generate_date)


### PR DESCRIPTION
The 'git_date' plugin uses git logs to compute date metadata so that
post dates do not have to explicitly set.
