### PR TITLE
Fixes #193 Adding TEMPLATE_PAGES to tipue_search plugin

### DIFF
--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -15,6 +15,7 @@ import os.path
 import json
 from bs4 import BeautifulSoup
 from codecs import open
+from urlparse import urljoin
 
 from pelican import signals
 
@@ -26,7 +27,10 @@ class Tipue_Search_JSON_Generator(object):
         self.output_path = output_path
         self.context = context
         self.siteurl = settings.get('SITEURL')
+        self.tpages = settings.get('TEMPLATE_PAGES')
+        self.output_path = output_path
         self.json_nodes = []
+
 
     def create_json_node(self, page):
 
@@ -54,6 +58,32 @@ class Tipue_Search_JSON_Generator(object):
 
         self.json_nodes.append(node)
 
+
+    def create_tpage_node(self, srclink):
+
+        srcfile = open(os.path.join(self.output_path, self.tpages[srclink]))
+        soup = BeautifulSoup(srcfile, 'html.parser')
+        page_text = soup.get_text()
+
+        # What happens if there is not a title.
+        if soup.title is not None:
+            page_title = soup.title.string
+        else:
+            page_title = ''
+
+        # Should set default category?
+        page_category = ''
+
+        page_url = urljoin(self.siteurl, self.tpages[srclink])
+
+        node = {'title': page_title,
+                'text': page_text,
+                'tags': page_category,
+                'loc': page_url}
+        
+        self.json_nodes.append(node)
+
+
     def generate_output(self, writer):
         path = os.path.join(self.output_path, 'tipuesearch_content.json')
 
@@ -61,6 +91,9 @@ class Tipue_Search_JSON_Generator(object):
 
         for article in self.context['articles']:
             pages += article.translations
+
+        for srclink in self.tpages:
+            self.create_tpage_node(srclink)
 
         for page in pages:
             self.create_json_node(page)


### PR DESCRIPTION
Adds a new function create_tpage_node() which accepts a TEMPLATE_PAGES file which it loads and adds into the JSON file. It uses the output file that has already passed through Jinja2 processing. See #193

This is my first attempt at a Pelican change so happy to take any feedback.
