### PR TITLE
Fix sitemap plugin to look for index#.html files (if pagination is on)

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -206,10 +206,13 @@ class SitemapGenerator(object):
                                                'date',
                                                'url'])
 
-            for standard_page_url in ['index.html',
-                                      'archives.html',
-                                      'tags.html',
-                                      'categories.html']:
+            standard_pages = ['index.html', 'archives.html',
+                              'tags.html', 'categories.html']
+
+            for i in range(100):
+                standard_pages.append('index'+str(i)+'.html')
+
+            for standard_page_url in standard_pages:
                 fake = FakePage(status='published',
                                 date=self.now,
                                 url=standard_page_url)


### PR DESCRIPTION
The current sitemap plugin only adds index.html to the sitemap, but if the user has pagination enabled (which generates index2.html, index3.html, etc.), then these additional index files don't get added to the sitemap.

I've quickly hacked together a solution that works, although I don't think hardcoding "100" in there is the right thing to do. Suggestions?
