### PR TITLE
Added example for summary markers in reST documents

### DIFF
--- a/summary/Readme.rst
+++ b/summary/Readme.rst
@@ -1,10 +1,10 @@
 Summary
 -------
 
-This plugin allows easy, variable length summaries directly embedded into the 
+This plugin allows easy, variable length summaries directly embedded into the
 body of your articles. It introduces two new settings: ``SUMMARY_BEGIN_MARKER``
 and ``SUMMARY_END_MARKER``: strings which can be placed directly into an article
-to mark the beginning and end of a summary. When found, the standard 
+to mark the beginning and end of a summary. When found, the standard
 ``SUMMARY_MAX_LENGTH`` setting will be ignored. The markers themselves will also
 be removed from your articles before they are published. The default values
 are ``<!-- PELICAN_BEGIN_SUMMARY -->`` and ``<!-- PELICAN_END_SUMMARY -->``.
@@ -16,7 +16,7 @@ For example::
     Category: yeah
     Slug: my-super-post
     Author: Alexis Metaireau
-    
+
     This is the content of my super blog post.
     <!-- PELICAN_END_SUMMARY -->
     and this content occurs after the summary.
@@ -25,3 +25,24 @@ Here, the summary is taken to be the first line of the post. Because no
 beginning marker was found, it starts at the top of the body. It is possible
 to leave out the end marker instead, in which case the summary will start at the
 beginning marker and continue to the end of the body.
+
+reST example
+~~~~~~~~~~~~
+
+Inserting the markers into a reStructuredText document makes use of the
+comment directive, because raw HTML is automatically escaped. The reST equivalent of the above Markdown example looks like this::
+
+    My super title
+    ##############
+
+    :date: 2010-12-03 10:20
+    :tags: thats, awesome
+    :category: yeah
+    :slug: my-super-post
+    :author: Alexis Metaireau
+
+    This is the content of my super blog post.
+
+    .. PELICAN_END_SUMMARY
+
+    and this content occurs after the summary.


### PR DESCRIPTION
This resolves issue #151
