### PR TITLE
latex: fix signal names to standardized (pelican-3.2 and later)

### DIFF
--- a/latex/latex.py
+++ b/latex/latex.py
@@ -51,5 +51,5 @@ def register():
     """
         Plugin registration
     """
-    signals.article_generate_context.connect(addLatex)
-    signals.pages_generate_context.connect(addLatex)
+    signals.article_generator_context.connect(addLatex)
+    signals.page_generator_context.connect(addLatex)


### PR DESCRIPTION
The names were accidentally reverted to pre-pelican-3.2 in
5fa7ddc0ea08d517c4a767ceaa1df6ccc4d721c "revised the latex plugin so
that it will work in both http and https protocols".
