### PR TITLE
Adds option to keep the original filename and put the the thumbnail in a folder instead

### DIFF
--- a/thumbnailer/Readme.md
+++ b/thumbnailer/Readme.md
@@ -16,7 +16,8 @@ Configuration
 * IMAGE_PATH is the path to the image directory.  It should reside under content, and defaults to "pictures"
 * THUMBNAIL_DIR is the path to the output sub directory where the thumbnails are generated
 * THUMBNAIL_SIZES is a dictionary mapping name of size to size specifications.
-  The generated filename will be originalname_thumbnailname.ext
+  The generated filename will be originalname_thumbnailname.ext unless THUMBNAIL_KEEP_NAME is set.
+* THUMBNAIL_KEEP_NAME is a boolean which if set puts the file with the original name in a thumbnailname folder.
 
 Sizes can be specified using any of the following formats:
 

--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -92,14 +92,17 @@ class _resizer(object):
         new_filename = "{0}{1}".format(basename, ext)
         return new_filename
 
-    def resize_file_to(self, in_path, out_path):
+    def resize_file_to(self, in_path, out_path, keep_filename=False):
         """ Given a filename, resize and save the image per the specification into out_path
 
         :param in_path: path to image file to save.  Must be supposed by PIL
         :param out_path: path to the directory root for the outputted thumbnails to be stored
         :return: None
         """
-        filename = path.join(out_path, self.get_thumbnail_name(in_path))
+        if keep_filename:
+            filename = path.join(out_path, path.basename(in_path))
+        else:
+            filename = path.join(out_path, self.get_thumbnail_name(in_path))
         if not path.exists(out_path):
             os.makedirs(out_path)
         if not path.exists(filename):
@@ -131,7 +134,10 @@ def resize_thumbnails(pelican):
             for name, resizer in resizers.items():
                 in_filename = path.join(dirpath, filename)
                 logger.debug("Processing thumbnail {0}=>{1}".format(filename, name))
-                resizer.resize_file_to(in_filename, out_path)
+                if pelican.settings.get('THUMBNAIL_KEEP_NAME', False):
+                    resizer.resize_file_to(in_filename, path.join(out_path, name), True)
+                else:
+                    resizer.resize_file_to(in_filename, out_path)
 
 
 def _image_path(pelican):


### PR DESCRIPTION
Adds THUMBNAIL_KEEP_NAME which if set puts the thumbnail in a folder named like the key in THUMBNAIL_SIZES.
