### PR TITLE
[pelican_comment_system] Properly encode metadata

### DIFF
--- a/pelican_comment_system/avatars.py
+++ b/pelican_comment_system/avatars.py
@@ -69,7 +69,7 @@ def getAvatarPath(comment_id, metadata):
 	author = tuple()
 	for data in _identicon_data:
 		if data in metadata:
-			string = str(metadata[data])
+			string = "{}".format(metadata[data])
 			md5.update(string.encode('utf-8'))
 			author += tuple([string])
 		else:


### PR DESCRIPTION
Related to #235

Fixes a python 2 unicode error when avatars are enabled and unicode characters are in the metadata.
