### PR TITLE
Allow unicode chars in tipuesearch_content.json

### DIFF
--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -103,7 +103,7 @@ class Tipue_Search_JSON_Generator(object):
         root_node = {'pages': self.json_nodes}
 
         with open(path, 'w', encoding='utf-8') as fd:
-            json.dump(root_node, fd, separators=(',', ':'))
+            json.dump(root_node, fd, separators=(',', ':'), ensure_ascii=False)
 
 
 def get_generators(generators):


### PR DESCRIPTION
The file `tipuesearch_content.json` has utf-8 encoding and contains Unicode text. It does not make sense to enforce only ascii-characters in it, which is the default setting of `json.dump()`. This also has a downside of increasing the size of the by 160% in case of Russian texts (from 500kB to 1300kB) -- a serious problem for the target use case.

This pull request allows Unicode text to be present in   `tipuesearch_content.json`
