### PR TITLE
assets: add support for named bundles via the settings file

### DIFF
--- a/assets/Readme.rst
+++ b/assets/Readme.rst
@@ -64,6 +64,19 @@ The above will produce a minified and gzipped JS file:
 Pelican's debug mode is propagated to Webassets to disable asset packaging
 and instead work with the uncompressed assets.
 
+If you need to create named bundles (for example, if you need to compile SASS
+files before minifying with other CSS files), you can use the ``ASSET_BUNDLES``
+variable in your settings file. This is an ordered sequence of 3-tuples, where
+the 3-tuple is defined as ``(name, args, kwargs)``. This tuple is passed to the
+`environment's register() method`_. The following will compile two SCSS files
+into a named bundle, using the ``pyscss`` filter:
+
+.. code-block:: python
+
+    ASSET_BUNDLES = (
+        ('scss', ['colors.scss', 'main.scss'], {'filters': 'pyscss'}),
+    )
+
 Many of Webasset's available compilers have additional configuration options
 (i.e. 'Less', 'Sass', 'Stylus', 'Closure_js').  You can pass these options to
 Webassets using the ``ASSET_CONFIG`` in your settings file.
@@ -78,3 +91,4 @@ LessCSS's binary:
 
 .. _Webassets: https://github.com/miracle2k/webassets
 .. _Webassets documentation: http://webassets.readthedocs.org/en/latest/builtin_filters.html
+.. _environment's register() method: http://webassets.readthedocs.org/en/latest/environment.html#registering-bundles

--- a/assets/assets.py
+++ b/assets/assets.py
@@ -46,6 +46,10 @@ def create_assets_env(generator):
         for item in generator.settings['ASSET_CONFIG']:
             generator.env.assets_environment.config[item[0]] = item[1]
 
+    if 'ASSET_BUNDLES' in generator.settings:
+        for name, args, kwargs in generator.settings['ASSET_BUNDLES']:
+            generator.env.assets_environment.register(name, *args, **kwargs)
+
     if logging.getLevelName(logger.getEffectiveLevel()) == "DEBUG":
         generator.env.assets_environment.debug = True
 


### PR DESCRIPTION
I added a new settings variable to the assets plugin, `ASSET_BUNDLES`, so that you can work with named/nested bundles. In my case, I want to compile SCSS files first (specified in the settings file), then minify the output of that plus a couple of other CSS files (specified in the Jinja template).
