### PR TITLE
Add an ellipsis after the end of summary

### DIFF
--- a/summary/summary.py
+++ b/summary/summary.py
@@ -54,7 +54,7 @@ def content_object_init(instance):
                             len(instance.settings['SUMMARY_BEGIN_MARKER'])
                             if begin_summary != -1 else 0)
             end_summary = end_summary if end_summary != -1 else None
-            instance._summary = instance._update_content(content[begin_summary:end_summary], instance._context.get('localsiteurl', ''))
+            instance._summary = instance._update_content(content[begin_summary:end_summary] + '...', instance._context.get('localsiteurl', ''))
 
 def register():
     signals.initialized.connect(initialized)


### PR DESCRIPTION
The summary plugin should display an ellipsis after the end of summary content. I fixed this just add one.
