### PR TITLE
Fix jpegtran command line

### DIFF
--- a/optimize_images/optimize_images.py
+++ b/optimize_images/optimize_images.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 # A list of file types with their respective commands
 COMMANDS = [
-    ('.jpg', 'jpegtran -copy none -optimize "{filename}" "{filename}"'),
+    ('.jpg', 'jpegtran -copy none -optimize -outfile "{filename}" "{filename}"'),
     ('.png', 'optipng "{filename}"'),
 ]
 


### PR DESCRIPTION
Fix the non-processing of jpeg files.

Fix the error:

```
jpegtran: only one input file
```
