### PR TITLE
ADD: sort_tags plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "pelican-langcategory"]
 	path = pelican-langcategory
 	url = https://github.com/CNBorn/pelican-langcategory.git
+[submodule "sort_tags"]
+	path = sort_tags
+	url = https://github.com/ingwinlu/sort_tags.git


### PR DESCRIPTION
This plugin adds `tags_sorted_article_length` to the context,
which is a list of tupels (Tag, [Articles]) that is sorted 
by number of Articles first and Tag second.
