### PR TITLE
Make liquid video support relative url path and pelican internal content.

### DIFF
--- a/liquid_tags/test_video.py
+++ b/liquid_tags/test_video.py
@@ -1,0 +1,39 @@
+import unittest
+from .video import video
+
+
+class TestVideoTag(unittest.TestCase):
+    def setUp(self):
+        self.preprocessor = None
+        self.tag = 'video'
+
+    def test_normal_example(self):
+        markup = 'http://site.com/video.mp4 720 480 http://site.com/poster-frame.jpg'
+        expected = (
+            "<video width='720' height='480' preload='none' controls poster='http://site.com/poster-frame.jpg'>"
+            "<source src='http://site.com/video.mp4' type='video/mp4; codecs=\"avc1.42E01E, mp4a.40.2\"'>"
+            "</video>")
+        actual = video(self.preprocessor, self.tag, markup)
+        self.assertEqual(actual, expected)
+
+    def test_relative_path(self):
+        markup = 'files/video.mp4 720 480 images/poster-frame.jpg'
+        expected = (
+            "<video width='720' height='480' preload='none' controls poster='images/poster-frame.jpg'>"
+            "<source src='files/video.mp4' type='video/mp4; codecs=\"avc1.42E01E, mp4a.40.2\"'>"
+            "</video>")
+        actual = video(self.preprocessor, self.tag, markup)
+        self.assertEqual(actual, expected)
+
+    def test_internal_content(self):
+        markup = '{filename}../files/video.mp4 720 480 {filename}../images/poster-frame.jpg'
+        expected = (
+            "<video width='720' height='480' preload='none' controls poster='{filename}../images/poster-frame.jpg'>"
+            "<source src='{filename}../files/video.mp4' type='video/mp4; codecs=\"avc1.42E01E, mp4a.40.2\"'>"
+            "</video>")
+        actual = video(self.preprocessor, self.tag, markup)
+        self.assertEqual(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/liquid_tags/video.py
+++ b/liquid_tags/video.py
@@ -24,9 +24,14 @@ import os
 import re
 from .mdx_liquid_tags import LiquidTags
 
-SYNTAX = "{% video url/to/video [url/to/video] [url/to/video] [width height] [url/to/poster] %}"
+SYNTAX = "{% video [http[s]://]path/to/video [[http[s]://]path/to/video] [[http[s]://]path/to/video] [width height] [[http[s]://]path/to/poster] %}"
 
 VIDEO = re.compile(r'(/\S+|https?:\S+)(\s+(/\S+|https?:\S+))?(\s+(/\S+|https?:\S+))?(\s+(\d+)\s(\d+))?(\s+(/\S+|https?:\S+))?')
+VIDEO = re.compile(
+    r'((?:https?://|/|\S+/)\S+)(\s+((?:https?://|/|\S+/)\S+))?(\s+((?:https?://|/|\S+/)\S+))?'  # Up to 3 videos
+    r'(\s+(\d+)\s(\d+))?'  # width and height
+    r'(\s+((?:https?://|/|\S+/)\S+))?'  # poster
+)
 
 VID_TYPEDICT = {'.mp4':"type='video/mp4; codecs=\"avc1.42E01E, mp4a.40.2\"'",
                 '.ogv':"type='video/ogg; codecs=theora, vorbis'",
@@ -66,5 +71,5 @@ def video(preprocessor, tag, markup):
 
 
 #----------------------------------------------------------------------
-# This import allows image tag to be a Pelican plugin
+# This import allows video tag to be a Pelican plugin
 from liquid_tags import register


### PR DESCRIPTION
I'd like to make liquid video tag support relative url path (such as `../videos/xxx.mp4`) and pelican internal content (e.g. `{filename}../videos/2013/xxx.mp4`).

A unit test is also added to verify the functionality.
