### PR TITLE
Fix /index.html as / in sitemap

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -160,11 +160,12 @@ class SitemapGenerator(object):
             pri = self.priorities['indexes']
             chfreq = self.changefreqs['indexes']
 
+        pageurl = '' if page.url == 'index.html' else page.url
 
         if self.format == 'xml':
-            fd.write(XML_URL.format(self.siteurl, page.url, lastmod, chfreq, pri))
+            fd.write(XML_URL.format(self.siteurl, pageurl, lastmod, chfreq, pri))
         else:
-            fd.write(self.siteurl + '/' + page.url + '\n')
+            fd.write(self.siteurl + '/' + pageurl + '\n')
 
     def get_date_modified(self, page, default):
         if hasattr(page, 'modified'):


### PR DESCRIPTION
Hide `index.html` since it's an "implementation detail."
Unsure if it's a real problem, but likely nobody wants Google to index their `/index.html` instead of simply "www root."
