### PR TITLE
Fixed article and page signal names.

### DIFF
--- a/latex/latex.py
+++ b/latex/latex.py
@@ -51,5 +51,5 @@ def register():
     """
         Plugin registration
     """
-    signals.article_generate_context.connect(addLatex)
-    signals.pages_generate_context.connect(addLatex)
+    signals.article_generator_context.connect(addLatex)
+    signals.page_generator_context.connect(addLatex)


### PR DESCRIPTION
Signal names were fixed before but were reverted to old names in a subsequent commit.
