### PR TITLE
Add end_summary plugin as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "cjk-auto-spacing"]
 	path = cjk-auto-spacing
 	url = https://github.com/yuex/cjk-auto-spacing.git
+[submodule "end_summary"]
+	path = end_summary
+	url = git@github.com:beresovskiy/end_origin.git


### PR DESCRIPTION
`end_summary` is a simple plugin that complements `summary` plugin with `end-summary` directive for reStructuredText.

So this code:

``` rst
.. raw:: html

    <!-- PELICAN_END_SUMMARY -->
```

Can be replaced with the following line:

``` rst
.. end-summary::
```
