### PR TITLE
Add missing __init__ to gallery plugin

### DIFF
--- a/gallery/__init__.py
+++ b/gallery/__init__.py
@@ -1,0 +1,1 @@
+from .gallery import *


### PR DESCRIPTION
For fix it

```
CRITICAL: 'pelican.contents.Page object' has no attribute 'gallery'
```
