### PR TITLE
FIX: removes the '-None' inserted into output HTML filenames by asciidoc_reader plugin

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -10,9 +10,10 @@ File extension should be ``.asc``, ``.adoc``, or ``asciidoc``.
 from pelican.readers import BaseReader
 from pelican.utils import pelican_open
 from pelican import signals
-import logging
+import logging, inspect
 
 logger = logging.getLogger(__name__)
+whoami = lambda: inspect.stack()[1][3]
 
 try:
     # asciidocapi won't import on Py3

--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -68,7 +68,12 @@ def add_writer(self, content):
           whoami(), dir(content), content.save_as, content.url)
 
     if hasattr(content, 'save_as'):
-        content.override_save_as=content.save_as.replace('-None', '')
+        content.override_save_as = content.save_as.replace('-None', '')
+    if hasattr(content, 'url'):
+        content.override_url = content.url.replace('-None', '')
+
+    logger.debug("AFTER: asciidoc_reader=%s save_as=%s url=%s",
+        whoami(), content.save_as, content.url)
 
 def add_reader(readers):
     logger.debug("asciidoc_reader=%s readers.settings=%s", whoami(), dir(readers))

--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -56,9 +56,14 @@ class AsciiDocReader(BaseReader):
             metadata['title'] = metadata['doctitle']
         return content, metadata
 
+def add_writer(self, content):
+    if hasattr(content, 'save_as'):
+        content.override_save_as=content.save_as.replace('-None', '')
+
 def add_reader(readers):
     for ext in AsciiDocReader.file_extensions:
         readers.reader_classes[ext] = AsciiDocReader
 
 def register():
     signals.readers_init.connect(add_reader)
+    signals.article_generator_write_article.connect(add_writer)

--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -38,8 +38,6 @@ class AsciiDocReader(BaseReader):
     def oread(self, source_path):
         """Parse content and metadata of asciidoc files"""
 
-        logger.debug("asciidoc_reader=%s source_path=%s", whoami(), source_path)
-
         from cStringIO import StringIO
         with pelican_open(source_path) as source:
             text = StringIO(source)
@@ -63,21 +61,14 @@ class AsciiDocReader(BaseReader):
             metadata['title'] = metadata['doctitle']
         return content, metadata
 
-def add_writer(self, content):
-    logger.debug("BEFORE: asciidoc_reader=%s content=%s save_as=%s url=%s",
-          whoami(), dir(content), content.save_as, content.url)
 
+def add_writer(self, content):
     if hasattr(content, 'save_as'):
         content.override_save_as = content.save_as.replace('-None', '')
     if hasattr(content, 'url'):
         content.override_url = content.url.replace('-None', '')
 
-    logger.debug("AFTER: asciidoc_reader=%s save_as=%s url=%s",
-        whoami(), content.save_as, content.url)
-
 def add_reader(readers):
-    logger.debug("asciidoc_reader=%s readers.settings=%s", whoami(), dir(readers))
-    readers.reader_classes['asciidoc'] = AsciiDocReader
     for ext in AsciiDocReader.file_extensions:
         readers.reader_classes[ext] = AsciiDocReader
 

--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -35,8 +35,11 @@ class AsciiDocReader(BaseReader):
     default_options = ["--no-header-footer", "-a newline=\\n"]
     default_backend = 'html5'
 
-    def read(self, source_path):
+    def oread(self, source_path):
         """Parse content and metadata of asciidoc files"""
+
+        logger.debug("asciidoc_reader=%s source_path=%s", whoami(), source_path)
+
         from cStringIO import StringIO
         with pelican_open(source_path) as source:
             text = StringIO(source)
@@ -61,10 +64,15 @@ class AsciiDocReader(BaseReader):
         return content, metadata
 
 def add_writer(self, content):
+    logger.debug("BEFORE: asciidoc_reader=%s content=%s save_as=%s url=%s",
+          whoami(), dir(content), content.save_as, content.url)
+
     if hasattr(content, 'save_as'):
         content.override_save_as=content.save_as.replace('-None', '')
 
 def add_reader(readers):
+    logger.debug("asciidoc_reader=%s readers.settings=%s", whoami(), dir(readers))
+    readers.reader_classes['asciidoc'] = AsciiDocReader
     for ext in AsciiDocReader.file_extensions:
         readers.reader_classes[ext] = AsciiDocReader
 

--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -10,6 +10,9 @@ File extension should be ``.asc``, ``.adoc``, or ``asciidoc``.
 from pelican.readers import BaseReader
 from pelican.utils import pelican_open
 from pelican import signals
+import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     # asciidocapi won't import on Py3

--- a/asciidoc_reader/asciidocapi.py
+++ b/asciidoc_reader/asciidocapi.py
@@ -53,6 +53,10 @@ under the terms of the GNU General Public License (GPL).
 """
 
 import sys,os,re,imp
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 API_VERSION = '0.1.2'
 MIN_ASCIIDOC_VERSION = '8.4.1'  # Minimum acceptable AsciiDoc version.


### PR DESCRIPTION
Removes the '-None' that automatically gets added to HTML files generated by AsciiDoc plugin. Also removes the '-None' from the URL links to those files. 

After this fix, the AsciiDoc plugin behaves the same way as other Pelican readers (like Markdown) do, meaning both the filenames and URL links to those files are named the same way. So if a file is test.asciidoc, the HTML file is now test.html (before this bug fix AsciiDoc files would have been named test-None.html) .
