### PR TITLE
Fix liquid_tags for Markdown 2.5

### DIFF
--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -71,8 +71,7 @@ def include_code(preprocessor, tag, markup):
         raise ValueError("Error processing input, "
                          "expected syntax: {0}".format(SYNTAX))
 
-    settings = preprocessor.configs.config['settings']
-    code_dir = settings.get('CODE_DIR', 'code')
+    code_dir = preprocessor.configs.getConfig('CODE_DIR')
     code_path = os.path.join('content', code_dir, src)
 
     if not os.path.exists(code_path):

--- a/liquid_tags/liquid_tags.py
+++ b/liquid_tags/liquid_tags.py
@@ -1,5 +1,5 @@
 from pelican import signals
-from .mdx_liquid_tags import LiquidTags
+from .mdx_liquid_tags import LiquidTags, LT_CONFIG
 
 
 def addLiquidTags(gen):
@@ -8,7 +8,12 @@ def addLiquidTags(gen):
         gen.settings['MD_EXTENSIONS'] = DEFAULT_CONFIG['MD_EXTENSIONS']
 
     if LiquidTags not in gen.settings['MD_EXTENSIONS']:
-        configs = dict(settings=gen.settings)
+        configs = dict()
+        for key,value in LT_CONFIG.items():
+            configs[key]=value
+        for key,value in gen.settings.items():
+            if key in LT_CONFIG:
+                configs[key]=value
         gen.settings['MD_EXTENSIONS'].append(LiquidTags(configs))
 
 

--- a/liquid_tags/mdx_liquid_tags.py
+++ b/liquid_tags/mdx_liquid_tags.py
@@ -19,7 +19,12 @@ from functools import wraps
 # Define some regular expressions
 LIQUID_TAG = re.compile(r'\{%.*?%\}')
 EXTRACT_TAG = re.compile(r'(?:\s*)(\S+)(?:\s*)')
-
+LT_CONFIG = { 'CODE_DIR': 'code',
+              'NOTEBOOK_DIR': 'notebooks'
+}
+LT_HELP = { 'CODE_DIR' : 'Code directory for include_code subplugin', 
+            'NOTEBOOK_DIR' : 'Notebook directory for notebook subplugin'
+}
 
 class _LiquidTagsPreprocessor(markdown.preprocessors.Preprocessor):
     _tags = {}
@@ -51,6 +56,18 @@ class _LiquidTagsPreprocessor(markdown.preprocessors.Preprocessor):
 
 class LiquidTags(markdown.Extension):
     """Wrapper for MDPreprocessor"""
+    def __init__(self, config):
+        try:
+            # Needed for markdown versions >= 2.5
+            for key,value in LT_CONFIG.items():
+                self.config[key] = [value,LT_HELP[key]]
+            super(LiquidTags,self).__init__(**config)
+        except AttributeError:
+            # Markdown versions < 2.5
+            for key,value in LT_CONFIG.items():
+                config[key] = [config[key],LT_HELP[key]]
+            super(LiquidTags,self).__init__(config)
+
     @classmethod
     def register(cls, tag):
         """Decorator to register a new include tag"""

--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -261,8 +261,7 @@ def notebook(preprocessor, tag, markup):
 
     language_applied_highlighter = partial(custom_highlighter, language=language)
 
-    settings = preprocessor.configs.config['settings']
-    nb_dir =  settings.get('NOTEBOOK_DIR', 'notebooks')
+    nb_dir =  preprocessor.configs.getConfig('NOTEBOOK_DIR')
     nb_path = os.path.join('content', nb_dir, src)
 
     if not os.path.exists(nb_path):


### PR DESCRIPTION
This patch closes issue #312 as far as I can see.

Markdown 2.5 changed the config system for markdown extensions. Inspired by
the render_math plugin, I added code to cope with both versions. New settings
used in the markdown part must go in LT_CONFIG and LT_HELP in `mdx_liquid_tags.py`.
