### PR TITLE
Added files for new Youtube Privacy Enhancer Pelican plugin.

### DIFF
--- a/video_privacy_enhancer/Readme.md
+++ b/video_privacy_enhancer/Readme.md
@@ -1,0 +1,49 @@
+# Video Privacy Enhancer
+
+This plugin is a conceptual port of the Electronic Frontier Foundation's (EFF's) [MyTube Drupal plugin](https://www.eff.org/pages/mytube-limit-privacy-risks-embedded-video "EFF blog post about the MyTube Plugin") to Pelican. **It increases user privacy by stopping Google's ability to place cookies on a user's system through an embedded YouTube video without that user explicitly opting-in to viewing the video (by clicking on it).** In the future, support will hopefully expand to include other video platforms.
+
+
+## Copyright, Contact, and Acknowledgements
+
+This plugin is copyright 2014 Jacob Levernier  
+It is released under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3 (as is the default for Pelican Plugins in the getpelican/pelican-plugins repository).
+
+Although not required by the license, I would very much appreciate it if you placed a note in the "About" page of your website that you use this plugin, in order to raise user awareness of web tracking issues.
+
+### To contact the author:
+
+* jleverni at uoregon dot edu  
+* http://AdUnumDatum.org  
+* BitBucket: https://bitbucket.org/jlev_uo/  
+* Github: https://github.com/publicus  
+
+This is the first plugin that I've written for Pelican, and it was intended as a training project for learning Pelican as well as Python better. I would be very happy to hear constructive feedback on the plugin and for suggestions for making it more efficient and/or expandable. Also, I've heavily annotated all of the Python and jQuery code in order to make it easier to understand for others looking to learn more, like I was when I wrote the plugin.
+
+### Acknowledgements
+
+I'm grateful to [Jordi Burgos](http://jordiburgos.com/post/2014/first-pelican-plugin-readtime.html "Blog post on writing plugins for Pelican") and [Duncan Lock](http://duncanlock.net/blog/2013/10/18/how-i-upgraded-this-website-to-pelican-33/ "Another blog post on writing plugins for Pelican") for writing helpful introductory blog posts on writing Pelican plugins. Both of these posts helped to decrease the intimidation factor associated with learning a new system like Pelican.
+
+I'm also grateful to the authors of the plugins in the pelican-plugins repo; being able to look over other plugins' authors' code helped me immensely in learning more about how Pelican's [signals](http://docs.getpelican.com/en/3.3.0/plugins.html#how-to-create-plugins "Pelican documentation on creating plugins") system works.
+
+
+## Explanation and Rationale
+
+YouTube videos that are embedded in a website are capable of placing a cookie (or using other tracking methods) on a visitor's computer even if that visitor does not play the movie. For certain sites that deal with political or other potentially sensitive topics, this automatic tracking could raise privacy concerns among users. Thus, this plugin fetches and stores, on your server, a copy of the thumbnail image of each embedded YouTube video on your website. It then displays that image instead of the video until the user "opts-in" to watching the video by clicking on the thumbnail (at which point the image is replaced by the youtube embed iframe).
+
+This plugin allows the shortcode **`!youtube(video_id)`** (for example, `!youtube(2XID_W4neJo)` for the video available at [https://www.youtube.com/watch?v=2XID_W4neJo](https://www.youtube.com/watch?v=2XID_W4neJo)) to be used in any Pelican page or article. During the `make html` process, the plugin will find every instance of the shortcode, and for each instance, will automatically download the video's thumbnail from YouTube if it hasn't been downloaded previously, and will save the thumbnail to the Pelican output folder (by default, to /output/images/youtube-thumbnails). It will then replace the shortcode with the thumbnail image. A jQuery script then watches for thumbnail image clicks; when a user clicks a thumbnail image, the jQuery script will fade the image out, and replace it with the actual youtube video iframe.
+
+YouTube does have a ["privacy-enhanced mode"](https://support.google.com/youtube/answer/171780?expand=PrivacyEnhancedMode#privacy) that purports not to place cookies on a user's page until the user clicks on a video. However, if you are a website author who wants to *ensure* that no cookies are initially placed, this plugin puts that power in your hands.
+
+
+## Usage
+
+`!youtube(2XID_W4neJo)` written anywhere in the content of a page or post will become `<img class="youtube-embed-dummy-image" id="2XID_W4neJo" src="YOUR_SITEURL/images/youtube-thumbnails/2XID_W4neJo.jpg" alt="Embedded Video - Click to view" title="Embedded Video - Click to view"></img>` during the `make html` process ('YOUR_SITEURL' is replaced by your actual `SITEURL` from pelicanconf.py). The plugin will take care of downloading `2XID_W4neJo.jpg`.
+
+The plugin comes with an example jQuery file to copy into your theme's static folder. **With this jQuery script, anytime a thumbnail image is clicked by a user, the thumbnail will fade out and then be replaced by the actual video embed.** Thus, the `<img>...</img>` code above will become `<iframe width="853" height="480" src="//www.youtube-nocookie.com/embed/2XID_W4neJo" frameborder="0" allowfullscreen></iframe>` when clicked.
+
+To set the plugin up, just read the instructions at the top of youtube_privacy_enhancer.py. That file also includes some example CSS to copy into your theme's CSS file, as well as a setting or two for you to look over.
+
+
+## To Do
+
+As noted in an EFF [blog post](https://www.eff.org/deeplinks/2010/08/upgrade-mytube "EFF blog post about updates to MyTube"), the Drupal MyTube plugin from which this plugin takes its idea is capable of handling videos not only from YouTube, but also from Vimeo, Comedy Central, and other sites. It would be nice to expand this Pelican plugin in the future to do the same. In addition, the code could likely be refactored to make extending the plugin easier.

--- a/video_privacy_enhancer/__init__.py
+++ b/video_privacy_enhancer/__init__.py
@@ -1,0 +1,1 @@
+from .video_privacy_enhancer import *

--- a/video_privacy_enhancer/video_privacy_enhancer.py
+++ b/video_privacy_enhancer/video_privacy_enhancer.py
@@ -1,0 +1,137 @@
+"""
+Video Privacy Enhancer
+--------------------------
+
+Authored by Jacob Levernier, 2014
+Released under the GNU AGPLv3
+
+For more information on this plugin, please see the attached Readme.md file.
+
+"""
+
+"""
+SETTINGS
+"""
+
+# Do not use a leading or trailing slash below (e.g., use "images/video-thumbnails"):
+output_directory_for_thumbnails = "images/video-thumbnails"
+
+""" 
+In order for this plugin to work optimally, you need to do just a few things:
+
+1. Enable the plugn in pelicanconf.py (see http://docs.getpelican.com/en/3.3.0/plugins.html for documentation):  
+    PLUGIN_PATH = "/pelican-plugins"  
+    PLUGINS = ["video_privacy_enhancer"]
+
+2a. If necessary, install jQuery on your site (See https://stackoverflow.com/questions/1458349/installing-jquery -- the jQuery base file should go into your Pelican themes 'static' directory)
+
+2b. Copy the jQuery file in this folder into, for example, your_theme_folder/static/video_privacy_enhancer_jQuery.js, and add a line like this to the <head></head> element of your website's base.html (or equivalent) template:
+    `<script src="{{ SITEURL }}/theme/video_privacy_enhancer_jquery.js"></script> <!--Load jQuery functions for the Video Privacy Enhancer Pelican plugin -->`
+
+3. Choose a default video embed size and add corresponding CSS to your theme's CSS file:
+
+Youtube allows the following sizes in its embed GUI (as of this writing, in March 2014). I recommend choosing one, and then having the iframe for the actual video embed match it (so that it's a seamless transition). This can be handled with CSS in both cases, so I haven't hard-coded it here:
+    1280 W x 720 H
+    853 W x 480 H
+    640 W x 360 H
+    560 W x 315 H
+
+Here's an example to add to your CSS file:
+
+```
+/* For use with the video-privacy-enhancer Pelican plugin */
+img.video-embed-dummy-image.
+iframe.embedded_youtube_video {
+    width: 843px;
+    max-height: 480px;
+
+    /* Center the element on the screen */
+    display: block;
+    margin-top: 2em;
+    margin-bottom: 2em;
+    margin-left: auto;
+    margin-right: auto;
+}
+iframe.embedded_youtube_video {
+    width: 843px;
+    height: 480px;
+}
+```
+
+"""
+
+
+"""
+END SETTINGS
+"""
+
+
+from pelican import signals # For making this plugin work with Pelican.
+
+import os.path # For checking whether files are present in the filesystem.
+
+import re # For using regular expressions.
+import urllib # For downloading the video thumbnails.
+
+import logging
+logger = logging.getLogger(__name__) # For using logger.debug() to log errors or other notes.
+
+
+# A function to check whtether output_directory_for_thumbnails (a variable set above in the SETTINGS section) exists. If it doesn't exist, we'll create it.
+def check_for_thumbnail_directory(pelican_output_path):
+    # Per http://stackoverflow.com/a/84173, check if a file exists. isfile() works on files, and exists() works on files and directories.
+    try:
+        if not os.path.exists(pelican_output_path + "/" + output_directory_for_thumbnails): # If the directory doesn't exist already...
+            os.makedirs(pelican_output_path + "/" + output_directory_for_thumbnails) # Create the directory to hold the video thumbnails.
+            return True
+    except:
+        print logger.debug("Error in checking if thumbnail folder exists and making the directory if it doesn't.") # In case something goes wrong.
+        return False
+
+
+# A function to download the video thumbnail from YouTube (currently the only supported video platform):
+def download_thumbnail(video_id_from_shortcode, pelican_output_path):
+    # Check if the thumbnail directory exists already:
+    check_for_thumbnail_directory(pelican_output_path)
+    
+    # Check if the thumbnail for this video exists already (if it's been previously downloaded). If it doesn't, download it:
+    if not os.path.exists(pelican_output_path + "/" + output_directory_for_thumbnails + "/" + video_id_from_shortcode + ".jpg"): # If the thumbnail doesn't already exist...
+        urllib.urlretrieve("https://img.youtube.com/vi/" + video_id_from_shortcode + "/0.jpg", pelican_output_path + "/" + output_directory_for_thumbnails + "/" + video_id_from_shortcode + ".jpg") # Download the thumbnail. This follows the instructions at http://www.reelseo.com/youtube-thumbnail-image/ for downloading YouTube thumbnail images.
+
+
+# A function to read through each page and post as it comes through from Pelican, find all instances of `!youtube(...)`, and change it into an HTML <img> element with the video thumbnail.
+def process_youtube_shortcodes(data_passed_from_pelican):
+    if data_passed_from_pelican._content: # If the item passed from Pelican has a "content" attribute (i.e., if it's not an image file or something else like that). NOTE: data_passed_from_pelican.content (without an underscore in front of 'content') seems to be read-only, whereas data_passed_from_pelican._content is able to be overwritten. This is somewhat explained in an IRC log from 2013-02-03 from user alexis to user webdesignhero_ at https://botbot.me/freenode/pelican/2013-02-01/?tz=America/Los_Angeles.
+        full_content_of_page_or_post = data_passed_from_pelican._content
+    else:
+        return # Exit the function, essentially passing over the (non-text) file.
+
+    all_instances_of_the_youtube_shortcode = re.findall('\!youtube.*?\)', full_content_of_page_or_post) # Use a regular expression to find every instance of '!youtube' followed by anything up to the first matching ')'.
+
+    if(len(all_instances_of_the_youtube_shortcode) > 0): # If the article/page HAS any shortcodes, go on. Otherwise, don't (to do so would inadvertantly wipe out the output content for that article/page).
+        replace_shortcode_in_text = "" # This just gives this an initial value before going into the loop below.
+
+        # Go through each shortcode instance that we found above, and parse it:
+        for youtube_shortcode_to_parse in all_instances_of_the_youtube_shortcode:
+
+            video_id_from_shortcode = re.findall('(?<=youtube\().*?(?=\))', youtube_shortcode_to_parse)[0] # Get what's inside of the parentheses in '!youtube(...).'
+            
+            # print "Video ID is " + video_id_from_shortcode # Good for debugging purposes.
+            
+            # Use the Pelican pelicanconf.py settings:
+            pelican_output_path = data_passed_from_pelican.settings['OUTPUT_PATH']
+            pelican_site_url = data_passed_from_pelican.settings['SITEURL']
+
+            # Download the video thumbnail if it's not already on the filesystem:            
+            download_thumbnail(video_id_from_shortcode, pelican_output_path)
+
+            # Replace '!youtube(...)' with '<img>...</img>'. Note that the <img> is given a class that the jQuery file mentioned at the top of this file will watch over. Any time an image with that class is clicked, the jQuery function will trigger and turn it into the full video embed.
+            replace_shortcode_in_text = re.sub(r'\!youtube\(' + video_id_from_shortcode + '\)', r'<img class="youtube-embed-dummy-image" id="' + video_id_from_shortcode + '" src="' +  pelican_site_url + '/' + output_directory_for_thumbnails + '/' + video_id_from_shortcode + '.jpg" alt="Embedded Video - Click to view" title="Embedded Video - Click to view"></img>', full_content_of_page_or_post)
+
+        # Replace the content of the page or post with our now-updated content (having gone through all instances of the !youtube() shortcode and updated them all, exiting the loop above.
+        data_passed_from_pelican._content = replace_shortcode_in_text
+
+
+# Make Pelican work (see http://docs.getpelican.com/en/3.3.0/plugins.html#how-to-create-plugins):
+def register():
+    signals.content_object_init.connect(process_youtube_shortcodes)

--- a/video_privacy_enhancer/video_privacy_enhancer_jquery.js
+++ b/video_privacy_enhancer/video_privacy_enhancer_jquery.js
@@ -1,0 +1,19 @@
+$(document).ready(function() {
+// NOTE WELL: This is wrapped in a `$(document).ready(function() {...})` function (i.e., a "Document Ready" function that starts a section that won't load until the rest of the document/page has loaded (i.e., is "ready")). HOWEVER, this makes it so that jQuery functions from different .js files here are not able to see and talk to functions within this Document Ready function. Within a Document Ready function, functions and variables lose global scope. See http://stackoverflow.com/a/6547906 for more information.
+    
+// Whenever a link for an image created with the video_privacy_enhancer plugin is clicked, transform it into a video embed:
+$('body').on("click",'img.youtube-embed-dummy-image',function(event) // Whenever an image with the class "youtube-embed-dummy-image" is clicked...
+	{
+	    // '$(this)' below refers to the image that's been clicked. Before we go down into the function below, where the definition/scope of '$(this)' will change, we'll set it in a variable so that we can refer to it within the function below.
+	    var image_that_was_clicked = $(this);
+	    
+	    var youtube_video_id = $(this).attr('id'); // This assumes that the img ID attribute is set to the youtube video id.
+
+        // Fade out the image, and replace it with the iframe embed code for the actual YouTube video:
+	    $(this).fadeOut(250, function() {
+	        image_that_was_clicked.replaceWith('<iframe class="embedded_youtube_video" src="//www.youtube-nocookie.com/embed/' + youtube_video_id + '" frameborder="0" allowfullscreen></iframe>') // This will automatically show again.
+			}); // End fadeOut.
+	});
+
+
+}) // End Document Ready wrapper.


### PR DESCRIPTION
Hello,

I've created a new plugin for Pelican, and would like it to be added to the pelican-plugins repo.

This plugin is a conceptual replication of the Electronic Frontier Foundation's MyTube plugin, which pre-caches thumbnails of embedded YouTube videos so that users are not tracked by Google until they explicitly "opt-in" by clicking on the thumbnail (at which point the thumbnail is replaced by the video embed iframe).

Thank you for your consideration!

Note: I originally made this pull request at https://github.com/getpelican/pelican-plugins/pull/183, but then closed that request after realizing that I should have put the changes in their own branch.
