### PR TITLE
bs4 -> beautifulsoup4

### DIFF
--- a/better_figures_and_images/readme.rst
+++ b/better_figures_and_images/readme.rst
@@ -1,7 +1,7 @@
 Requirements
 ------------
 
-* pip install pillow bs4
+* pip install pillow beautifulsoup4
 
 Summary
 ===========


### PR DESCRIPTION
The name of the package in pip is `beautifulsoup4`, not `bs4`.
