### PR TITLE
Fix documentation about PLUGIN_PATH setting

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -15,7 +15,7 @@ Easiest way to install and use these plugins is cloning this repo::
 
 and activating the ones you want in your settings file::
 
-    PLUGIN_PATH = 'path/to/pelican-plugins'
+    PLUGIN_PATHS = ['path/to/pelican-plugins']
     PLUGINS = ['assets', 'sitemap', 'gravatar']
 
 ``PLUGIN_PATH`` can be a path relative to your settings file or an absolute path.


### PR DESCRIPTION
`PLUGIN_PATH` setting has been replaced by `PLUGIN_PATHS` and it should be a list.

```
% make ssh_upload                             
pelican /home/yoyo/projects/pelican-website/content -o /home/yoyo/projects/pelican-website/output -s /home/yoyo/projects/pelican-website/publishconf.py 
WARNING: PLUGIN_PATH setting has been replaced by PLUGIN_PATHS, moving it to the new setting name.
WARNING: Defining PLUGIN_PATHS setting as string has been deprecated (should be a list)
```
