### PR TITLE
Removing debug printing statements from thumbnailer

### DIFF
--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -146,8 +146,6 @@ def expand_gallery(generator, metadata):
     :return: None
     """
     if "gallery" not in metadata or metadata['gallery'] is None:
-        import pprint
-        pprint.pprint(metadata)
         return  # If no gallery specified, we do nothing
 
     lines = [ ]


### PR DESCRIPTION
Accidentally left in a debugging print statement in the thumbnailer which spews on regeneration.
