### PR TITLE
better_figures_and_images: handle missing files with unicode names

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -13,6 +13,7 @@ TODO: Need to add a test.py for this plugin.
 
 """
 
+from __future__ import unicode_literals
 from os import path, access, R_OK
 
 from pelican import signals
@@ -52,7 +53,7 @@ def content_object_init(instance):
 
                 logger.debug('Better Fig. src: %s', src)
                 if not (path.isfile(src) and access(src, R_OK)):
-                    logger.error('Better Fig. Error: image not found: {}'.format(src))
+                    logger.error('Better Fig. Error: image not found: %s', src)
 
                 # Open the source image and query dimensions; build style string
                 im = Image.open(src)


### PR DESCRIPTION
Before, we get an unhelpful crash when a missing file has a unicode character in the name

```python
ERROR: Could not process ./2014-12-24-incubator-final.md
  | 'ascii' codec can't encode character u'\xc2' in position 67: ordinal not in range(128)
  |___
  | Traceback (most recent call last):
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/pelican/generators.py", line 502, in generate_context
  |     context_sender=self)
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/pelican/readers.py", line 492, in read_file
  |     context=context)
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/pelican/contents.py", line 143, in __init__
  |     signals.content_object_init.send(self)
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/blinker/base.py", line 267, in send
  |     for receiver in self.receivers_for(sender)]
  |   File "/Users/dhalperi/Code/blog/pelican-plugins/better_figures_and_images/better_figures_and_images.py", line 55, in content_object_init
  |     logger.error('Better Fig. Error: image not found: {}'.format(src))
  | UnicodeEncodeError: 'ascii' codec can't encode character u'\xc2' in position 67: ordinal not in range(128)
```

after:

```python
ERROR: Could not process ./2014-12-24-incubator-final.md
  | [Errno 2] No such file or directory: u'/Users/dhalperi/Code/blog/content/images/2014-12-04-fall-incubator-\xc2Katsuyama.JPG'
  |___
  | Traceback (most recent call last):
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/pelican/generators.py", line 502, in generate_context
  |     context_sender=self)
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/pelican/readers.py", line 492, in read_file
  |     context=context)
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/pelican/contents.py", line 143, in __init__
  |     signals.content_object_init.send(self)
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/blinker/base.py", line 267, in send
  |     for receiver in self.receivers_for(sender)]
  |   File "/Users/dhalperi/Code/blog/pelican-plugins/better_figures_and_images/better_figures_and_images.py", line 58, in content_object_init
  |     im = Image.open(src)
  |   File "/Users/dhalperi/Envs/blog/lib/python2.7/site-packages/PIL/Image.py", line 2251, in open
  |     fp = builtins.open(fp, "rb")
  | IOError: [Errno 2] No such file or directory: u'/Users/dhalperi/Code/blog/content/images/2014-12-04-fall-incubator-\xc2Katsuyama.JPG'
```