### PR TITLE
Improved the example template code in the multi_part plugin readme

### DIFF
--- a/multi_part/Readme.md
+++ b/multi_part/Readme.md
@@ -13,20 +13,12 @@ to display other parts of current post.
 For example:
 
     {% if article.metadata.parts_articles %}
+        <p>This post is part of a series:</p>
         <ol class="parts">
-        <li>Post parts</li>
-        {% for part_article in article.metadata.parts_articles %}
-            {% if part_article == article %}
-                <li class="active">
-                    <a href='{{ SITEURL }}/{{ part_article.url }}'>{{ part_article.title }}
-                    </a>
+            {% for part_article in article.metadata.parts_articles %}
+                <li {% if part_article == article %}class="active"{% endif %}>
+                    <a href='{{ SITEURL }}/{{ part_article.url }}'>{{ part_article.title }}</a>
                 </li>
-            {% else %}
-                <li>
-                    <a href='{{ SITEURL }}/{{ part_article.url }}'>{{ part_article.title }}
-                    </a>
-                </li>
-            {% endif %}
-        {% endfor %}
+            {% endfor %}
         </ol>
     {% endif %}


### PR DESCRIPTION
The old example wasn't great - you end up with the heading as the first item in the list, and the if statement is un-necessarily long.
