### PR TITLE
Fix share_post plugin

### DIFF
--- a/share_post/share_post.py
+++ b/share_post/share_post.py
@@ -15,11 +15,11 @@ from pelican import signals, contents
 
 
 def article_title(content):
-    main_title = BeautifulSoup(content.title, 'html.parser').prettify().strip()
+    main_title = BeautifulSoup(content.title, 'html.parser').get_text().strip()
     sub_title = ''
     if hasattr(content, 'subtitle'):
-        sub_title = BeautifulSoup(content.subtitle, 'html.parser').prettify().strip()
-    return quote(('%s %s' % (main_title, sub_title)).encode('utf-8'))
+        sub_title = ' ' + BeautifulSoup(content.subtitle, 'html.parser').get_text().strip()
+    return quote(('%s%s' % (main_title, sub_title)).encode('utf-8'))
 
 
 def article_url(content):
@@ -28,7 +28,7 @@ def article_url(content):
 
 
 def article_summary(content):
-    return quote(content.summary.encode('utf-8'))
+    return quote(BeautifulSoup(content.summary, 'html.parser').get_text().strip().encode('utf-8'))
 
 
 def share_post(content):
@@ -38,13 +38,11 @@ def share_post(content):
     url = article_url(content)
     summary = article_summary(content)
 
-    tweet = '%s %s' % (title, url)
-    facebook_link = 'http://www.facebook.com/sharer/sharer.php?s=100' \
-                    '&p[url]=%s&p[images][0]=&p[title]=%s&p[summary]=%s' \
-                    % (url, title, summary)
+    tweet = quote(('%s %s' % (title, url)).encode('utf-8'))
+    facebook_link = 'http://www.facebook.com/sharer/sharer.php?s=100&amp;p%%5Burl%%5D=%s' % url
     gplus_link = 'https://plus.google.com/share?url=%s' % url
     twitter_link = 'http://twitter.com/home?status=%s' % tweet
-    mail_link = 'mailto:?subject=%s&body=%s' % (title, url)
+    mail_link = 'mailto:?subject=%s&amp;body=%s' % (title, url)
 
     share_links = {'twitter': twitter_link,
                    'facebook': facebook_link,


### PR DESCRIPTION
Firstly, the implemented services only accept unmarked text, so `get_text()` instead of `prettify()` is called.

Secondly, `&amp;` is properly escaped ampersand in href URLs.
