### PR TITLE
[pelican_comment_system] pep8-ify

### DIFF
--- a/pelican_comment_system/comment.py
+++ b/pelican_comment_system/comment.py
@@ -20,7 +20,7 @@ class Comment(Content):
         name = os.path.split(source_path)[1]
 
         if not hasattr(self, 'slug'):
-            #compute the slug before initializing the base Content object, so
+            # compute the slug before initializing the base Content object, so
             # it doesn't get set there
             # This is required because we need a slug containing the file
             # extension.

--- a/pelican_comment_system/identicon/identicon.py
+++ b/pelican_comment_system/identicon/identicon.py
@@ -26,7 +26,9 @@ __all__ = ['render_identicon', 'IdenticonRendererBase']
 
 
 class Matrix2D(list):
+
     """Matrix for Patch rotation"""
+
     def __init__(self, initial=[0.] * 9):
         assert isinstance(initial, list) and len(initial) == 9
         list.__init__(self, initial)
@@ -84,7 +86,7 @@ class Matrix2D(list):
         return kls.translate(-pivot[0], -pivot[1]) * matR *
             kls.translate(*pivot)
     """
-    
+
     @classmethod
     def rotateSquare(kls, theta, pivot=None):
         theta = theta % 4
@@ -100,7 +102,7 @@ class Matrix2D(list):
 
 class IdenticonRendererBase(object):
     PATH_SET = []
-    
+
     def __init__(self, code):
         """
         @param code code for icon
@@ -108,25 +110,25 @@ class IdenticonRendererBase(object):
         if not isinstance(code, int):
             code = int(code)
         self.code = code
-    
+
     def render(self, size):
         """
         render identicon to PIL.Image
-        
+
         @param size identicon patchsize. (image size is 3 * [size])
         @return PIL.Image
         """
-        
+
         # decode the code
         middle, corner, side, foreColor, backColor = self.decode(self.code)
         size = int(size)
-        # make image        
+        # make image
         image = Image.new("RGB", (size * 3, size * 3))
         draw = ImageDraw.Draw(image)
-        
+
         # fill background
         draw.rectangle((0, 0, image.size[0], image.size[1]), fill=0)
-        
+
         kwds = {
             'draw': draw,
             'size': size,
@@ -140,17 +142,17 @@ class IdenticonRendererBase(object):
         for i in range(4):
             pos = [(1, 0), (2, 1), (1, 2), (0, 1)][i]
             self.drawPatch(pos, side[2] + 1 + i, side[1], **kwds)
-        
+
         # corner patch
         kwds['type'] = corner[0]
         for i in range(4):
             pos = [(0, 0), (2, 0), (2, 2), (0, 2)][i]
             self.drawPatch(pos, corner[2] + 1 + i, corner[1], **kwds)
-        
+
         return image
-                
+
     def drawPatch(self, pos, turn, invert, type, draw, size, foreColor,
-            backColor):
+                  backColor):
         """
         @param size patch size
         """
@@ -162,27 +164,28 @@ class IdenticonRendererBase(object):
         patch = ImagePath.Path(path)
         if invert:
             foreColor, backColor = backColor, foreColor
-        
+
         mat = Matrix2D.rotateSquare(turn, pivot=(0.5, 0.5)) *\
-              Matrix2D.translate(*pos) *\
-              Matrix2D.scale(size, size)
-        
+            Matrix2D.translate(*pos) *\
+            Matrix2D.scale(size, size)
+
         patch.transform(mat.for_PIL())
         draw.rectangle((pos[0] * size, pos[1] * size, (pos[0] + 1) * size,
-            (pos[1] + 1) * size), fill=backColor)
+                        (pos[1] + 1) * size), fill=backColor)
         draw.polygon(patch, fill=foreColor, outline=foreColor)
 
-    ### virtual functions
+    # virtual functions
     def decode(self, code):
         raise NotImplementedError
 
 
 class DonRenderer(IdenticonRendererBase):
+
     """
     Don Park's implementation of identicon
     see : http://www.docuverse.com/blog/donpark/2007/01/19/identicon-updated-and-source-released
     """
-    
+
     PATH_SET = [
         [(0, 0), (4, 0), (4, 4), (0, 4)],   # 0
         [(0, 0), (4, 0), (0, 4)],
@@ -192,7 +195,7 @@ class DonRenderer(IdenticonRendererBase):
         [(0, 0), (4, 2), (4, 4), (2, 4)],
         [(2, 0), (4, 4), (2, 4), (3, 2), (1, 2), (2, 4), (0, 4)],
         [(0, 0), (4, 2), (2, 4)],
-        [(1, 1), (3, 1), (3, 3), (1, 3)],   # 8   
+        [(1, 1), (3, 1), (3, 3), (1, 3)],   # 8
         [(2, 0), (4, 0), (0, 4), (0, 2), (2, 2)],
         [(0, 0), (2, 0), (2, 2), (0, 2)],
         [(0, 2), (4, 2), (2, 4)],
@@ -201,34 +204,34 @@ class DonRenderer(IdenticonRendererBase):
         [(0, 0), (2, 0), (0, 2)],
         []]                                 # 15
     MIDDLE_PATCH_SET = [0, 4, 8, 15]
