### PR TITLE
changed git  submodule config to use https instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,10 +33,10 @@
 	url = https://github.com/badele/pelicanthemes-generator
 [submodule "pelican-page-order"]
 	path = pelican-page-order
-	url = git://github.com/akhayyat/pelican-page-order
+	url = https://github.com/akhayyat/pelican-page-order.git
 [submodule "pelican-page-hierarchy"]
 	path = pelican-page-hierarchy
-	url = git://github.com/akhayyat/pelican-page-hierarchy
+	url = https://github.com/akhayyat/pelican-page-hierarchy.git
 [submodule "multi_neighbors"]
 	path = multi_neighbors
-	url = git@github.com:davidlesieur/multi_neighbors.git
+	url = https://github.com/davidlesieur/multi_neighbors.git


### PR DESCRIPTION
@kura @justinmayer
on git submodule result in errors if use git protocol to clone. 
The way it was set up, it would be necessary to access the public key of such repositories, which is not the case, since we only need to clone the repository 

changed git  submodules config to use https instead of git

this pull-request fixed this issue: https://travis-ci.org/pythonclub/pythonclub.github.io/builds/33389359

this is final fix to make pythonclub build working again

Related issues and pull-requests: #264 #269 
