### PR TITLE
extract_toc: fix markdown case when toc not found

### DIFF
--- a/extract_toc/extract_toc.py
+++ b/extract_toc/extract_toc.py
@@ -23,7 +23,7 @@ def extract_toc(content):
     # if it is a Markdown file
     if extension in readers.MarkdownReader.file_extensions:
         toc = soup.find('div', class_='toc')
-        toc.extract()
+        if toc: toc.extract()
     # else if it is a reST file
     elif extension in readers.RstReader.file_extensions:
         toc = soup.find('div', class_='contents topic')


### PR DESCRIPTION
The guard is needed to avoid:

  'NoneType' object has no attribute 'extract'

This fixes the bug introduced in the parent commit.
