### PR TITLE
Implemented gallery also for static pages

### DIFF
--- a/gallery/gallery.py
+++ b/gallery/gallery.py
@@ -23,6 +23,27 @@ def add_gallery_post(generator):
             article.galleryimages = sorted(galleryimages)
 
 
+def add_gallery_page(generator):
+
+    contentpath = generator.settings.get('PATH')
+    gallerycontentpath = os.path.join(contentpath,'images/gallery')
+
+    for page in generator.pages:
+        if 'gallery' in page.metadata.keys():
+            album = page.metadata.get('gallery')
+            galleryimages = []
+
+            pagegallerypath=os.path.join(gallerycontentpath, album)
+
+            if(os.path.isdir(pagegallerypath)):
+                for i in os.listdir(pagegallerypath):
+                    if not i.startswith('.') and os.path.isfile(os.path.join(os.path.join(gallerycontentpath, album), i)):
+                        galleryimages.append(i)
+
+            page.album = album
+            page.galleryimages = sorted(galleryimages)
+
+
 def generate_gallery_page(generator):
 
     contentpath = generator.settings.get('PATH')
@@ -46,3 +67,4 @@ def generate_gallery_page(generator):
 def register():
     signals.article_generator_finalized.connect(add_gallery_post)
     signals.page_generator_finalized.connect(generate_gallery_page)
+    signals.page_generator_finalized.connect(add_gallery_page)


### PR DESCRIPTION
This patch allows the gallery plugin to be used not only for blog articles, but also for static pages.

It is needed in order to make image galleries on the http://cownado.com/ website work, but I think it could be useful for other Pelican users too.
