### PR TITLE
Update bootstrap_rst_directives.py

### DIFF
--- a/twitter_bootstrap_rst_directives/bootstrap_rst_directives.py
+++ b/twitter_bootstrap_rst_directives/bootstrap_rst_directives.py
@@ -345,9 +345,9 @@ class Alert(rst.Directive):
 
         *example:*
 
-            .. alert-default::
+            .. alert-warning::
 
-                This is a default alert content
+                This is a warning alert content
 
     """
     has_content = True


### PR DESCRIPTION
changed alert-default to alert-warning in docs, there is no 'alert-default' in bootstrap.
