### PR TITLE
Custom Article URLs, generating the temp_article now uses empty string rather than None

### DIFF
--- a/custom_article_urls/custom_article_urls.py
+++ b/custom_article_urls/custom_article_urls.py
@@ -33,7 +33,7 @@ def custom_url(generator, metadata):
                 """
                 pass
             else:
-                temp_article = Article(None, metadata=metadata)
+                temp_article = Article("", metadata=metadata)
                 url_format = pattern_matched['URL']
                 save_as_format = pattern_matched['SAVE_AS']
                 url = url_format.format(**temp_article.url_format)


### PR DESCRIPTION
This fixes a bug when this plugin interacts with the clean summary plugin. A temporary Article object is created to access the URL formatting methods. It was initialized with None as the content. This caused an error with the
Clean Summary plugin, which processes all Article objects even if it's temporary. Problem is fixed by initializing with an empty string rather than None. 
