### PR TITLE
Added note about Pelican 3.5 to Assets documentation

### DIFF
--- a/assets/Readme.rst
+++ b/assets/Readme.rst
@@ -92,7 +92,8 @@ LessCSS's binary:
 If you wish to place your assets in locations other than the theme output
 directory, you can use ``ASSET_SOURCE_PATHS`` in your settings file to provide
 webassets with a list of additional directories to search, relative to the
-theme's top-level directory. For example:
+theme's top-level directory. Note that as of Pelican 3.5.0, this setting is
+required, as the ``StaticGenerator`` generator now runs last in sequence:
 
 .. code-block:: python
 


### PR DESCRIPTION
Pelican 3.5.0 changed the order that the various generators are run in, which broke this plugin for a number of users (see getpelican/pelican#1523). This clarification will hopefully serve to avoid more confusion.
