### PR TITLE
[liquid_tags:notebook] Fix hardcoded content path

### DIFF
--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -258,7 +258,7 @@ def notebook(preprocessor, tag, markup):
 
     settings = preprocessor.configs.config['settings']
     nb_dir =  settings.get('NOTEBOOK_DIR', 'notebooks')
-    nb_path = os.path.join('content', nb_dir, src)
+    nb_path = os.path.join(settings.get('PATH',''), nb_dir, src)
 
     if not os.path.exists(nb_path):
         raise ValueError("File {0} could not be found".format(nb_path))


### PR DESCRIPTION
'content' is not supposed to even be the default for PATH.

Maybe there is a more standard way to do it, but this patch works.
