### PR TITLE
Move additional CSS/JS to separate files, include only in article pages.

### DIFF
--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -30,7 +30,7 @@ After typing "make html" when using the `ipynb` tag, three files are
 produced and put into the theme directory:
 
     /theme/css/ipynb.css
-    /theme/js/collapsecode.js
+    /theme/js/collapse.js
     /theme/js/math.js
 
 In order to take effect, you have to include this additional header-entry in
@@ -43,7 +43,7 @@ the article-template:
   <script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
   <script src="{{ SITEURL }}/theme/js/math.js"></script>
-  <script src="{{ SITEURL }}/theme/js/collapsecode.js"></script>
+  <script src="{{ SITEURL }}/theme/js/collapse.js"></script>
   {% endif %}
 
 All efforts have been made to ensure that this CSS will not override formats


### PR DESCRIPTION
I love this plugin and plan to use it for my site. To do so, I adjusted few things that bugged me. I don't know if these are generally wanted features or not - merge if wanted!

Issues it addresses:
- The current version puts about 1600 lines of mainly css and some javascript into the html-header.
- It includes this massive header on each page.
- Site-specific css are hard-coded in the plugin.

The changes address the issues in the following way:
- The additional css/js is put into separate files in the /theme/css and /theme/js directories.
- The required header is only on the articles pages, and only if the tag 'ipynb' is present.
- Site-specific css-changes have to be saved outside the plugin in 'output/theme/css/ipynb_mod.py'. 

I am not familiar enough with the pelican code itself. The following could therefore be improved: The paths 'output/theme/css' and 'output/theme/js' are hard-coded. Pelican has, presumably, variables containing these paths. These variables should be used instead.

Thanks for the great plugin!
Dieter
