### PR TITLE
Add Dateish plugin

### DIFF
--- a/dateish/Readme.rst
+++ b/dateish/Readme.rst
@@ -1,0 +1,36 @@
+Dateish Plugin for Pelican
+==========================
+
+This plugin adds the ability to treat arbitrary metadata fields as datetime
+objects.
+
+Usage
+-----
+
+For example, if you have the following pieces of metadata in an article:
+
+.. code-block:: markdown
+
+    # my_article.markdown
+    Date: 2000-01-01
+    Created_Date: 1999-08-04
+    Idea_Date: 1993-03-04
+
+Normally, the Created_Date and Idea_Date variables will be strings, so you will
+not be able to use the strftime() Jinja filter on them.
+
+With this plugin, you define in your settings file a list of the names of
+the additional metadata fields you want to treat as dates:
+
+.. code-block:: python
+
+    # pelicanconf.py
+    DATEISH_PROPERTIES = ['created_date', 'idea_date']
+
+Then you can use them in templates just like date:
+
+.. code-block:: html+jinja
+
+    # mytemplate.html
+    <p>Created date: {{ article.created_date | strftime('%d %B %Y') }}</p>
+

--- a/dateish/__init__.py
+++ b/dateish/__init__.py
@@ -1,0 +1,1 @@
+from .dateish import *

--- a/dateish/dateish.py
+++ b/dateish/dateish.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+Dateish Plugin for Pelican
+==========================
+
+This plugin adds the ability to treat arbitrary metadata fields as datetime
+objects.
+"""
+
+from pelican import signals
+from pelican.utils import get_date
+
+
+def dateish(generator):
+    if 'DATEISH_PROPERTIES' not in generator.settings:
+        return
+
+    for article in generator.articles:
+        for field in generator.settings['DATEISH_PROPERTIES']:
+            if hasattr(article, field):
+                text = getattr(article, field)
+                as_datetime = get_date(text)
+                setattr(article, field, as_datetime)
+
+def register():
+    signals.article_generator_finalized.connect(dateish)


### PR DESCRIPTION
This plugin allows arbitrary metadata fields to be automatically converted to datetime objects, just like the 'date' field.

It uses a new variable in `pelicanconf.py` named `DATEISH_PROPERTIES`. If that variable is not present, nothing happens.