-    
+
     # modify path set
     for idx in range(len(PATH_SET)):
         if PATH_SET[idx]:
             p = map(lambda vec: (vec[0] / 4.0, vec[1] / 4.0), PATH_SET[idx])
             p = list(p)
             PATH_SET[idx] = p + p[:1]
-    
+
     def decode(self, code):
-        # decode the code        
-        middleType  = self.MIDDLE_PATCH_SET[code & 0x03]
-        middleInvert= (code >> 2) & 0x01
-        cornerType  = (code >> 3) & 0x0F
-        cornerInvert= (code >> 7) & 0x01
-        cornerTurn  = (code >> 8) & 0x03
-        sideType    = (code >> 10) & 0x0F
-        sideInvert  = (code >> 14) & 0x01
-        sideTurn    = (code >> 15) & 0x03
-        blue        = (code >> 16) & 0x1F
-        green       = (code >> 21) & 0x1F
-        red         = (code >> 27) & 0x1F
-        
+        # decode the code
+        middleType = self.MIDDLE_PATCH_SET[code & 0x03]
+        middleInvert = (code >> 2) & 0x01
+        cornerType = (code >> 3) & 0x0F
+        cornerInvert = (code >> 7) & 0x01
+        cornerTurn = (code >> 8) & 0x03
+        sideType = (code >> 10) & 0x0F
+        sideInvert = (code >> 14) & 0x01
+        sideTurn = (code >> 15) & 0x03
+        blue = (code >> 16) & 0x1F
+        green = (code >> 21) & 0x1F
+        red = (code >> 27) & 0x1F
+
         foreColor = (red << 3, green << 3, blue << 3)
-        
+
         return (middleType, middleInvert, 0),\
                (cornerType, cornerInvert, cornerTurn),\
                (sideType, sideInvert, sideTurn),\
-               foreColor, ImageColor.getrgb('white')
+            foreColor, ImageColor.getrgb('white')
 
 
 def render_identicon(code, size, renderer=None):
@@ -239,11 +242,11 @@ def render_identicon(code, size, renderer=None):
 
 if __name__ == '__main__':
     import sys
-    
+
     if len(sys.argv) < 2:
         print('usage: python identicon.py [CODE]....')
         raise SystemExit
-    
+
     for code in sys.argv[1:]:
         if code.startswith('0x') or code.startswith('0X'):
             code = int(code[2:], 16)
@@ -251,6 +254,6 @@ if __name__ == '__main__':
             code = int(code[1:], 8)
         else:
             code = int(code)
-        
+
         icon = render_identicon(code, 24)
         icon.save('%08x.png' % code, 'PNG')

--- a/pelican_comment_system/pelican_comment_system.py
+++ b/pelican_comment_system/pelican_comment_system.py
@@ -27,35 +27,48 @@ def pelican_initialized(pelican):
     from pelican.settings import DEFAULT_CONFIG
     DEFAULT_CONFIG.setdefault('PELICAN_COMMENT_SYSTEM', False)
     DEFAULT_CONFIG.setdefault('PELICAN_COMMENT_SYSTEM_DIR', 'comments')
-    DEFAULT_CONFIG.setdefault('PELICAN_COMMENT_SYSTEM_IDENTICON_OUTPUT_PATH' 'images/identicon')
+    DEFAULT_CONFIG.setdefault(
+        'PELICAN_COMMENT_SYSTEM_IDENTICON_OUTPUT_PATH' 'images/identicon')
     DEFAULT_CONFIG.setdefault('PELICAN_COMMENT_SYSTEM_IDENTICON_DATA', ())
     DEFAULT_CONFIG.setdefault('PELICAN_COMMENT_SYSTEM_IDENTICON_SIZE', 72)
     DEFAULT_CONFIG.setdefault('PELICAN_COMMENT_SYSTEM_AUTHORS', {})
-    DEFAULT_CONFIG.setdefault('PELICAN_COMMENT_SYSTEM_FEED', os.path.join('feeds', 'comment.%s.atom.xml'))
+    DEFAULT_CONFIG.setdefault(
+        'PELICAN_COMMENT_SYSTEM_FEED', os.path.join('feeds', 'comment.%s.atom.xml'))
     DEFAULT_CONFIG.setdefault('COMMENT_URL', '#comment-{slug}')
