### PR TITLE
Add categories and subcategories support to Neighbors plugin

### DIFF
--- a/neighbors/Readme.rst
+++ b/neighbors/Readme.rst
@@ -2,7 +2,10 @@ Neighbor Articles Plugin for Pelican
 ====================================
 
 This plugin adds ``next_article`` (newer) and ``prev_article`` (older) 
-variables to the article's context
+variables to the article's context.
+
+Also adds ``next_article_in_category`` and ``prev_article_in_category``.
+
 
 Usage
 -----
@@ -24,4 +27,71 @@ Usage
             </a>
         </li>
     {% endif %}
-    </ul>
+   </ul>    
+   <ul>
+    {% if article.prev_article_in_category %}
+        <li>
+            <a href="{{ SITEURL }}/{{ article.prev_article_in_category.url}}">
+                {{ article.prev_article_in_category.title }}
+            </a>
+        </li>
+    {% endif %}
+    {% if article.next_article %}
+        <li>
+            <a href="{{ SITEURL }}/{{ article.next_article_in_category.url}}">
+                {{ article.next_article_in_category.title }}
+            </a>
+        </li>
+    {% endif %}
+    </ul> 
+
+Usage with the Subcategory plugin
+---------------------------------
+
+If you want to get the neigbors within a subcategory it's a little different.
+Since an article can belong to more than one subcategory, subcategories are
+stored in a list. If you have an article with subcategories like 
+
+``Category/Foo/Bar``
+
+it will belong to both subcategory Foo, and Foo/Bar. Subcategory neighbors are
+added to an article as ``next_article_in_subcategory#`` and 
+``prev_article_in_subcategory#`` where ``#`` is the level of subcategory. So using
+the example from above, subcategory1 will be Foo, and subcategory2 Foo/Bar. 
+Therefor the usage with subcategories is:
+
+.. code-block:: html+jinja
+
+    <ul>
+    {% if article.prev_article_subcategory1 %}
+        <li>
+            <a href="{{ SITEURL }}/{{ article.prev_article_in_subcategory1.url}}">
+                {{ article.prev_article_in_subcategory1.title }}
+            </a>
+        </li>
+    {% endif %}
+    {% if article.next_article %}
+        <li>
+            <a href="{{ SITEURL }}/{{ article.next_article_subcategory1.url}}">
+                {{ article.next_article_subcategory1.title }}
+            </a>
+        </li>
+    {% endif %}
+   </ul>    
+   <ul>
+    {% if article.prev_article_in_subcategory2 %}
+        <li>
+            <a href="{{ SITEURL }}/{{ article.prev_article_in_subcategory2.url}}">
+                {{ article.prev_article_in_subcategory2.title }}
+            </a>
+        </li>
+    {% endif %}
+    {% if article.next_article %}
+        <li>
+            <a href="{{ SITEURL }}/{{ article.next_article_in_subcategory2.url}}">
+                {{ article.next_article_in_subcategory2.title }}
+            </a>
+        </li>
+    {% endif %}
+    </ul> 
+

--- a/neighbors/neighbors.py
+++ b/neighbors/neighbors.py
@@ -6,7 +6,6 @@ Neighbor Articles Plugin for Pelican
 This plugin adds ``next_article`` (newer) and ``prev_article`` (older) 
 variables to the article's context
 """
-
 from pelican import signals
 
 def iter3(seq):
@@ -26,14 +25,33 @@ def get_translation(article, prefered_language):
             return translation
     return article
 
-def neighbors(generator):
-    for nxt, cur, prv in iter3(generator.articles):
-        cur.next_article = nxt
-        cur.prev_article = prv
+def set_neighbors(articles, next_name, prev_name):
+    for nxt, cur, prv in iter3(articles):
+        exec("cur.{} = nxt".format(next_name))
+        exec("cur.{} = prv".format(prev_name))
 
         for translation in cur.translations:
-            translation.next_article = get_translation(nxt, translation.lang)
-            translation.prev_article = get_translation(prv, translation.lang)
+            exec(
+            "translation.{} = get_translation(nxt, translation.lang)".format(
+                next_name))
+            exec(
+            "translation.{} = get_translation(prv, translation.lang)".format(
+                prev_name))
+      
+def neighbors(generator):
+    set_neighbors(generator.articles, 'next_article', 'prev_article')
+    
+    for category, articles in generator.categories:
+        articles.sort(key=(lambda x: x.date), reverse=(True))
+        set_neighbors(
+            articles, 'next_article_in_category', 'prev_article_in_category')
+    
+    for subcategory, articles in generator.subcategories:
+        articles.sort(key=(lambda x: x.date), reverse=(True))
+        index = subcategory.name.count('/')
+        next_name = 'next_article_in_subcategory{}'.format(index)
+        prev_name = 'prev_article_in_subcategory{}'.format(index)
+        set_neighbors(articles, next_name, prev_name)
 
 def register():
     signals.article_generator_finalized.connect(neighbors)


### PR DESCRIPTION
All there in the title.

The subcategory features are based on an updated version of the subcategory, as mentioned in my comment on #133.
