### PR TITLE
Escape "^" in the json file because it is a special character for tique ...

### DIFF
--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -34,7 +34,7 @@ class Tipue_Search_JSON_Generator(object):
             return
 
         soup_title = BeautifulSoup(page.title.replace('&nbsp;', ' '))
-        page_title = soup_title.get_text(' ', strip=True).replace('“', '"').replace('”', '"').replace('’', "'")
+        page_title = soup_title.get_text(' ', strip=True).replace('“', '"').replace('”', '"').replace('’', "'").replace('^', '&#94;')
 
         soup_text = BeautifulSoup(page.content)
         page_text = soup_text.get_text(' ', strip=True).replace('“', '"').replace('”', '"').replace('’', "'").replace('¶', ' ').replace('^', '&#94;')


### PR DESCRIPTION
...search.

According to the author of tipue search, `^` [is used as a record seperator and as such is a protected character](https://github.com/Tipue/Tipue-Search/issues/1). So we have to replace `^` with something else. Its html entity might be a good choice.
