### PR TITLE
Liquid Tags (Youtube)

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -14,7 +14,8 @@ First, in your pelicanconf.py file, add the plugins you want to  use:
 
     PLUGIN_PATH = '/path/to/pelican-plugins'
     PLUGINS = ['liquid_tags.img', 'liquid_tags.video',
-               'liquid_tags.include_code', 'liquid_tags.notebook']
+               'liquid_tags.youtube', 'liquid_tags.include_code',
+               'liquid_tags.notebook']
 
 There are several options available
 
@@ -24,6 +25,14 @@ To insert a sized and labeled image in your document, enable the
 
     {% img [class name(s)] path/to/image [width [height]] [title text | "title text" ["alt text"]] %}
 
+## Youtube Tag
+To insert youtube video into a post, enable the
+``liquid_tags.youtube`` plugin, and add to your document:
+
+    {% youtube youtube_id [width] [height] %}
+
+The width and height are in pixels, and can be optionally specified.  If they
+are not, then the dimensions will be 640 (wide) by 390 (tall).
 
 ## Video Tag
 To insert flash/HTML5-friendly video into a post, enable the

--- a/liquid_tags/youtube.py
+++ b/liquid_tags/youtube.py
@@ -1,0 +1,53 @@
+"""
+Youtube Tag
+---------
+This implements a Liquid-style youtube tag for Pelican,
+based on the jekyll / octopress youtube tag [1]_
+
+Syntax
+------
+{% youtube id [width height] %}
+
+Example
+-------
+{% youtube dQw4w9WgXcQ 640 480 %}
+
+Output
+------
+<iframe width="640" height="480" src="http://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+
+[1] https://gist.github.com/jamieowen/2063748
+"""
+import os
+import re
+from .mdx_liquid_tags import LiquidTags
+
+SYNTAX = "{% youtube id [width height] %}"
+
+YOUTUBE = re.compile(r'(\w+)(\s+(\d+)\s(\d+))?')
+
+@LiquidTags.register('youtube')
+def youtube(preprocessor, tag, markup):
+    width = 640
+    height = 390
+    youtube_id = None
+
+    match = YOUTUBE.search(markup)
+    if match:
+        groups = match.groups()
+        youtube_id = groups[0]
+        width = groups[2] or width
+        height = groups[3] or height
+
+    if youtube_id:
+        youtube_out = "<iframe width='{width}' height='{height}' src='http://www.youtube.com/embed/{youtube_id}' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>".format(width=width, height=height, youtube_id=youtube_id)
+    else:
+        raise ValueError("Error processing input, "
+                         "expected syntax: {0}".format(SYNTAX))
+
+    return youtube_out
+
+
+#----------------------------------------------------------------------
+# This import allows image tag to be a Pelican plugin
+from liquid_tags import register


### PR DESCRIPTION
This adds on to the existing work on Liquid-style tags and includes a youtube tag similar to [this Jekyll plugin](https://gist.github.com/jamieowen/2063748). 
- To insert a youtube video:
  
  ```
  {% youtube youtube_id [width] [height] %}
  ```
