### PR TITLE
Render_math now working with markdown versions >= 2.5

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -5,8 +5,8 @@ Math Render Plugin for Pelican
 This plugin allows your site to render Math. It uses
 the MathJax JavaScript engine.
 
-For markdown, the plugin works by creating a Markdown 
-extension which is used during the markdown compilation stage. 
+For markdown, the plugin works by creating a Markdown
+extension which is used during the markdown compilation stage.
 Math therefore gets treated like a "first class citizen" in Pelican
 
 For reStructuredText, the plugin instructs the rst engine
@@ -53,7 +53,7 @@ def process_settings(pelicanobj):
 
     # Source for MathJax: Works boths for http and https (see http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn)
     mathjax_settings['source'] = "'//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
-    
+
     # Get the user specified settings
     try:
         settings = pelicanobj.settings['MATH_JAX']
@@ -94,7 +94,7 @@ def process_settings(pelicanobj):
 def configure_typogrify(pelicanobj, mathjax_settings):
     """Instructs Typogrify to ignore math tags - which allows Typogfrify
     to play nicely with math related content"""
-    
+
     # If Typogrify is not being used, then just exit
     if not pelicanobj.settings.get('TYPOGRIFY', False):
         return
@@ -102,7 +102,7 @@ def configure_typogrify(pelicanobj, mathjax_settings):
     try:
         import typogrify
         from distutils.version import LooseVersion
-        
+
         if LooseVersion(typogrify.__version__) < LooseVersion('2.0.7'):
             raise TypeError('Incorrect version of Typogrify')
 
@@ -141,14 +141,16 @@ def mathjax_for_markdown(pelicanobj, mathjax_settings):
 
     # Create the configuration for the markdown template
     config = {}
-    config['mathjax_script'] = [process_mathjax_script(mathjax_settings),'Mathjax JavaScript script']
-    config['math_tag_class'] = ['math', 'The class of the tag in which mathematics is wrapped']
-    
+    config['mathjax_script'] = process_mathjax_script(mathjax_settings)
+    config['math_tag_class'] = 'math'
+
     # Instantiate markdown extension and append it to the current extensions
     try:
         pelicanobj.settings['MD_EXTENSIONS'].append(PelicanMathJaxExtension(config))
     except:
-        print("\nError - the pelican mathjax markdown extension was not configured, so mathjax will not be work.\nThe error message was as follows - [%s]" % sys.exc_info()[0])
+        sys.excepthook(*sys.exc_info())
+        sys.stderr.write("\nError - the pelican mathjax markdown extension failed to configure. MathJax is non-functional.\n")
+        sys.stderr.flush()
 
 def mathjax_for_rst(pelicanobj, mathjax_settings):
     pelicanobj.settings['DOCUTILS_SETTINGS'] = {'math_output': 'MathJax'}

--- a/render_math/pelican_mathjax_markdown_extension.py
+++ b/render_math/pelican_mathjax_markdown_extension.py
@@ -42,10 +42,9 @@ class PelicanMathJaxTreeProcessor(markdown.treeprocessors.Treeprocessor):
         self.pelican_mathjax_extension = pelican_mathjax_extension
 
     def run(self, root):
-
         # If no mathjax was present, then exit
         if (not self.pelican_mathjax_extension.mathjax_needed):
-            return
+            return root
 
         # Add the mathjax script to the html document
         mathjax_script = etree.Element('script')
@@ -56,23 +55,37 @@ class PelicanMathJaxTreeProcessor(markdown.treeprocessors.Treeprocessor):
         # Reset the boolean switch to false so that script is only added
         # to other pages if needed
         self.pelican_mathjax_extension.mathjax_needed = False
+        return root
 
 class PelicanMathJaxExtension(markdown.Extension):
     """A markdown extension enabling mathjax processing in Markdown for Pelican"""
     def __init__(self, config):
-        super(PelicanMathJaxExtension,self).__init__(config)
 
-        # Regex to detect mathjax
-        self.mathjax_inline_regex = r'(?P<prefix>\$)(?P<math>.+?)(?P<suffix>(?<!\s)\2)'
-        self.mathjax_display_regex = r'(?P<prefix>(?:\$\$)|\\begin\{(.+?)\})(?P<math>.+?)(?P<suffix>\2|\\end\{\3\})'
+        try:
+            # Needed for markdown versions >= 2.5
+            self.config['mathjax_script'] = ['', 'Mathjax JavaScript script']
+            self.config['math_tag_class'] = ['math', 'The class of the tag in which mathematics is wrapped']
+            super(PelicanMathJaxExtension,self).__init__(**config)
+        except AttributeError:
+            # Markdown versions < 2.5
+            config['mathjax_script'] = [config['mathjax_script'], 'Mathjax JavaScript script']
+            config['math_tag_class'] = [config['math_tag_class'], 'The class of the tag in which mathematic is wrapped']
+            super(PelicanMathJaxExtension,self).__init__(config)
+
+        # Used as a flag to determine if javascript
+        # needs to be injected into a document
         self.mathjax_needed = False
 
     def extendMarkdown(self, md, md_globals):
+        # Regex to detect mathjax
+        mathjax_inline_regex = r'(?P<prefix>\$)(?P<math>.+?)(?P<suffix>(?<!\s)\2)'
+        mathjax_display_regex = r'(?P<prefix>\$\$|\\begin\{(.+?)\})(?P<math>.+?)(?P<suffix>\2|\\end\{\3\})'
+
         # Process mathjax before escapes are processed since escape processing will
         # intefer with mathjax. The order in which the displayed and inlined math
         # is registered below matters
-        md.inlinePatterns.add('mathjax_displayed', PelicanMathJaxPattern(self, 'div', self.mathjax_display_regex), '<escape')
-        md.inlinePatterns.add('mathjax_inlined', PelicanMathJaxPattern(self, 'span', self.mathjax_inline_regex), '<escape')
+        md.inlinePatterns.add('mathjax_displayed', PelicanMathJaxPattern(self, 'div', mathjax_display_regex), '<escape')
+        md.inlinePatterns.add('mathjax_inlined', PelicanMathJaxPattern(self, 'span', mathjax_inline_regex), '<escape')
 
         # If necessary, add the JavaScript Mathjax library to the document. This must
         # be last in the ordered dict (hence it is given the position '_end')


### PR DESCRIPTION
Markdown version 2.5 made non-backward compatible changes. This PR enables the plugin to work with versions < 2.5 and versions >= 2.5
