### PR TITLE
Thumbnailer doc enhancement

### DIFF
--- a/thumbnailer/Readme.md
+++ b/thumbnailer/Readme.md
@@ -1,14 +1,14 @@
 Thumbnail Creation of images
 ============================
 
-This plugin creates thumbnails for all of the images found under a specific directory, in various thumbnail sizes.
-It requires PIL to function properly since PIL is used to resize the images, and will only rebuild a thumbnail if it
-doesn't already exists (to save processing time).
+This plugin creates thumbnails for all of the images found under a specific directory, in various thumbnail sizes
+It requires `PIL` to function properly since `PIL` is used to resize the images, and will only rebuild a thumbnail if it
+doesn't already exists (to save processing time)
 
 Installation
 -------------
 
-Set up like a normal plugin by setting PLUGIN_PATH, and adding "thumbnailer" to the PLUGINS list.
+Set up like a normal plugin by setting `PLUGIN_PATH`, and adding `thumbnailer` to the `PLUGINS` list.
 
 [PIL](http://www.pythonware.com/products/pil/) or [Pillow](http://pillow.readthedocs.org/en/latest/installation.html#)
 is required. If you go with Pillow, you need to install some additional
@@ -17,11 +17,11 @@ is required. If you go with Pillow, you need to install some additional
 Configuration
 -------------
 
-* IMAGE_PATH is the path to the image directory.  It should reside under content, and defaults to "pictures"
-* THUMBNAIL_DIR is the path to the output sub directory where the thumbnails are generated
-* THUMBNAIL_SIZES is a dictionary mapping name of size to size specifications.
-  The generated filename will be originalname_thumbnailname.ext unless THUMBNAIL_KEEP_NAME is set.
-* THUMBNAIL_KEEP_NAME is a boolean which if set puts the thumbnails (with their original filename) in a folder named like the key in THUMBNAIL_SIZES
+* `IMAGE_PATH` is the path to the image directory.  It should reside under content, and defaults to "pictures"
+* `THUMBNAIL_DIR` is the path to the output sub directory where the thumbnails are generated
+* `THUMBNAIL_SIZES` is a dictionary mapping name of size to size specifications.
+  The generated filename will be `originalname_thumbnailname.ext` unless `THUMBNAIL_KEEP_NAME` is set.
+* `THUMBNAIL_KEEP_NAME` is a boolean which if set puts the file with the original name in a thumbnailname folder, named like the key in `THUMBNAIL_SIZES`.
 
 Sizes can be specified using any of the following formats:
 


### PR DESCRIPTION
- document need for `PIL` or `Pillow`
- document need for external libraries if using `Pillow`
- format code blocks
