### PR TITLE
The `asset_url` was also hardcoded instead of using `theme_static_dir`

### DIFF
--- a/assets/assets.py
+++ b/assets/assets.py
@@ -38,10 +38,10 @@ def add_jinja2_ext(pelican):
 def create_assets_env(generator):
     """Define the assets environment and pass it to the generator."""
 
-    assets_url = 'theme/'
     theme_static_dir = generator.settings['THEME_STATIC_DIR']
     assets_src = os.path.join(generator.output_path, theme_static_dir)
-    generator.env.assets_environment = Environment(assets_src, assets_url)
+    generator.env.assets_environment = Environment(
+        assets_src, theme_static_dir)
 
     if 'ASSET_CONFIG' in generator.settings:
         for item in generator.settings['ASSET_CONFIG']:


### PR DESCRIPTION
Forgot this change in the previous pull-request. I was using hardcoded paths in my template.

If the destination changes in the output folder (using `THEME_STATIC_DIR`) also the URL used for the assets should change and use the `THEME_STATIC_DIR` instead of the hardocded `theme/`
