### PR TITLE
Fix an issue in neighbors plugin which was introduced after subcategory ...

### DIFF
--- a/neighbors/neighbors.py
+++ b/neighbors/neighbors.py
@@ -45,13 +45,14 @@ def neighbors(generator):
         articles.sort(key=(lambda x: x.date), reverse=(True))
         set_neighbors(
             articles, 'next_article_in_category', 'prev_article_in_category')
-    
-    for subcategory, articles in generator.subcategories:
-        articles.sort(key=(lambda x: x.date), reverse=(True))
-        index = subcategory.name.count('/')
-        next_name = 'next_article_in_subcategory{}'.format(index)
-        prev_name = 'prev_article_in_subcategory{}'.format(index)
-        set_neighbors(articles, next_name, prev_name)
+
+    if hasattr(generator, 'subcategories'):
+        for subcategory, articles in generator.subcategories:
+            articles.sort(key=(lambda x: x.date), reverse=(True))
+            index = subcategory.name.count('/')
+            next_name = 'next_article_in_subcategory{}'.format(index)
+            prev_name = 'prev_article_in_subcategory{}'.format(index)
+            set_neighbors(articles, next_name, prev_name)
 
 def register():
     signals.article_generator_finalized.connect(neighbors)


### PR DESCRIPTION
...support

It is not necessary that articles will have subcategories. You may
end up getting following critical error.

> CRITICAL: ("'ArticlesGenerator' object has no attribute 'subcategories'",)
> CRITICAL: 'ArticlesGenerator' object has no attribute 'subcategories'
> Traceback (most recent call last):
>   File "/Users/talha/Repos/VirtualEnvs/pelican-dev/bin/pelican", line 8, in <module>
>     load_entry_point('pelican==3.3', 'console_scripts', 'pelican')()
>   File "/Users/talha/Repos/VirtualEnvs/pelican-dev/lib/python2.7/site-packages/pelican-3.3-py2.7.egg/pelican/**init**.py", line 346, in main
>     pelican.run()
>   File "/Users/talha/Repos/VirtualEnvs/pelican-dev/lib/python2.7/site-packages/pelican-3.3-py2.7.egg/pelican/**init**.py", line 162, in run
>     p.generate_context()
>   File "/Users/talha/Repos/VirtualEnvs/pelican-dev/lib/python2.7/site-packages/pelican-3.3-py2.7.egg/pelican/generators.py", line 480, in generate_context
>     signals.article_generator_finalized.send(self)
>   File "/Users/talha/Repos/VirtualEnvs/pelican-dev/lib/python2.7/site-packages/blinker/base.py", line 267, in send
>     for receiver in self.receivers_for(sender)]
>   File "/Users/talha/Repos/pelican-plugins/neighbors/neighbors.py", line 49, in neighbors
>     for subcategory, articles in generator.subcategories:
> AttributeError: 'ArticlesGenerator' object has no attribute 'subcategories'
