### PR TITLE
Fixes link to Tipue search official documentation

### DIFF
--- a/tipue_search/README.md
+++ b/tipue_search/README.md
@@ -60,6 +60,6 @@ JSON is written to file `tipuesearch_content.json` which is created in the root 
 How to use
 ==========
 
-To utilize JSON Search mode, your theme needs to have Tipue Search properly configured in it. [Official documentation](http://www.tipue.com/search/docs/json/) has the required details.
+To utilize JSON Search mode, your theme needs to have Tipue Search properly configured in it. [Official documentation](http://www.tipue.com/search/docs/#json) has the required details.
 
 Pelican [Elegant Theme](https://github.com/talha131/pelican-elegant) has Tipue Search configured. You can view its code to understand the configuration. 


### PR DESCRIPTION
The old documentation link does not work anymore, I updated it with the correct one.
