### PR TITLE
Added new plugin: pelican-genealogy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "pelican-md-yaml"]
 	path = pelican-md-yaml
 	url = https://github.com/joachimneu/pelican-md-yaml.git
+[submodule "pelican-genealogy"]
+	path = pelican-genealogy
+	url = git@github.com:zappala/pelican-genealogy.git


### PR DESCRIPTION
This is a small plugin that helps genealogy bloggers. The plugin uses new metadata to track surnames and people mentioned in a blog post. It creates a page for each surname and person listing all the articles where they are mentioned, similar to how tags are handled. The plugin also provides context for themes to get a list of all surnames and people.
