### PR TITLE
Fixed tipue_search failing with pages due to no category.

### DIFF
--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -40,7 +40,7 @@ class Tipue_Search_JSON_Generator(object):
         page_text = soup_text.get_text(' ', strip=True).replace('“', '"').replace('”', '"').replace('’', "'").replace('¶', ' ').replace('^', '&#94;')
         page_text = ' '.join(page_text.split())
 
-        if getattr(page, 'category') == 'None':
+        if getattr(page, 'category', 'None') == 'None':
             page_category = ''
         else:
             page_category = page.category.name


### PR DESCRIPTION
Would fail with following error on pages due to pages having no
category:

```
CRITICAL: 'Page' object has no attribute 'category'
Traceback (most recent call last):
  File "/usr/local/bin/pelican", line 9, in <module>
    load_entry_point('pelican==3.2', 'console_scripts', 'pelican')()
  File "/usr/local/lib/python2.7/dist-packages/pelican-3.2-py2.7.egg/pelican/__init__.py", line 376, in main
    pelican.run()
  File "/usr/local/lib/python2.7/dist-packages/pelican-3.2-py2.7.egg/pelican/__init__.py", line 181, in run
    p.generate_output(writer)
  File "/home/rmore/src/pelican-plugins/tipue_search/tipue_search.py", line 66, in generate_output
    self.create_json_node(page)
  File "/home/rmore/src/pelican-plugins/tipue_search/tipue_search.py", line 43, in create_json_node
    if getattr(page, 'category') == 'None':
AttributeError: 'Page' object has no attribute 'category'
```
