### PR TITLE
Prevent compression of webm video files in gzip_cache.

### DIFF
--- a/gzip_cache/gzip_cache.py
+++ b/gzip_cache/gzip_cache.py
@@ -37,6 +37,7 @@ EXCLUDE_TYPES = [
     '.avi',
     '.mov',
     '.mp4',
+    '.webm',
 ]
 
 COMPRESSION_LEVEL = 9 # Best Compression


### PR DESCRIPTION
This prevents unnecessary and expensive compression of .webm video files, that should not be gzip compressed.
