### PR TITLE
revised the latex plugin so that it will work under both http and https protocols

### DIFF
--- a/latex/latex.py
+++ b/latex/latex.py
@@ -11,21 +11,28 @@ writing equations in by using `\begin{equation}`...`\end{equation}`.
 
 from pelican import signals
 
+# Reference about dynamic loading of MathJax can be found at http://docs.mathjax.org/en/latest/dynamic.html
+# The https cdn address can be found at http://www.mathjax.org/resources/faqs/#problem-https
 latexScript = """
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type= "text/javascript">
-       MathJax.Hub.Config({
-           config: ["MMLorHTML.js"],
-           jax: ["input/TeX","input/MathML","output/HTML-CSS","output/NativeMML"],
-           TeX: { extensions: ["AMSmath.js","AMSsymbols.js","noErrors.js","noUndefined.js"], equationNumbers: { autoNumber: "AMS" } },
-           extensions: ["tex2jax.js","mml2jax.js","MathMenu.js","MathZoom.js"],
-           tex2jax: { 
-               inlineMath: [ [\'$\',\'$\'] ],
-               displayMath: [ [\'$$\',\'$$\'] ],
-               processEscapes: true },
-           "HTML-CSS": {
-               styles: { ".MathJax .mo, .MathJax .mi": {color: "black ! important"}}
-           }
-       });
+    <script type= "text/javascript">
+        var s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.src = 'https:' == document.location.protocol ? 'https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js' : 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'; 
+        s[(window.opera ? "innerHTML" : "text")] =
+            "MathJax.Hub.Config({" + 
+            "    config: ['MMLorHTML.js']," + 
+            "    jax: ['input/TeX','input/MathML','output/HTML-CSS','output/NativeMML']," +
+            "    TeX: { extensions: ['AMSmath.js','AMSsymbols.js','noErrors.js','noUndefined.js'], equationNumbers: { autoNumber: 'AMS' } }," + 
+            "    extensions: ['tex2jax.js','mml2jax.js','MathMenu.js','MathZoom.js']," +
+            "    tex2jax: { " +
+            "        inlineMath: [ [\'$\',\'$\'] ], " +
+            "        displayMath: [ [\'$$\',\'$$\'] ]," +
+            "        processEscapes: true }, " +
+            "    'HTML-CSS': { " +
+            "        styles: { '.MathJax .mo, .MathJax .mi': {color: 'black ! important'}} " +
+            "    } " +
+            "}); ";
+        (document.body || document.getElementsByTagName('head')[0]).appendChild(s);
     </script>
 """
 
@@ -44,5 +51,5 @@ def register():
     """
         Plugin registration
     """
-    signals.article_generator_context.connect(addLatex)
-    signals.page_generator_context.connect(addLatex)
+    signals.article_generate_context.connect(addLatex)
+    signals.pages_generate_context.connect(addLatex)


### PR DESCRIPTION
The previous implementation of `latex` plugin can only work under http protocol, because it uses the http version of `MathJax`'s CDN, which will be blocked by some browsers by default if the website is under https. This will cause the equations fail to be rendered.

This commit utilizes `MathJax`'s [dynamic loading](http://docs.mathjax.org/en/latest/dynamic.html) with [https URL of CDN](http://www.mathjax.org/resources/faqs/#problem-https) to make the plugin work under both http and https protocols, with the capability to use the correct URL accordingly.

It has been tested in IE 9, IE 10, and Chrome 30.0.1599.69. An example under https can be found [here](https://grapeot.me/some-technical-details-about-kinectfusion.html).
