### PR TITLE
Liquid Tags: line numbers for include_code

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -61,7 +61,15 @@ To include code from a file in your document with a link to the original
 file, enable the ``liquid_tags.include_code`` plugin, and add to your
 document:
 
-    {% include_code myscript.py [Title text] %}
+    {% include_code /path/to/code.py [lang:python] [lines:X-Y] [:hidefilename:] [title] %}
+
+All arguments are optional but their order must be kept. `:hidefilename:` is
+only allowed if a title is also given.
+
+    {% include_code /path/to/code.py lines:1-10 :hidefilename: Test Example %}
+
+This example will show the first 10 lines of the file while hiding the actual
+filename.
 
 The script must be in the ``code`` subdirectory of your content folder:
 this default location can be changed by specifying


### PR DESCRIPTION
This PR adds line numbers to the include_code directive in the liquid tags plugin.

The syntax is now

```
{% include_code /path/to/code.py [lang:python] [lines:X-Y] [:hidefilename:] [title] %}
```

All arguments are optional but their order must be kept. It could be done in a slightly nicer fashion but this way it stays fully backwards compatible. If the lines argument is omitted, it will still show the whole file.

Example that only shows the first ten lines and hides the actual filename but shows `Some Title` as the title.

```
{% include_code /path/to/code.py lines:1-10 :hidefilename: Some Title %}
```
