### PR TITLE
Fixed errors arising from Python 3.x

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -18,7 +18,6 @@ for template builders that want to adjust the look and feel of the math.
 See README for more details.
 """
 
-from __future__ import print_function
 import os
 import re
 
@@ -55,7 +54,7 @@ def binary_search(match_tuple, ignore_within):
     # Find first value in array where predicate is False
     # predicate function: tupleList[mid][0] < t[index]
     while lo < hi:
-        mid = lo + (hi-lo+1)/2
+        mid = lo + (hi-lo+1)//2
         if ignore_within[mid][0] < match_tuple[0]:
             lo = mid
         else:


### PR DESCRIPTION
This change makes the render_math plugin compatible with Python 3. It fixes the integer division used for binary search
