### PR TITLE
[post_stats] Python 3 compatibility

### DIFF
--- a/post_stats/readability.py
+++ b/post_stats/readability.py
@@ -30,7 +30,7 @@ def normalize(text):
 def text_stats(text, wc):
     text = normalize(text)
     stcs = [s.split(" ") for s in text.split(". ")]
-    stcs = filter(lambda s: len(s) >= 2, stcs)
+    stcs = list(filter(lambda s: len(s) >= 2, stcs))
 
     if wc:
         words = wc


### PR DESCRIPTION
In Python 3, `filter()` returns an iterator instead of a list, which causes an error on line 42: "object of type 'filter' has no len()".
