### PR TITLE
[i18n_subsites] Possibility to hide separately untranslated pages and articles

### DIFF
--- a/i18n_subsites/README.rst
+++ b/i18n_subsites/README.rst
@@ -11,6 +11,7 @@ What it does
 3. For each non-default language a "sub-site" with a modified config [#conf]_ is created [#run]_, linking the translations to the originals (if available). The configured language code is appended to the *OUTPUT_PATH* and *SITEURL* of each sub-site. For each sub-site, *DEFAULT_LANG* is changed to the language of the sub-site so that articles in a different language are treated as translations.
 
 If *HIDE_UNTRANSLATED_CONTENT* is True (default), content without a translation for a language is generated as hidden (for pages) or draft (for articles) for the corresponding language sub-site.
+To hide only pages or articles, use *HIDE_UNTRANSLATED_PAGES* and *HIDE_UNTRANSLATED_ARTICLES* separately.
 
 .. [#conf] For each language a config override is given in the *I18N_SUBSITES* dictionary.
 .. [#run] Using a new *PELICAN_CLASS* instance and its ``run`` method, so each sub-site could even have a different *PELICAN_CLASS* if specified in *I18N_SUBSITES* conf overrides.

--- a/i18n_subsites/i18n_subsites.py
+++ b/i18n_subsites/i18n_subsites.py
@@ -110,6 +110,8 @@ def update_generator_contents(generator, *args):
 
     Hide content without a translation for current DEFAULT_LANG
     if HIDE_UNTRANSLATED_CONTENT is True
+    Hide separately pages and articles in the same way with HIDE_UNTRANSLATED_PAGES
+    and HIDE_UNTRANSLATED_ARTICLES
     """
     generator.translations = []
     is_pages_gen = hasattr(generator, 'pages')
@@ -122,6 +124,10 @@ def update_generator_contents(generator, *args):
             move_translations_links(article)
 
     if not generator.settings.get('HIDE_UNTRANSLATED_CONTENT', True):
+        return
+    if is_pages_gen and not generator.settings.get('HIDE_UNTRANSLATED_PAGES', True):
+        return
+    if not is_pages_gen and not generator.settings.get('HIDE_UNTRANSLATED_ARTICLES', True):
         return
     contents = generator.pages if is_pages_gen else generator.articles
     hidden_contents = generator.hidden_pages if is_pages_gen else generator.drafts


### PR DESCRIPTION
It may be useful to hide only untranslated articles, or only untranslated pages.
For instance one can consider the page lang consistency to be more important on a site, while allowing some articles to be in another language.

I used to hide pages manually with the theme, but maybe this way is more appropriate.

Sorry for the duplicate PR, I am new to github…
