### PR TITLE
Fixed missing quote mark in an HTML example

### DIFF
--- a/subcategory/README.md
+++ b/subcategory/README.md
@@ -28,7 +28,7 @@ breadcrumb-style navigation you might try something like this:
         </li>
     {% for subcategory in article.subcategories %}
         <li>
-            <a href="{{ SITEURL }}/{{ subcategory.url }}>{{ subcategory.shortname }}</a>
+            <a href="{{ SITEURL }}/{{ subcategory.url }}">{{ subcategory.shortname }}</a>
         </li>
     {% endfor %}
     </ol>


### PR DESCRIPTION
Fixed  a typo in the README file for subcategories that rendered the HTML example invalid
