### PR TITLE
FIX: Sitemap offset-naive datetimes(modified) error

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -180,7 +180,7 @@ class SitemapGenerator(object):
             for article in articles:
                 lastmod = max(lastmod, article.date.replace(tzinfo=self.timezone))
                 try:
-                    modified = self.get_date_modified(article, datetime.min.replace(tzinfo=self.timezone));
+                    modified = self.get_date_modified(article, datetime.min).replace(tzinfo=self.timezone)
                     lastmod = max(lastmod, modified)
                 except ValueError:
                     # Supressed: user will be notified.


### PR DESCRIPTION
If an article specified modified date, the `modified` value will
still be offset-naive, so set timezone explicitly.
