### PR TITLE
Assets: Allow to explicitly set debug mode

### DIFF
--- a/assets/assets.py
+++ b/assets/assets.py
@@ -51,7 +51,9 @@ def create_assets_env(generator):
         for name, args, kwargs in generator.settings['ASSET_BUNDLES']:
             generator.env.assets_environment.register(name, *args, **kwargs)
 
-    if logging.getLevelName(logger.getEffectiveLevel()) == "DEBUG":
+    if 'ASSET_DEBUG' in generator.settings:
+        generator.env.assets_environment.debug = generator.settings['ASSET_DEBUG']
+    elif logging.getLevelName(logger.getEffectiveLevel()) == "DEBUG":
         generator.env.assets_environment.debug = True
 
     if 'ASSET_SOURCE_PATHS' in generator.settings:


### PR DESCRIPTION
Allow to explicitly set debug mode instead of relying on the logger. Running `--debug` in pelican only changes the logging so it can be used in production however with this using the logger to change how assets work I can no longer use it in production (which is needed for other reasons). So this change is to allow more control.

I haven't tested or anything, about to make the change myself and use it. However adding code here should easily show you what  I mean if you want to implement it a different way.