### PR TITLE
Youtube align

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -34,7 +34,7 @@ To insert youtube video into a post, enable the
 The width and height are in pixels, and can be optionally specified. The align
 field is also optional and follows the attributes of the [W3C text-align]
 specification. If they are not specified, then the dimensions will be
-640 (wide) by 390 (tall) and default right alignment.
+640 (wide) by 390 (tall) and default left alignment.
 
 ## Video Tag
 To insert flash/HTML5-friendly video into a post, enable the

--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -32,9 +32,9 @@ To insert youtube video into a post, enable the
     {% youtube youtube_id [width] [height] [align] %}
 
 The width and height are in pixels, and can be optionally specified. The align
-field is optional and follows the attributes of the [W3C text-align]
+field is also optional and follows the attributes of the [W3C text-align]
 specification. If they are not specified, then the dimensions will be
-640 (wide) by 390 (tall) and default to right alignment.
+640 (wide) by 390 (tall) and default right alignment.
 
 ## Video Tag
 To insert flash/HTML5-friendly video into a post, enable the

--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -29,10 +29,12 @@ To insert a sized and labeled image in your document, enable the
 To insert youtube video into a post, enable the
 ``liquid_tags.youtube`` plugin, and add to your document:
 
-    {% youtube youtube_id [width] [height] %}
+    {% youtube youtube_id [width] [height] [align] %}
 
-The width and height are in pixels, and can be optionally specified.  If they
-are not, then the dimensions will be 640 (wide) by 390 (tall).
+The width and height are in pixels, and can be optionally specified. The align
+field is optional and follows the attributes of the [W3C text-align]
+specification. If they are not specified, then the dimensions will be
+640 (wide) by 390 (tall) and default to right alignment.
 
 ## Video Tag
 To insert flash/HTML5-friendly video into a post, enable the
@@ -105,3 +107,4 @@ are a few extra steps required for this plugin:
   this will insert the proper css formatting into your document.
 
 [1] https://github.com/ipython/nbconvert
+[W3C text-align]: http://www.w3.org/TR/CSS21/text.html

--- a/liquid_tags/youtube.py
+++ b/liquid_tags/youtube.py
@@ -6,15 +6,15 @@ based on the jekyll / octopress youtube tag [1]_
 
 Syntax
 ------
-{% youtube id [width height] %}
+{% youtube id [width height align] %}
 
 Example
 -------
-{% youtube dQw4w9WgXcQ 640 480 %}
+{% youtube dQw4w9WgXcQ 640 480 center %}
 
 Output
 ------
-<iframe width="640" height="480" src="http://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+<div style="text-align:center"><iframe width="640" height="480" src="http://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></div>
 
 [1] https://gist.github.com/jamieowen/2063748
 """
@@ -22,25 +22,32 @@ import os
 import re
 from .mdx_liquid_tags import LiquidTags
 
-SYNTAX = "{% youtube id [width height] %}"
+SYNTAX = "{% youtube id [width height align] %}"
 
-YOUTUBE = re.compile(r'(\w+)(\s+(\d+)\s(\d+))?')
+YOUTUBE = re.compile(r'(?P<id>\w+)'
+    r'( (?P<width>\d+))?'
+    r'( (?P<height>\d+))?')
+
+ALIGN = re.compile(r'(?P<align>left|right|center|justify)')
 
 @LiquidTags.register('youtube')
 def youtube(preprocessor, tag, markup):
     width = 640
     height = 390
+    align = 'left'
     youtube_id = None
 
     match = YOUTUBE.search(markup)
+    align_match = ALIGN.search(markup)
+
     if match:
-        groups = match.groups()
-        youtube_id = groups[0]
-        width = groups[2] or width
-        height = groups[3] or height
+        youtube_id = match.group('id')
+        width = match.group('width') or width
+        height = match.group('height') or height
+        align = align_match.group('align') or align
 
     if youtube_id:
-        youtube_out = "<iframe width='{width}' height='{height}' src='http://www.youtube.com/embed/{youtube_id}' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>".format(width=width, height=height, youtube_id=youtube_id)
+        youtube_out = "<div style='text-align:{align}'><iframe width='{width}' height='{height}' display='block' src='http://www.youtube.com/embed/{youtube_id}' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></div>".format(width=width, height=height, align=align, youtube_id=youtube_id)
     else:
         raise ValueError("Error processing input, "
                          "expected syntax: {0}".format(SYNTAX))


### PR DESCRIPTION
Added text-align attribute to liquid_tags.youtube by enclosing the iframe in an HTML <div> tag and specifying the text-align property.

Also, shifted to named groups for Python regex.

Thought someone might want to do the same thing!
