### PR TITLE
FIX: Sitemap offset-naive datetimes error

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -65,7 +65,7 @@ class SitemapGenerator(object):
 
         self.default_timezone = settings.get('TIMEZONE', 'UTC')
         self.timezone = getattr(self, 'timezone', self.default_timezone)
-	    self.timezone = timezone(self.timezone)
+        self.timezone = timezone(self.timezone)
 
         self.format = 'xml'
 


### PR DESCRIPTION
So, i don't know python and that's my first pull request, i hope i'm doing things right!

Since 3.4.0 the sitemap plugin is broken, see #264

This worked for my blog
