### PR TITLE
Update signal names for Pelican 3.2+

### DIFF
--- a/gallery/gallery.py
+++ b/gallery/gallery.py
@@ -47,4 +47,4 @@ def generate_gallery_page(generator):
 
 def register():
     signals.article_generator_finalized.connect(add_gallery_post)
-    signals.pages_generator_finalized.connect(generate_gallery_page)
+    signals.page_generator_finalized.connect(generate_gallery_page)

--- a/ical/ical.py
+++ b/ical/ical.py
@@ -48,5 +48,5 @@ def add_ical(generator, metadata):
 
 
 def register():
-    signals.pages_generator_init.connect(init_cal)
-    signals.pages_generate_context.connect(add_ical)
+    signals.page_generator_init.connect(init_cal)
+    signals.page_generator_context.connect(add_ical)

--- a/latex/latex.py
+++ b/latex/latex.py
@@ -45,4 +45,4 @@ def register():
         Plugin registration
     """
     signals.article_generator_context.connect(addLatex)
-    signals.pages_generate_context.connect(addLatex)
+    signals.page_generator_context.connect(addLatex)


### PR DESCRIPTION
According to http://docs.getpelican.com/en/3.3.0/plugins.html#plugins, signal names had been changed from Pelican 3.2. But there are still several old signal names in pelican plugins code. This commit updates all old names to corresponding new ones.
