### PR TITLE
Fix to make filetime_from_git work with GitPython 0.3.2.1

### DIFF
--- a/filetime_from_git/filetime_from_git.py
+++ b/filetime_from_git/filetime_from_git.py
@@ -45,7 +45,7 @@ def filetime_from_git(content):
         content.date = datetime_from_timestamp(os.stat(path).st_ctime, content)
     else:
         # file is managed by git
-        commits = repo.commits(path=path)
+        commits = list(repo.iter_commits(path=path))
         if len(commits) == 0:
             # never commited, but staged
             content.date = datetime_from_timestamp(os.stat(path).st_ctime, content)


### PR DESCRIPTION
When using the _filetime_from_git_ plugin with GitPython 0.3.2.1 installed, I encountered the following error message: 
```
 'Repo' object has no attribute 'commits'
```

This is just a quick fix to make it work with the most recent version of GitPython. When I run pelican now, it works as described, but warns about

```
Exception ImportError: ImportError('No module named sys',) in <bound method WindowCursor.__del__ of <smmap.mman.WindowCursor object at 0x10a2de368>> ignored
```

However, this is something that is either related to my environment or to smmap as a dependency. Nevertheless, I'd be happy to get any hints on how to fix it. :-)