### PR TITLE
BUG: use relative import for mdx_liquid_tags

### DIFF
--- a/liquid_tags/liquid_tags.py
+++ b/liquid_tags/liquid_tags.py
@@ -1,5 +1,5 @@
 from pelican import signals
-from mdx_liquid_tags import LiquidTags
+from .mdx_liquid_tags import LiquidTags
 
 
 def addLiquidTags(gen):


### PR DESCRIPTION
This should fix #84.
