### PR TITLE
Better Figures and Images plugin: Fix crash on external image links

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -15,6 +15,7 @@ TODO: Need to add a test.py for this plugin.
 
 from __future__ import unicode_literals
 from os import path, access, R_OK
+import os
 
 from pelican import signals
 
@@ -51,12 +52,21 @@ def content_object_init(instance):
                 else:
                     logger.warning('Better Fig. Error: img_path should start with either {filename}, |filename| or /static')
 
-                # Build the source image filename
-                src = instance.settings['PATH'] + img_path + '/' + img_filename
+                # search src path list
+                # 1. Build the source image filename from PATH
+                # 2. Build the source image filename from STATIC_PATHS
+                src = os.path.join(instance.settings['PATH'], img_path, img_filename)
+                src_candidates = [src]
+                src_candidates += [os.path.join(instance.settings['PATH'], static_path, img_path, img_filename) for static_path in instance.settings['STATIC_PATHS']]
+                src_candidates = [f for f in src_candidates if path.isfile(f) and access(f, R_OK)]
 
-                logger.debug('Better Fig. src: %s', src)
-                if not (path.isfile(src) and access(src, R_OK)):
+                if not src_candidates:
                     logger.error('Better Fig. Error: image not found: %s', src)
+                    logger.debug('Better Fig. Skip src: %s', img_path + '/' + img_filename)
+                    continue
+
+                src = src_candidates[0]
+                logger.debug('Better Fig. src: %s', src)
 
                 # Open the source image and query dimensions; build style string
                 im = Image.open(src)


### PR DESCRIPTION
## Description
plugin name : better figures and images

if I use external url for image, it occur crash. Because, url is not local path. I add error handling.

## Buggy markdown
```
![Image](https://raw.github.com/if1live/rpi-mpd-controller/master/documentation/image.jpg)
```

## Original message
```
DEBUG: Better Fig. src: /home/sora/develop/libsora.so/contenthttps://raw.github.com/if1live/rpi-mpd-controller/master/documentation/image.jpg
ERROR: Better Fig. Error: image not found: /home/sora/develop/libsora.so/contenthttps://raw.github.com/if1live/rpi-mpd-controller/master/documentation/image.jpg
WARNING: Could not process development/rpi-mpd-controller.md
[Errno 2] No such file or directory: u'/home/sora/develop/libsora.so/contenthttps://raw.github.com/if1live/rpi-mpd-controller/master/documentation/image.jpg'
```

## Fixed message
```
WARNING: Better Fig. Error: img_path should start with either {filename}, |filename| or /static
DEBUG: Better Fig. src: /home/sora/develop/libsora.so/contenthttps://raw.github.com/if1live/rpi-mpd-controller/master/documentation/image.jpg
ERROR: Better Fig. Error: image not found: /home/sora/develop/libsora.so/contenthttps://raw.github.com/if1live/rpi-mpd-controller/master/documentation/image.jpg
DEBUG: Better Fig. Skip src: https://raw.github.com/if1live/rpi-mpd-controller/master/documentation/image.jpg
```