### PR TITLE
Change MathJax URL from deprecated Rackspace CDN

### DIFF
--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -141,7 +141,7 @@ div.collapseheader {
 }
 </style>
 
-<script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
 <script type="text/javascript">
 init_mathjax = function() {
     if (window.MathJax) {


### PR DESCRIPTION
Hey @jakevdp -- another quick fix here.

The old Rackspace CDN for MathJax [has been deprecated](http://www.mathjax.org/changes-to-the-mathjax-cdn/) for a while and stopped working for real as of today.

```
$ curl -I  https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=UTF-8
Content-Length: 0
X-Trans-Id: tx0e20742c207744059ea0d-0054035223dfw1
Cache-Control: public, max-age=30
Expires: Sun, 31 Aug 2014 16:50:10 GMT
Date: Sun, 31 Aug 2014 16:49:40 GMT
Connection: keep-alive
```

This PR just switches to the new one:

```
$ curl -I https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
HTTP/1.1 200 OK
Server: cloudflare-nginx
Date: Sun, 31 Aug 2014 16:49:28 GMT
Content-Type: application/javascript
Content-Length: 58757
Connection: keep-alive
[...]
```
