### PR TITLE
Added files for new Codeblock Line Numbering Pelican plugin.

### DIFF
--- a/better_codeblock_line_numbering/Readme.md
+++ b/better_codeblock_line_numbering/Readme.md
@@ -1,0 +1,125 @@
+# Better Code Line Numbering Plugin
+
+## Copyright, Contact, and Acknowledgements
+
+This plugin is copyright 2014 Jacob Levernier  
+It is released under the BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause). This basically means that you can do whatever you want with the code, provided that you include this copyright and license notice.
+
+Some of this code is modified from my YouTube Privacy Enhancer plugin for Pelican (https://github.com/getpelican/pelican-plugins/pull/183).
+
+
+### To contact the author:
+
+* jleverni at uoregon dot edu  
+* http://AdUnumDatum.org  
+* BitBucket: https://bitbucket.org/jlev_uo/  
+* Github: https://github.com/publicus  
+
+This is the second plugin that I've written for Pelican, and it was intended as a training project for learning Pelican as well as Python better. I would be very happy to hear constructive feedback on the plugin and for suggestions for making it more efficient and/or expandable. Also, I've heavily annotated all of the Python code in order to make it easier to understand for others looking to learn more, like I was when I wrote the plugin.
+
+### Acknowledgements
+
+I'm grateful to the authors of the plugins in the pelican-plugins repo; being able to look over other plugins' authors' code helped me immensely in learning more about how Pelican's [signals](http://docs.getpelican.com/en/3.3.0/plugins.html#how-to-create-plugins "Pelican documentation on creating plugins") system works.
+
+
+## Explanation and Rationale
+
+Pelican uses Python's built-in code highlighting extension when processing Markdown. This extension, called Code HiLite (https://pythonhosted.org/Markdown/extensions/code_hilite.html), can add line numbers to any code that is enclosed in triple backticks (and, by default, has a shebang as a first line), like this:
+
+```
+#!python
+
+code goes here
+
+more code goes here
+```
+
+This works well, except for one problem: If the lines of code are long (or if the page template is narrow), the code will run off of the page, requiring that the user scroll sideways to read it. This can be annoying in some circumstances (e.g., if the code block scrollbar is at the very bottom of a long block of code). The Code HiLite Python extension creates line numbers by making a table with all of the line numbers in one column (as a big line of text, not separated into different table rows) and the code in the second column, like this:
+
+Column 1  | Column 2  
+--------- | -------------  
+1         | Code line 1 goes here, and maybe is very very long.  
+2         | Code line 2 goes here.  
+
+It is possible to use CSS to get this code to wrap, but the line numbers can become mis-matched with the code to which they're supposed to refer, like this:
+
+Column 1  | Column 2  
+--------- | -------------  
+1         | Code line 1 goes here, and  
+2         | maybe is very very long.  
+          | Code line 2 goes here.
+
+This plugin enables the use of a CSS technique from http://bililite.com/blog/2012/08/05/line-numbering-in-pre-elements/ . All that this plugin does is wrap every individual line of a code block with <span class="code-line">...</span>. When you combine this with the CSS that's included in the setup instructions below, your code blocks will word-wrap and have nicely formatted line numbers. Since they're added with CSS, the line numbers will not be highlighted when a user wants to copy and paste the contents of the code block, making it easier for the user to benefit from what you've written.
+
+
+## Usage
+
+**After you set up the plugin (by following the steps below), any code written in triple backticks will have line numbers added to it.** Thus, to avoid line numbers, you can use a single backtick to include code `like this`, and can add line numbers by using three backticks
+
+```
+like this
+```
+
+That's all there is to it!
+
+Since this plugin builds on the Code HiLite plugin, you can change syntax highlighting by using one of two methods:
+
+```{python}
+This code will highlight as python
+```
+
+```
+#!python
+This code will also highlight as python
+```
+
+
+**In order for this plugin to work optimally, you need to do just a few things:**
+
+1. Enable the plugin in pelicanconf.py (see http://docs.getpelican.com/en/3.3.0/plugins.html for documentation):  
+    PLUGIN_PATH = "/pelican-plugins"  
+    PLUGINS = ["better_codeblock_line_numbering"]
+
+2. Add the following to your pelicanconf.py file:  
+```
+MD_EXTENSIONS = [
+    'codehilite(css_class=highlight,linenums=False)',
+    'extra'
+    ]
+```  
+This sets python's CodeHiLite Markdown extension (http://pythonhosted.org/Markdown/extensions/code_hilite.html) so that it never assigns line numbers (since we're taking care of those ourselves now), and to wrap code blocks in a div with class="highlight". As is the default for Pelican (see http://docs.getpelican.com/en/3.1.1/settings.html, under "MD_EXTENSIONS"), this also keeps the 'extra' extension (http://pythonhosted.org/Markdown/extensions/extra.html) active.
+
+3. Add the following code to your CSS file:  
+```
+/* For use with the code_line-number_word-wrap_switcher_jquery.js Pelican plugin */
+code {
+	overflow: auto;
+	/* This uses `white-space: pre-wrap` to get elements within <pre> tags to wrap. Python, for code chunks within three backticks (```), doesn't wordwrap code lines by default, because they're within <pre> tags, which don't wrap by default. See https://github.com/github/markup/issues/168 , which is specifically about this parsing issue, even though that link's discussion is talking about GitHub. */
+	white-space: pre-wrap;       /* css-3 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}
+
+/* Following http://bililite.com/blog/2012/08/05/line-numbering-in-pre-elements/, use CSS to add line numbers to all spans that have the class 'code-line' */
+
+.highlight pre {
+    counter-reset: linecounter;
+    padding-left: 2em;
+}
+.highlight pre span.code-line {
+	counter-increment: linecounter;
+    padding-left: 1em;
+	text-indent: -1em;
+	display: inline-block;
+}
+.highlight pre span.code-line:before {
+    content: counter(linecounter);
+    padding-right: 1em;
+    display: inline-block;
+    color: grey;
+    text-align: right;
+}
+```
+

--- a/better_codeblock_line_numbering/__init__.py
+++ b/better_codeblock_line_numbering/__init__.py
@@ -1,0 +1,1 @@
+from .better_codeblock_line_numbering import *

--- a/better_codeblock_line_numbering/better_codeblock_line_numbering.py
+++ b/better_codeblock_line_numbering/better_codeblock_line_numbering.py
@@ -1,0 +1,47 @@
+"""
+Better Code-Block Line Numbering Plugin
+--------------------------
+
+Authored by Jacob Levernier, 2014
+Released under the BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+
+For more information on this plugin, please see the attached Readme.md file.
+"""
+
+from pelican import signals # For making this plugin work with Pelican.
+
+import os.path # For checking whether files are present in the filesystem.
+
+import re # For using regular expressions.
+
+def add_line_wrappers(data_passed_from_pelican):
+    """A function to read through each page and post as it comes through from Pelican, find all instances of triple-backtick (```...```) code blocks, and add an HTML wrapper to each line of each of those code blocks"""
+
+    if data_passed_from_pelican._content: # If the item passed from Pelican has a "content" attribute (i.e., if it's not an image file or something else like that). NOTE: data_passed_from_pelican.content (without an underscore in front of 'content') seems to be read-only, whereas data_passed_from_pelican._content is able to be overwritten. This is somewhat explained in an IRC log from 2013-02-03 from user alexis to user webdesignhero_ at https://botbot.me/freenode/pelican/2013-02-01/?tz=America/Los_Angeles.
+        full_content_of_page_or_post = data_passed_from_pelican._content
+    else:
+        return # Exit the function, essentially passing over the (non-text) file.
+
+    all_instances_of_pre_elements = re.findall('<pre>.*?</pre>', full_content_of_page_or_post, re.DOTALL) # Use a regular expression to find every instance of '<pre>' followed by anything up to the first matching '</pre>'. re.DOTALL puts python's regular expression engine ('re') into a mode where a dot ('.') matches absolutely anything, including newline characters.
+    
+    if(len(all_instances_of_pre_elements) > 0): # If the article/page HAS any <pre>...</pre> elements, go on. Otherwise, don't (to do so would inadvertantly wipe out the output content for that article/page).
+        updated_full_content_of_page_or_post = full_content_of_page_or_post # This just gives this an initial value before going into the loop below.
+
+        # Go through each <pre> element instance that we found above, and parse it:
+        for pre_element_to_parse in all_instances_of_pre_elements:
+
+            # Wrap each line of the <pre>...</pre> section with <span class=code-line>...</span>, following http://bililite.com/blog/2012/08/05/line-numbering-in-pre-elements/. We'll use these to add line numbers using CSS later.
+            # Note that below, '^' is the beginning of a string, '$' is the end of a string, and '\n' is a newline.
+            replacement_text_with_beginning_of_each_line_wrapped_in_span = re.sub(r'(<pre.*?>|\n(?!</pre>))','\\1<span class="code-line">',pre_element_to_parse) # The (?!...) here is a Negative Lookahead (cf. http://www.regular-expressions.info/lookaround.html). This full regular expression says "Give me all code snippets that start with <pre ****> or start with a newline (\n), but NOT if the newline is followed immediately with '</pre>'. Take whatever you find, and replace it with what you found (\1) followed immediately by '<span class="code-lines">'.
+            # http://stackoverflow.com/a/14625628 explains why we need to escape the backslash in the capture group reference (the '\1'). In short, python will recognize it as "\x01" if it's not escaped.
+            replacement_text_with_full_line_wrapped_in_span = re.sub(r'((?<!</pre>)$|(?<!</pre>)\n)','</span>\\1',replacement_text_with_beginning_of_each_line_wrapped_in_span) # This regular expression says "Give me all code snippets that are the end of a string or a newline (but not preceeded by "</pre>" (this is a 'negative lookahead,' '(?<)'), and replace whatever you found with '</span'> followed by whatever you found (\1).
+            
+            updated_full_content_of_page_or_post = updated_full_content_of_page_or_post.replace(pre_element_to_parse,replacement_text_with_full_line_wrapped_in_span)
+
+        # Replace the content of the page or post with our now-updated content (having gone through all instances of <pre> elements and updated them all, exiting the loop above.
+        data_passed_from_pelican._content = updated_full_content_of_page_or_post
+
+
+# Make Pelican work (see http://docs.getpelican.com/en/3.3.0/plugins.html#how-to-create-plugins):
+def register():
+    signals.content_object_init.connect(add_line_wrappers)


### PR DESCRIPTION
Hello,

I've created a new plugin for Pelican, and would like it to be added to the pelican-plugins repo.

This plugin adds better line-numbering abilities to Pelican by automatically wrapping each line of every codeblock in a separate <span> element. This allows line numbering with CSS in a way that will still work if the code is word-wrapped (which is not the case with the python markdown CodeHiLite plugin that Pelican uses).

Thank you for your consideration!
