### PR TITLE
assets: add support for specifying additional source load paths

### DIFF
--- a/assets/Readme.rst
+++ b/assets/Readme.rst
@@ -76,5 +76,17 @@ LessCSS's binary:
     ASSET_CONFIG = (('closure_compressor_optimization', 'WHITESPACE_ONLY'),
                     ('less_bin', 'lessc.cmd'), )
 
+If you wish to place your assets in locations other than the theme output
+directory, you can use ``ASSET_SOURCE_PATHS`` in your settings file to provide
+webassets with a list of additional directories to search, relative to the
+theme's top-level directory. For example:
+
+.. code-block:: python
+
+   ASSET_SOURCE_PATHS = (
+       'vendor/css',
+       'scss',
+   )
+
 .. _Webassets: https://github.com/miracle2k/webassets
 .. _Webassets documentation: http://webassets.readthedocs.org/en/latest/builtin_filters.html

--- a/assets/assets.py
+++ b/assets/assets.py
@@ -49,6 +49,14 @@ def create_assets_env(generator):
     if logging.getLevelName(logger.getEffectiveLevel()) == "DEBUG":
         generator.env.assets_environment.debug = True
 
+    if 'ASSET_SOURCE_PATHS' in generator.settings:
+        # the default load path gets overridden if additional paths are
+        # specified, add it back
+        generator.env.assets_environment.append_path(assets_src)
+        for path in generator.settings['ASSET_SOURCE_PATHS']:
+            full_path = os.path.join(generator.theme, path)
+            generator.env.assets_environment.append_path(full_path)
+
 
 def register():
     """Plugin registration."""


### PR DESCRIPTION
Adds a new settings variable to the assets plugin, `ASSET_SOURCE_PATHS`, so that you can specify additional paths from which assets are loaded.

Relevant webassets documentation: http://webassets.readthedocs.org/en/latest/environment.html#webassets.env.Environment.load_path
