### PR TITLE
validate_file does not support argument type unicode on my system.

### DIFF
--- a/w3c_validate/wc3_validate.py
+++ b/w3c_validate/wc3_validate.py
@@ -39,7 +39,7 @@ def validate(filename):
     LOG.info("Validating: {0}".format(filename))
 
     # call w3c webservice
-    vld.validate_file(filename)
+    vld.validate_file(filename.encode('ascii'))
 
     # display errors and warning
     for err in vld.errors:


### PR DESCRIPTION
encoding filename in ascii fixes this problem.
