### PR TITLE
Use THEME_STATIC_DIR instead of hardcoded 'theme'

### DIFF
--- a/assets/assets.py
+++ b/assets/assets.py
@@ -39,7 +39,8 @@ def create_assets_env(generator):
     """Define the assets environment and pass it to the generator."""
 
     assets_url = 'theme/'
-    assets_src = os.path.join(generator.output_path, 'theme')
+    theme_static_dir = generator.settings['THEME_STATIC_DIR']
+    assets_src = os.path.join(generator.output_path, theme_static_dir)
     generator.env.assets_environment = Environment(assets_src, assets_url)
 
     if 'ASSET_CONFIG' in generator.settings:


### PR DESCRIPTION
The output folder for the theme can be changed via `THEME_STATIC_DIR` setting. But the assets plugin uses the harcoded `theme` string. This small patch makes the asset plugin use the setting.
