### PR TITLE
Make touch plugin touch files with lists

### DIFF
--- a/touch/__init__.py
+++ b/touch/__init__.py
@@ -8,12 +8,23 @@ import time
 logger = logging.getLogger(__name__)
 
 
+def set_file_utime(path, datetime):
+    mtime = time.mktime(datetime.timetuple())
+    logger.info('touching %s', path)
+    os.utime(path, (mtime, mtime))
+
+
 def touch_file(path, context):
     content = context.get('article', context.get('page'))
+    page = context.get('articles_page')
+    dates = context.get('dates')
+
     if content and hasattr(content, 'date'):
-        mtime = time.mktime(content.date.timetuple())
-        logger.info('touching %s', path)
-        os.utime(path, (mtime, mtime))
+        set_file_utime(path, content.date)
+    elif page:
+        set_file_utime(path, max(x.date for x in page.object_list))
+    elif dates:
+        set_file_utime(path, max(x.date for x in dates))
 
 
 def register():


### PR DESCRIPTION
Currently touch plugin does not touch a lot of pages with lists of articles: archives, period archives, index pages, tags pages. 

This simple change makes the plugin touch these pages with the timestamp of the most recent article on the page.
