### PR TITLE
Add GZIP_CACHE_OVERWRITE option to overwrite original files

### DIFF
--- a/gzip_cache/Readme.rst
+++ b/gzip_cache/Readme.rst
@@ -8,3 +8,10 @@ at a higher compression level for increased optimization.
 
 The ``gzip_cache`` plugin compresses all common text type files into a ``.gz``
 file within the same directory as the original file.
+
+Settings
+--------
+
+* `GZIP_CACHE_OVERWRITE`
+  If True, the original files will be replaced by the gzip-compressed files. 
+  This is useful for static hosting services (e.g S3). Defaults to False.

--- a/gzip_cache/gzip_cache.py
+++ b/gzip_cache/gzip_cache.py
@@ -61,7 +61,7 @@ def create_gzip_cache(pelican):
         for name in filenames:
             if should_compress(name):
                 filepath = os.path.join(dirpath, name)
-                create_gzip_file(filepath)
+                create_gzip_file(filepath, should_overwrite(pelican.settings))
 
 
 def should_compress(filename):
@@ -75,11 +75,18 @@ def should_compress(filename):
 
     return True
 
+def should_overwrite(settings):
+    '''Check if the gzipped files should overwrite the originals.
 
-def create_gzip_file(filepath):
+    :param settings: The pelican instance settings
+    '''
+    return settings.get('GZIP_CACHE_OVERWRITE', False)
+
+def create_gzip_file(filepath, overwrite):
     '''Create a gzipped file in the same directory with a filepath.gz name.
 
     :param filepath: A file to compress
+    :param overwrite: Whether the original file should be overwritten
     '''
     compressed_path = filepath + '.gz'
 
@@ -97,6 +104,10 @@ def create_gzip_file(filepath):
             except Exception as ex:
                 logger.critical('Gzip compression failed: %s' % ex)
 
+        if overwrite:
+            logger.debug('Overwriting: %s with %s' % (filepath, compressed_path))
+            os.remove(filepath)
+            os.rename(compressed_path, filepath)
 
 def register():
     signals.finalized.connect(create_gzip_cache)

--- a/gzip_cache/test_gzip_cache.py
+++ b/gzip_cache/test_gzip_cache.py
@@ -43,6 +43,15 @@ class TestGzipCache(unittest.TestCase):
         self.assertFalse(gzip_cache.should_compress('baz.mp3'))
         self.assertFalse(gzip_cache.should_compress('foo.mov'))
 
+    def test_should_overwrite(self):
+        # Default to false if GZIP_CACHE_OVERWRITE is not set
+        settings = { }
+        self.assertFalse(gzip_cache.should_overwrite(settings))
+        settings = { 'GZIP_CACHE_OVERWRITE': False }
+        self.assertFalse(gzip_cache.should_overwrite(settings))
+        settings = { 'GZIP_CACHE_OVERWRITE': True }
+        self.assertTrue(gzip_cache.should_overwrite(settings))
+
     def test_creates_gzip_file(self):
         # A file matching the input filename with a .gz extension is created.
 
@@ -51,7 +60,7 @@ class TestGzipCache(unittest.TestCase):
         # not report it). Therefore, create a dummy file to use.
         with temporary_folder() as tempdir:
             _, a_html_filename = tempfile.mkstemp(suffix='.html', dir=tempdir)
-            gzip_cache.create_gzip_file(a_html_filename)
+            gzip_cache.create_gzip_file(a_html_filename, False)
             self.assertTrue(os.path.exists(a_html_filename + '.gz'))
 
     def test_creates_same_gzip_file(self):
@@ -63,13 +72,24 @@ class TestGzipCache(unittest.TestCase):
         with temporary_folder() as tempdir:
             _, a_html_filename = tempfile.mkstemp(suffix='.html', dir=tempdir)
             a_gz_filename = a_html_filename + '.gz'
-            gzip_cache.create_gzip_file(a_html_filename)
+            gzip_cache.create_gzip_file(a_html_filename, False)
             gzip_hash = get_md5(a_gz_filename)
             time.sleep(1)
-            gzip_cache.create_gzip_file(a_html_filename)
+            gzip_cache.create_gzip_file(a_html_filename, False)
             self.assertEqual(gzip_hash, get_md5(a_gz_filename))
 
+    def test_overwrites_gzip_file(self):
+        # A file matching the input filename with a .gz extension is not created.
+
+        # The plugin walks over the output content after the finalized signal
+        # so it is safe to assume that the file exists (otherwise walk would
+        # not report it). Therefore, create a dummy file to use.
+        with temporary_folder() as tempdir:
+            _, a_html_filename = tempfile.mkstemp(suffix='.html', dir=tempdir)
+            gzip_cache.create_gzip_file(a_html_filename, True)
+            self.assertFalse(os.path.exists(a_html_filename + '.gz'))
 
 def get_md5(filepath):
     with open(filepath, 'rb') as fh:
         return md5(fh.read()).hexdigest()
+


### PR DESCRIPTION
This option is useful when hosting static content on a service such as
Amazon S3. Setting to True will overwrite the original file with
the gzip-compressed file. In order to correctly serve the file, the
Content Encoding must be set to gzip by the hosting service.
