### PR TITLE
Add Advanced Thumbnailer plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "pelican-md-yaml"]
 	path = pelican-md-yaml
 	url = https://github.com/joachimneu/pelican-md-yaml.git
+[submodule "pelican-advthumbnailer"]
+	path = pelican-advthumbnailer
+	url = https://github.com/AlexJF/pelican-advthumbnailer.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -36,6 +36,7 @@ Plugin descriptions
 ========================  ===========================================================
 Plugin                    Description
 ========================  ===========================================================
+Advanced thumbnailer      Create thumbnails for image files with specially crafted filenames.
 AsciiDoc reader           Use AsciiDoc to write your posts.
 
 Asset management          Use the Webassets module to manage assets such as CSS and JS files.


### PR DESCRIPTION
A thumbnail generator for Pelican that automatically scans all image tags looking for missing images and creates the thumbnails based on the filename.

Based on the existing thumbnailer plugin.

https://github.com/AlexJF/pelican-advthumbnailer
