### PR TITLE
Update article_generate_context to article_generator_context

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -65,7 +65,7 @@ def register():
     """
     try:
         signals.article_generator_init.connect(feed_parser_initialization)
-        signals.article_generate_context.connect(fetch_github_activity)
+        signals.article_generator_context.connect(fetch_github_activity)
     except ImportError:
         logger.warning('`github_activity` failed to load dependency `feedparser`.'
                        '`github_activity` plugin not loaded.')

--- a/global_license/global_license.py
+++ b/global_license/global_license.py
@@ -15,4 +15,4 @@ def add_license(generator, metadata):
             metadata['license'] = generator.settings['LICENSE']
 
 def register():
-    signals.article_generate_context.connect(add_license)
+    signals.article_generator_context.connect(add_license)

--- a/goodreads_activity/goodreads_activity.py
+++ b/goodreads_activity/goodreads_activity.py
@@ -57,7 +57,7 @@ def initialize_feedparser(generator):
 def register():
     try:
         signals.article_generator_init.connect(initialize_feedparser)
-        signals.article_generate_context.connect(fetch_goodreads_activity)
+        signals.article_generator_context.connect(fetch_goodreads_activity)
     except ImportError:
         logger.warning('`goodreads_activity` failed to load dependency `feedparser`.'
                        '`goodreads_activity` plugin not loaded.')

--- a/gravatar/gravatar.py
+++ b/gravatar/gravatar.py
@@ -28,4 +28,4 @@ def add_gravatar(generator, metadata):
 
 
 def register():
-    signals.article_generate_context.connect(add_gravatar)
+    signals.article_generator_context.connect(add_gravatar)

--- a/latex/latex.py
+++ b/latex/latex.py
@@ -44,5 +44,5 @@ def register():
     """
         Plugin registration
     """
-    signals.article_generate_context.connect(addLatex)
+    signals.article_generator_context.connect(addLatex)
     signals.pages_generate_context.connect(addLatex)

--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -172,4 +172,4 @@ def expand_gallery(generator, metadata):
 
 def register():
     signals.finalized.connect(resize_thumbnails)
-    signals.article_generate_context.connect(expand_gallery)
+    signals.article_generator_context.connect(expand_gallery)


### PR DESCRIPTION
getpelican/pelican@f2d6f77462976f5ea291481cba40e041d42d9e8c changed
`article_generate_context` to `article_generator_context`. This commit
updates the plugin to reflect the change.
