### PR TITLE
liquid_tags.* plugins are not unicode aware

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -63,6 +63,12 @@ document:
 
     {% include_code myscript.py [Title text] %}
 
+'chardet' package is required to detect encoding of the file. (Contrary
+to popular belief, not all source code is plain ascii.) You will want to
+install it before using this plugin:
+
+    pip install chardet
+	
 The script must be in the ``code`` subdirectory of your content folder:
 this default location can be changed by specifying
 

--- a/liquid_tags/img.py
+++ b/liquid_tags/img.py
@@ -22,16 +22,17 @@ Output
 
 [1] https://github.com/imathis/octopress/blob/master/plugins/image_tag.rb
 """
+from __future__ import unicode_literals
 import re
 from .mdx_liquid_tags import LiquidTags
 
 SYNTAX = '{% img [class name(s)] [http[s]:/]/path/to/image [width [height]] [title text | "title text" ["alt text"]] %}'
 
 # Regular expression to match the entire syntax
-ReImg = re.compile("""(?P<class>\S.*\s+)?(?P<src>(?:https?:\/\/|\/|\S+\/)\S+)(?:\s+(?P<width>\d+))?(?:\s+(?P<height>\d+))?(?P<title>\s+.+)?""")
+ReImg = re.compile(ur"""(?P<class>\S.*\s+)?(?P<src>(?:https?:\/\/|\/|\S+\/)\S+)(?:\s+(?P<width>\d+))?(?:\s+(?P<height>\d+))?(?P<title>\s+.+)?""")
 
 # Regular expression to split the title and alt text
-ReTitleAlt = re.compile("""(?:"|')(?P<title>[^"']+)?(?:"|')\s+(?:"|')(?P<alt>[^"']+)?(?:"|')""")
+ReTitleAlt = re.compile(ur"""(?:"|')(?P<title>[^"']+)?(?:"|')\s+(?:"|')(?P<alt>[^"']+)?(?:"|')""")
 
 
 @LiquidTags.register('img')

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -29,13 +29,15 @@ in the STATIC_PATHS setting, e.g.:
 
 [1] https://github.com/imathis/octopress/blob/master/plugins/include_code.rb
 """
+from __future__ import unicode_literals
 import re
 import os
+import chardet, codecs
 from .mdx_liquid_tags import LiquidTags
 
 
 SYNTAX = "{% include_code /path/to/code.py [lang:python] [title] %}"
-FORMAT = re.compile(r"""^(?:\s+)?(?P<src>\S+)(?:\s+)?(?:(?:lang:)(?P<lang>\S+))?(?:\s+)?(?P<title>.+)?$""")
+FORMAT = re.compile(ur"""^(?:\s+)?(?P<src>\S+)(?:\s+)?(?:(?:lang:)(?P<lang>\S+))?(?:\s+)?(?P<title>.+)?$""")
 
 
 @LiquidTags.register('include_code')
@@ -62,7 +64,9 @@ def include_code(preprocessor, tag, markup):
     if not os.path.exists(code_path):
         raise ValueError("File {0} could not be found".format(code_path))
 
-    code = open(code_path).read()
+    # It is naive to think we can just open a file with code.
+    file_encoding = chardet.detect(open(code_path).read())['encoding']
+    code = codecs.open(code_path,'r',encoding=file_encoding).read()
 
     if title:
         title = "{0} {1}".format(title, os.path.basename(src))


### PR DESCRIPTION
For some of them, like youtube or vimeo, this makes no difference, but for img it does *(you want to be able to write titles in your language)* and for include_code it presents a more complicated problem -- the source code file might not actually be unicode in the first place. *(There are certain cases where this would be the norm.)*

This commit fixes both img and include_code. Tested locally, seems to work.