### PR TITLE
Update signal name to the correct signal

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -65,7 +65,7 @@ def register():
     """
     try:
         signals.article_generator_init.connect(feed_parser_initialization)
-        signals.article_generate_context.connect(fetch_github_activity)
+        signals.article_generator_context.connect(fetch_github_activity)
     except ImportError:
         logger.warning('`github_activity` failed to load dependency `feedparser`.'
                        '`github_activity` plugin not loaded.')


### PR DESCRIPTION
getpelican/pelican@f2d6f77462976f5ea291481cba40e041d42d9e8c changed
`article_generate_context` to `article_generator_context`. This commit
updates the plugin to reflect the change.
