### PR TITLE
Fix summary plugin not properly updating asset paths in summaries.

### DIFF
--- a/summary/summary.py
+++ b/summary/summary.py
@@ -54,7 +54,7 @@ def content_object_init(instance):
                             len(instance.settings['SUMMARY_BEGIN_MARKER'])
                             if begin_summary != -1 else 0)
             end_summary = end_summary if end_summary != -1 else None
-            instance._summary = content[begin_summary:end_summary]
+            instance._summary = instance._update_content(content[begin_summary:end_summary], instance._context.get('localsiteurl', ''))
 
 def register():
     signals.initialized.connect(initialized)


### PR DESCRIPTION
RST files with figures in the summary were not properly displaying the image, because the path was not properly being rewritten with the "|filename|" substituted with the proper path.

Calling _update_content() performs the proper regex substitutions.
