### PR TITLE
page doesn't have category

### DIFF
--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -38,10 +38,13 @@ class Tipue_Search_JSON_Generator(object):
         soup = BeautifulSoup(page.content, 'html.parser')
         page_text = soup.get_text()
 
-        if getattr(page, 'category') == 'None':
+        try:
+            if getattr(page, 'category') == 'None':       
+                page_category = ''
+            else:
+                page_category = page.category.name
+        except AttributeError:
             page_category = ''
-        else:
-            page_category = page.category.name
 
         page_url = self.siteurl + '/' + page.url
 


### PR DESCRIPTION
Tipue_search is not working with page. because, page(e.g., “About”, “Projects”, “Contact”) doesn't have category.
