### PR TITLE
Minor fixes for Custom Article URLs

### DIFF
--- a/custom_article_urls/README.md
+++ b/custom_article_urls/README.md
@@ -14,10 +14,10 @@ would like *Category 1* saved as `category-1/article-slug/` and *Category 2*
 saved as `/year/month/article-slug/`, you would add:
 
     CUSTOM_ARTICLE_URLS = {
-        'Category 1': {'URL': '{category}/{slug}/,
-            'SAVE_AS': '{category}/{slug}/index.html},
-        'Category 2': {'URL': '{date:%Y}/{date:%B}/{slug}/,
-            'SAVE_AS': '{date:%Y}/{date:%B}/{slug}/index.html},
+        'Category 1': {'URL': '{category}/{slug}/',
+            'SAVE_AS': '{category}/{slug}/index.html}',
+        'Category 2': {'URL': '{date:%Y}/{date:%B}/{slug}/',
+            'SAVE_AS': '{date:%Y}/{date:%B}/{slug}/index.html}',
         }
 
 If you had any other categories, they would use the default `ARTICLE_SAVE_AS`

--- a/custom_article_urls/custom_article_urls.py
+++ b/custom_article_urls/custom_article_urls.py
@@ -8,7 +8,7 @@ using a dictionary stored in pelican settings file as
 {category: {article_url_structure: stirng, article_save_as: string}}
 """
 from pelican import signals
-from pelican.contents import Content, Category
+from pelican.contents import Article, Category
 from six import text_type
 
 def custom_url(generator, metadata):
@@ -33,7 +33,7 @@ def custom_url(generator, metadata):
                 """
                 pass
             else:
-                temp_article = Content(None, metadata=metadata)
+                temp_article = Article(None, metadata=metadata)
                 url_format = pattern_matched['URL']
                 save_as_format = pattern_matched['SAVE_AS']
                 url = url_format.format(**temp_article.url_format)


### PR DESCRIPTION
Initializing base class `Content` is not valid so it's fixed. Also includes minor corrections for readme.

Fixes getpelican/pelican#1400
