### PR TITLE
Sitemap plug-in: '%s' should be '%z' for printing out timezone

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -47,7 +47,7 @@ XML_FOOTER = """
 
 def format_date(date):
     if date.tzinfo:
-        tz = date.strftime('%s')
+        tz = date.strftime('%z')
         tz = tz[:-2] + ':' + tz[-2:]
     else:
         tz = "-00:00"


### PR DESCRIPTION
Fixed #300.

`%s` simply does not exist in [python's `strftime`](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior).

`%z` should be the right one: 

> UTC offset in the form +HHMM or -HHMM
