### PR TITLE
[pelican_comment_system] Fix reference to _identiconImported broken by 98a83b.

### DIFF
--- a/pelican_comment_system/avatars.py
+++ b/pelican_comment_system/avatars.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 _log = "pelican_comment_system: avatars: "
 try:
     from . identicon import identicon
-    identiconImported = True
+    _identiconImported = True
 except ImportError as e:
     logger.warning(_log + "identicon deactivated: " + str(e))
     _identiconImported = False


### PR DESCRIPTION
This fixes a reference that was broken by commit 98a83bc3e3bf4b5596ca4909fd274b3f08314d50.
