### PR TITLE
Liquid tags: youtube / vimeo / video improvements

### DIFF
--- a/liquid_tags/video.py
+++ b/liquid_tags/video.py
@@ -49,7 +49,11 @@ def video(preprocessor, tag, markup):
         poster = groups[9]
 
     if any(videos):
-        video_out =  "<video width='{width}' height='{height}' preload='none' controls poster='{poster}'>".format(width=width, height=height, poster=poster)
+        video_out = """
+        <div class="videobox">
+            <video width="{width}" height="{height}" preload="none" controls poster="{poster}">
+        """.format(width=width, height=height, poster=poster).strip()
+
         for vid in videos:
             base, ext = os.path.splitext(vid)
             if ext not in VID_TYPEDICT:
@@ -57,7 +61,7 @@ def video(preprocessor, tag, markup):
                                  "{0}".format(ext))
             video_out += ("<source src='{0}' "
                           "{1}>".format(vid, VID_TYPEDICT[ext]))
-        video_out += "</video>"
+        video_out += "</video></div>"
     else:
         raise ValueError("Error processing input, "
                          "expected syntax: {0}".format(SYNTAX))

--- a/liquid_tags/vimeo.py
+++ b/liquid_tags/vimeo.py
@@ -24,7 +24,7 @@ from .mdx_liquid_tags import LiquidTags
 
 SYNTAX = "{% vimeo id [width height] %}"
 
-VIMEO = re.compile(r'(\w+)(\s+(\d+)\s(\d+))?')
+VIMEO = re.compile(r'(\S+)(\s+(\d+)\s(\d+))?')
 
 
 @LiquidTags.register('vimeo')
@@ -41,7 +41,14 @@ def vimeo(preprocessor, tag, markup):
         height = groups[3] or height
 
     if vimeo_id:
-        vimeo_out = '<div style="width:{width}px; height:{height}px;"><iframe src="//player.vimeo.com/video/{vimeo_id}?title=0&amp;byline=0&amp;portrait=0" width="{width}" height="{height}" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe></div>'.format(width=width, height=height, vimeo_id=vimeo_id)
+        vimeo_out = """
+            <div class="videobox">
+                <iframe src="//player.vimeo.com/video/{vimeo_id}?title=0&amp;byline=0&amp;portrait=0"
+                        width="{width}" height="{height}" frameborder="0"
+                        webkitAllowFullScreen mozallowfullscreen allowFullScreen>
+                </iframe>
+            </div>
+        """.format(width=width, height=height, vimeo_id=vimeo_id).strip()
     else:
         raise ValueError("Error processing input, "
                          "expected syntax: {0}".format(SYNTAX))

--- a/liquid_tags/youtube.py
+++ b/liquid_tags/youtube.py
@@ -24,7 +24,7 @@ from .mdx_liquid_tags import LiquidTags
 
 SYNTAX = "{% youtube id [width height] %}"
 
-YOUTUBE = re.compile(r'(\w+)(\s+(\d+)\s(\d+))?')
+YOUTUBE = re.compile(r'([\S]+)(\s+(\d+)\s(\d+))?')
 
 @LiquidTags.register('youtube')
 def youtube(preprocessor, tag, markup):
@@ -40,7 +40,15 @@ def youtube(preprocessor, tag, markup):
         height = groups[3] or height
 
     if youtube_id:
-        youtube_out = "<iframe width='{width}' height='{height}' src='http://www.youtube.com/embed/{youtube_id}' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>".format(width=width, height=height, youtube_id=youtube_id)
+        youtube_out = """
+            <div class="videobox">
+                <iframe width="{width}" height="{height}"
+                        src='http://www.youtube.com/v/{youtube_id}'
+                        frameborder='0'
+                        webkitAllowFullScreen mozallowfullscreen allowFullScreen>
+                </iframe>
+            </div>
+        """.format(width=width, height=height, youtube_id=youtube_id).strip()
     else:
         raise ValueError("Error processing input, "
                          "expected syntax: {0}".format(SYNTAX))


### PR DESCRIPTION
- Allow more flexible video identifiers, current one `\w` blocks e.g.
  youtube identifier `ul-FqOfX-t8`. New one allows also attaching
  positional arguments to video, e.g. `ul-FqOfX-t8#t=123`
- Surrounded each video element with a div having `videobox`-class for
  styling purposes (e.g. center alignment)
- improved code formatting
