### PR TITLE
Fix sitemap with disabled pages (fix #206)

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -134,6 +134,10 @@ class SitemapGenerator(object):
         if getattr(page, 'status', 'published') != 'published':
             return
 
+        # We can disable categories/authors/etc by using False instead of ''
+        if not page.save_as:
+            return
+
         page_path = os.path.join(self.output_path, page.save_as)
         if not os.path.exists(page_path):
             return


### PR DESCRIPTION
Recommendation in pelican < 3.4 was to disable pages using
a False boolean (http://docs.getpelican.com/en/3.3.0/settings.html#basic-settings)
It's now recommended to use '' and the sitemap plugins tries to
join paths using those variables, which won't work with a bool.
This checks that we have a truthy value before joining.

Fixes #206 
