### PR TITLE
fix tabbing

### DIFF
--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -134,19 +134,19 @@ def resize_thumbnails(pelican):
     logger.debug("Thumbnailer Started")
     for dirpath, _, filenames in os.walk(in_path):
         for filename in filenames:
-	    if not filename.startswith('.'):
-		for name, resizer in resizers.items():
-		    in_filename = path.join(dirpath, filename)
-		    logger.debug("Processing thumbnail {0}=>{1}".format(filename, name))
-		    if pelican.settings.get('THUMBNAIL_KEEP_NAME', False):
-			resizer.resize_file_to(in_filename, path.join(out_path, name), True)
-		    else:
-			resizer.resize_file_to(in_filename, out_path)
+            if not filename.startswith('.'):
+                for name, resizer in resizers.items():
+                    in_filename = path.join(dirpath, filename)
+                    logger.debug("Processing thumbnail {0}=>{1}".format(filename, name))
+                    if pelican.settings.get('THUMBNAIL_KEEP_NAME', False):
+                        resizer.resize_file_to(in_filename, path.join(out_path, name), True)
+                    else:
+                        resizer.resize_file_to(in_filename, out_path)
 
 
 def _image_path(pelican):
     return path.join(pelican.settings['PATH'],
-                        pelican.settings.get("IMAGE_PATH", DEFAULT_IMAGE_DIR))
+        pelican.settings.get("IMAGE_PATH", DEFAULT_IMAGE_DIR))
 
 
 def expand_gallery(generator, metadata):
@@ -167,17 +167,17 @@ def expand_gallery(generator, metadata):
     resizer = _resizer(thumbnail_name, '?x?')
     for dirpath, _, filenames in os.walk(in_path):
         for filename in filenames:
-	    if not filename.startswith('.'):
-		url = path.join(dirpath, filename).replace(base_path, "")[1:]
-		url = path.join('/static', generator.settings.get('IMAGE_PATH', DEFAULT_IMAGE_DIR), url).replace('\\', '/')
-		logger.debug("GALLERY: {0}".format(url))
-		thumbnail = resizer.get_thumbnail_name(filename)
-		thumbnail = path.join('/', generator.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR), thumbnail).replace('\\', '/')
-		lines.append(template.format(
-		    filename=filename,
-		    url=url,
-		    thumbnail=thumbnail,
-		))
+            if not filename.startswith('.'):
+                url = path.join(dirpath, filename).replace(base_path, "")[1:]
+                url = path.join('/static', generator.settings.get('IMAGE_PATH', DEFAULT_IMAGE_DIR), url).replace('\\', '/')
+                logger.debug("GALLERY: {0}".format(url))
+                thumbnail = resizer.get_thumbnail_name(filename)
+                thumbnail = path.join('/', generator.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR), thumbnail).replace('\\', '/')
+                lines.append(template.format(
+                    filename=filename,
+                    url=url,
+                    thumbnail=thumbnail,
+                ))
     metadata['gallery_content'] = "\n".join(lines)
 
 


### PR DESCRIPTION
this PR fixes:

```
pelican /Users/jchen/git/fly/burrito.sh/content -o /Users/jchen/git/fly/burrito.sh/output -s /Users/jchen/git/fly/burrito.sh/publishconf.py
Traceback (most recent call last):
  File "/Users/jchen/.venvs/burrito.sh/bin/pelican", line 11, in <module>
    sys.exit(main())
  File "/Users/jchen/.venvs/burrito.sh/lib/python3.4/site-packages/pelican/__init__.py", line 344, in main
    pelican, settings = get_instance(args)
  File "/Users/jchen/.venvs/burrito.sh/lib/python3.4/site-packages/pelican/__init__.py", line 338, in get_instance
    return cls(settings), settings
  File "/Users/jchen/.venvs/burrito.sh/lib/python3.4/site-packages/pelican/__init__.py", line 56, in __init__
    self.init_plugins()
  File "/Users/jchen/.venvs/burrito.sh/lib/python3.4/site-packages/pelican/__init__.py", line 76, in init_plugins
    str('module'))
  File "/Users/jchen/git/fly/burrito.sh/plugins/thumbnailer/__init__.py", line 1, in <module>
    from .thumbnailer import *
  File "/Users/jchen/git/fly/burrito.sh/plugins/thumbnailer/thumbnailer.py", line 137
    if not filename.startswith('.'):
                                   ^
TabError: inconsistent use of tabs and spaces in indentation
make: *** [publish] Error 1
```
