### PR TITLE
Add the pelican_commonmark plugin

### DIFF
--- a/pelican_commonmark/README.md
+++ b/pelican_commonmark/README.md
@@ -1,0 +1,18 @@
+# CommonMark for Pelican
+
+This reader plugin replaces the markdown reader with one that uses the
+[Python parser for CommonMark][1].
+
+It is useful if you want to use the [CommonMark][2] way of parsing markdown
+inside non-trivial nested HTML tags. It is not useful if you want to
+use the extensions available to the python markdown parser.
+
+## Requirements
+
+The plugin uses the CommonMark python package. It can be installed
+with the following command:
+
+    pip install -r REQUIREMENTS
+
+[1]: https://pypi.python.org/pypi/CommonMark
+[2]: http://commonmark.org

--- a/pelican_commonmark/REQUIREMENTS
+++ b/pelican_commonmark/REQUIREMENTS
@@ -1,0 +1,2 @@
+pelican>=3.5.0
+CommonMark>=0.5.4

--- a/pelican_commonmark/__init__.py
+++ b/pelican_commonmark/__init__.py
@@ -1,0 +1,32 @@
+from CommonMark import DocParser, HTMLRenderer
+from pelican.readers import BaseReader, MarkdownReader
+from pelican.utils import pelican_open
+
+
+class CommonMarkReader(BaseReader):
+    file_extensions = MarkdownReader.file_extensions
+
+    def read(self, source_path):
+        with pelican_open(source_path) as source:
+            metadata = {}
+            source_lines = []
+
+            reading_metadata = True
+            for line in source.splitlines():
+                if reading_metadata:
+                    if line.count(':') > 0:
+                        key, value = (x.strip() for x in line.split(':', 1))
+                        key = key.lower()
+                        metadata[key] = self.process_metadata(key, value)
+                    else:
+                        reading_metadata = False
+                if not reading_metadata:
+                    source_lines.append(line)
+
+            ast = DocParser().parse('\n'.join(source_lines))
+            content = HTMLRenderer().render(ast)
+            return content, metadata
+
+
+def register():
+    pass

--- a/pelican_commonmark/__init__.py
+++ b/pelican_commonmark/__init__.py
@@ -1,6 +1,7 @@
 from CommonMark import DocParser, HTMLRenderer
 from pelican.readers import BaseReader, MarkdownReader
 from pelican.utils import pelican_open
+from pelican import signals
 
 
 class CommonMarkReader(BaseReader):
@@ -28,5 +29,11 @@ class CommonMarkReader(BaseReader):
             return content, metadata
 
 
+def replace_markdown_reader(readers):
+    for ext, reader in readers.reader_classes.items():
+        if reader == MarkdownReader:
+            readers.reader_classes[ext] = CommonMarkReader
+
+
 def register():
-    pass
+    signals.readers_init.connect(replace_markdown_reader)

--- a/pelican_commonmark/test_data/markdown_in_html.md
+++ b/pelican_commonmark/test_data/markdown_in_html.md
@@ -1,0 +1,15 @@
+key1: value1
+key2: value2
+<div>
+<div>
+
+## header
+
+paragraph
+</div>
+<div>
+
+paragraph
+</div>
+</div>
+

--- a/pelican_commonmark/test_pelican_commonmark.py
+++ b/pelican_commonmark/test_pelican_commonmark.py
@@ -1,0 +1,33 @@
+import unittest
+import os
+
+from __init__ import CommonMarkReader
+
+CUR_DIR = os.path.dirname(__file__)
+CONTENT_PATH = os.path.join(CUR_DIR, 'test_data')
+
+
+class CommonMarkSmokeTest(unittest.TestCase):
+    EXPECTED_METADATA = {'key1': 'value1',
+                         'key2': 'value2'}
+    EXPECTED_HTML = '''<div>
+<div>
+<h2>header</h2>
+<p>paragraph</p>
+</div>
+<div>
+<p>paragraph</p>
+</div>
+</div>
+'''
+
+    def setUp(self):
+        self.reader = CommonMarkReader({})
+        source_path = os.path.join(CONTENT_PATH, 'markdown_in_html.md')
+        self.content, self.metadata = self.reader.read(source_path)
+
+    def test_metadata_should_be_parsed(self):
+        self.assertEqual(self.metadata, self.EXPECTED_METADATA)
+
+    def test_markdown_in_block_tags_should_be_parsed(self):
+        self.assertEqual(self.content, self.EXPECTED_HTML)


### PR DESCRIPTION
This provides a reader for markdown files that uses the Python parser
for CommonMark.
