### PR TITLE
thumbnailer: keeping picture directory structure

### DIFF
--- a/thumbnailer/Readme.md
+++ b/thumbnailer/Readme.md
@@ -18,6 +18,7 @@ Configuration
 * THUMBNAIL_SIZES is a dictionary mapping name of size to size specifications.
   The generated filename will be originalname_thumbnailname.ext unless THUMBNAIL_KEEP_NAME is set.
 * THUMBNAIL_KEEP_NAME is a boolean which if set puts the file with the original name in a thumbnailname folder.
+* THUMBNAIL_KEEP_DIR_STRUCT is a boolean which if set conserve the image directory structure in a thumbnailname folder. It is usefull with the THUMBNAIL_KEEP_NAME parameter
 
 Sizes can be specified using any of the following formats:
 

--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -123,8 +123,6 @@ def resize_thumbnails(pelican):
         return
 
     in_path = _image_path(pelican)
-    out_path = path.join(pelican.settings['OUTPUT_PATH'],
-                         pelican.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR))
 
     sizes = pelican.settings.get('THUMBNAIL_SIZES', DEFAULT_THUMBNAIL_SIZES)
     resizers = dict((k, _resizer(k, v)) for k,v in sizes.items())
@@ -133,6 +131,11 @@ def resize_thumbnails(pelican):
         for filename in filenames:
             for name, resizer in resizers.items():
                 in_filename = path.join(dirpath, filename)
+                out_path = path.join(pelican.settings['OUTPUT_PATH'],
+                                     pelican.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR),
+                                     "".join((os.curdir, os.sep, in_filename[len(in_path):(len(in_filename)-len(filename))])))
+                if not os.path.exists(out_path):
+                    os.makedirs(out_path)
                 logger.debug("Processing thumbnail {0}=>{1}".format(filename, name))
                 if pelican.settings.get('THUMBNAIL_KEEP_NAME', False):
                     resizer.resize_file_to(in_filename, path.join(out_path, name), True)

--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -22,6 +22,7 @@ DEFAULT_THUMBNAIL_SIZES = {
 }
 DEFAULT_TEMPLATE = """<a href="{url}" rel="shadowbox" title="{filename}"><img src="{thumbnail}" alt="{filename}"></a>"""
 DEFAULT_GALLERY_THUMB = "thumbnail_square"
+DEFAULT_THUMBNAIL_KEEP_DIR_STRUCT = False
 
 class _resizer(object):
     """ Resizes based on a text specification, see readme """
@@ -123,6 +124,8 @@ def resize_thumbnails(pelican):
         return
 
     in_path = _image_path(pelican)
+    out_path = path.join(pelican.settings['OUTPUT_PATH'],
+                         pelican.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR))
 
     sizes = pelican.settings.get('THUMBNAIL_SIZES', DEFAULT_THUMBNAIL_SIZES)
     resizers = dict((k, _resizer(k, v)) for k,v in sizes.items())
@@ -131,11 +134,12 @@ def resize_thumbnails(pelican):
         for filename in filenames:
             for name, resizer in resizers.items():
                 in_filename = path.join(dirpath, filename)
-                out_path = path.join(pelican.settings['OUTPUT_PATH'],
-                                     pelican.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR),
-                                     "".join((os.curdir, os.sep, in_filename[len(in_path):(len(in_filename)-len(filename))])))
-                if not os.path.exists(out_path):
-                    os.makedirs(out_path)
+                if (pelican.settings.get('THUMBNAIL_KEEP_DIR_STRUCT', DEFAULT_THUMBNAIL_KEEP_DIR_STRUCT)):
+                    out_path = path.join(pelican.settings['OUTPUT_PATH'],
+                                         pelican.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR),
+                                         "".join((os.curdir, os.sep, in_filename[len(in_path):(len(in_filename)-len(filename))])))
+                    if not os.path.exists(out_path):
+                        os.makedirs(out_path)
                 logger.debug("Processing thumbnail {0}=>{1}".format(filename, name))
                 if pelican.settings.get('THUMBNAIL_KEEP_NAME', False):
                     resizer.resize_file_to(in_filename, path.join(out_path, name), True)


### PR DESCRIPTION
A small quick and dirty (cf line 136) modifications in order to have the same directory structure than the picture directory.