-    DEFAULT_CONFIG['PAGE_EXCLUDES'].append(DEFAULT_CONFIG['PELICAN_COMMENT_SYSTEM_DIR'])
-    DEFAULT_CONFIG['ARTICLE_EXCLUDES'].append(DEFAULT_CONFIG['PELICAN_COMMENT_SYSTEM_DIR'])
+    DEFAULT_CONFIG['PAGE_EXCLUDES'].append(
+        DEFAULT_CONFIG['PELICAN_COMMENT_SYSTEM_DIR'])
+    DEFAULT_CONFIG['ARTICLE_EXCLUDES'].append(
+        DEFAULT_CONFIG['PELICAN_COMMENT_SYSTEM_DIR'])
     if pelican:
         pelican.settings.setdefault('PELICAN_COMMENT_SYSTEM', False)
         pelican.settings.setdefault('PELICAN_COMMENT_SYSTEM_DIR', 'comments')
-        pelican.settings.setdefault('PELICAN_COMMENT_SYSTEM_IDENTICON_OUTPUT_PATH', 'images/identicon')
-        pelican.settings.setdefault('PELICAN_COMMENT_SYSTEM_IDENTICON_DATA', ())
-        pelican.settings.setdefault('PELICAN_COMMENT_SYSTEM_IDENTICON_SIZE', 72)
+        pelican.settings.setdefault(
+            'PELICAN_COMMENT_SYSTEM_IDENTICON_OUTPUT_PATH', 'images/identicon')
+        pelican.settings.setdefault(
+            'PELICAN_COMMENT_SYSTEM_IDENTICON_DATA', ())
+        pelican.settings.setdefault(
+            'PELICAN_COMMENT_SYSTEM_IDENTICON_SIZE', 72)
         pelican.settings.setdefault('PELICAN_COMMENT_SYSTEM_AUTHORS', {})
-        pelican.settings.setdefault('PELICAN_COMMENT_SYSTEM_FEED', os.path.join('feeds', 'comment.%s.atom.xml'))
+        pelican.settings.setdefault(
+            'PELICAN_COMMENT_SYSTEM_FEED', os.path.join('feeds', 'comment.%s.atom.xml'))
         pelican.settings.setdefault('COMMENT_URL', '#comment-{slug}')
 
-        pelican.settings['PAGE_EXCLUDES'].append(pelican.settings['PELICAN_COMMENT_SYSTEM_DIR'])
-        pelican.settings['ARTICLE_EXCLUDES'].append(pelican.settings['PELICAN_COMMENT_SYSTEM_DIR'])
+        pelican.settings['PAGE_EXCLUDES'].append(
+            pelican.settings['PELICAN_COMMENT_SYSTEM_DIR'])
+        pelican.settings['ARTICLE_EXCLUDES'].append(
+            pelican.settings['PELICAN_COMMENT_SYSTEM_DIR'])
+
 
 def initialize(article_generator):
     avatars.init(
         article_generator.settings['OUTPUT_PATH'],
-        article_generator.settings['PELICAN_COMMENT_SYSTEM_IDENTICON_OUTPUT_PATH'],
+        article_generator.settings[
+            'PELICAN_COMMENT_SYSTEM_IDENTICON_OUTPUT_PATH'],
         article_generator.settings['PELICAN_COMMENT_SYSTEM_IDENTICON_DATA'],
-        article_generator.settings['PELICAN_COMMENT_SYSTEM_IDENTICON_SIZE']/3,
+        article_generator.settings[
+            'PELICAN_COMMENT_SYSTEM_IDENTICON_SIZE'] / 3,
         article_generator.settings['PELICAN_COMMENT_SYSTEM_AUTHORS'],
-        )
+    )
 
 
 def warn_on_slug_collision(items):
@@ -92,7 +105,7 @@ def add_static_comments(gen, content):
     content.comments_count = 0
     content.comments = []
 
-    #Modify the local context, so we get proper values for the feed
+    # Modify the local context, so we get proper values for the feed
     context = copy.copy(gen.context)
     context['SITEURL'] += "/" + content.url
     context['SITENAME'] += " - Comments: " + content.title
@@ -129,7 +142,7 @@ def add_static_comments(gen, content):
 
     write_feed(gen, comments + replies, context, content.slug)
 
-    #TODO: Fix this O(n²) loop
+    # TODO: Fix this O(n²) loop
     for reply in replies:
         for comment in chain(comments, replies):
             if comment.slug == reply.replyto:


### PR DESCRIPTION
This changes the files in pelican_comment_system to conform to pep8 (as requested in #236): `autopep8 -r -i pelican_comment_system`.

I checked that these still worked with my own blog after the changes.
