### PR TITLE
create always_modified plugin

### DIFF
--- a/always_modified/README.md
+++ b/always_modified/README.md
@@ -1,0 +1,11 @@
+# Always Modified
+
+Puts a "modified" date on articles, defaulting to the normal "created" date.
+
+## Usage
+
+1. Insert `ALWAYS_MODIFIED=True` in your `pelicanconf.py`.
+2. Now you can sort by modified date in your templates:
+```
+{% for article in articles|sort(reverse=True,attribute='modified') %}
+```

--- a/always_modified/__init__.py
+++ b/always_modified/__init__.py
@@ -1,0 +1,1 @@
+from .always_modified import *

--- a/always_modified/always_modified.py
+++ b/always_modified/always_modified.py
@@ -1,0 +1,20 @@
+"""
+Always provided articles with a "modified" date, defaulting to vanilla date.
+"""
+
+from pelican import signals
+from pelican.contents import Content, Article
+
+def add_modified(content):
+    if not isinstance(content, Article):
+        return
+    
+    if not content.settings.get('ALWAYS_MODIFIED', False):
+        return
+
+    if hasattr(content, 'date') and not hasattr(content, 'modified'):
+        content.modified = content.date
+        content.locale_modified = content.locale_date
+    
+def register():
+    signals.content_object_init.connect(add_modified)


### PR DESCRIPTION
Sometimes you want to be able to sort all articles by modified time (e.g. for a "latest changes" page) but not all articles have a modified time. This plugin fills the "modified" field with the contents of the "date" field if it is missing, enabling that. Suits "Blosxom"-style notebook blogs etc