### PR TITLE
[post_stats] Python 3 compatibility

### DIFF
--- a/post_stats/readability.py
+++ b/post_stats/readability.py
@@ -30,7 +30,7 @@ def normalize(text):
 def text_stats(text, wc):
     text = normalize(text)
     stcs = [s.split(" ") for s in text.split(". ")]
-    stcs = filter(lambda s: len(s) >= 2, stcs)
+    stcs = [s for s in stcs if len(s) >= 2]
 
     if wc:
         words = wc


### PR DESCRIPTION
In Python 3, `filter()` returns an iterator instead of a list, which causes an error on line 42: "object of type 'filter' has no len()". Using a list comprehension fixes this, and is probably a little more readable.

This is an enhanced version of #231, as suggested by @avaris.
