### PR TITLE
Properly encode author in comments

### DIFF
--- a/pelican_comment_system/comment.py
+++ b/pelican_comment_system/comment.py
@@ -15,7 +15,7 @@ class Comment(Content):
 		self.id = id
 		self.replies = []
 		self.avatar = avatar
-		self.title = "Posted by:  " + str(metadata['author'])
+		self.title = "Posted by:  {}".format(metadata['author'])
 
 	def addReply(self, comment):
 		self.replies.append(comment)


### PR DESCRIPTION
Rather than manually converting to string, this uses `format`, which properly handles extended characters in author names.
