### PR TITLE
Update sitemap plugin to play nicely with modified metadata

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -158,6 +158,8 @@ class SitemapGenerator(object):
 
     def get_date_modified(self, page, defalut):
         if hasattr(page, 'modified'):
+            if isinstance(getattr(page, 'modified'), datetime):
+                return getattr(page, 'modified')
             return get_date(getattr(page, 'modified'))
         else:
             return defalut


### PR DESCRIPTION
modified is a string in pelican <= 3.3 and datetime > 3.3

Sitemap used to treat it as string.
