### PR TITLE
Fix assets for pelican 3.5+

### DIFF
--- a/assets/Readme.rst
+++ b/assets/Readme.rst
@@ -92,8 +92,7 @@ LessCSS's binary:
 If you wish to place your assets in locations other than the theme output
 directory, you can use ``ASSET_SOURCE_PATHS`` in your settings file to provide
 webassets with a list of additional directories to search, relative to the
-theme's top-level directory. Note that as of Pelican 3.5.0, this setting is
-required, as the ``StaticGenerator`` generator now runs last in sequence:
+theme's top-level directory:
 
 .. code-block:: python
 

--- a/assets/assets.py
+++ b/assets/assets.py
@@ -39,9 +39,9 @@ def create_assets_env(generator):
     """Define the assets environment and pass it to the generator."""
 
     theme_static_dir = generator.settings['THEME_STATIC_DIR']
-    assets_src = os.path.join(generator.output_path, theme_static_dir)
+    assets_destination = os.path.join(generator.output_path, theme_static_dir)
     generator.env.assets_environment = Environment(
-        assets_src, theme_static_dir)
+        assets_destination, theme_static_dir)
 
     if 'ASSET_CONFIG' in generator.settings:
         for item in generator.settings['ASSET_CONFIG']:
@@ -54,13 +54,10 @@ def create_assets_env(generator):
     if logging.getLevelName(logger.getEffectiveLevel()) == "DEBUG":
         generator.env.assets_environment.debug = True
 
-    if 'ASSET_SOURCE_PATHS' in generator.settings:
-        # the default load path gets overridden if additional paths are
-        # specified, add it back
-        generator.env.assets_environment.append_path(assets_src)
-        for path in generator.settings['ASSET_SOURCE_PATHS']:
-            full_path = os.path.join(generator.theme, path)
-            generator.env.assets_environment.append_path(full_path)
+    for path in (generator.settings['THEME_STATIC_PATHS'] +
+                 generator.settings.get('ASSET_SOURCE_PATHS', [])):
+        full_path = os.path.join(generator.theme, path)
+        generator.env.assets_environment.append_path(full_path)
 
 
 def register():

--- a/assets/test_assets.py
+++ b/assets/test_assets.py
@@ -12,43 +12,13 @@ import subprocess
 
 from pelican import Pelican
 from pelican.settings import read_settings
+from pelican.tests.support import mute, skipIfNoExecutable, module_exists
 
 CUR_DIR = os.path.dirname(__file__)
 THEME_DIR = os.path.join(CUR_DIR, 'test_data')
 CSS_REF = open(os.path.join(THEME_DIR, 'static', 'css',
                             'style.min.css')).read()
 CSS_HASH = hashlib.md5(CSS_REF).hexdigest()[0:8]
-
-
-def skipIfNoExecutable(executable):
-    """Skip test if `executable` is not found
-
-    Tries to run `executable` with subprocess to make sure it's in the path,
-    and skips the tests if not found (if subprocess raises a `OSError`).
-    """
-
-    with open(os.devnull, 'w') as fnull:
-        try:
-            res = subprocess.call(executable, stdout=fnull, stderr=fnull)
-        except OSError:
-            res = None
-
-    if res is None:
-        return unittest.skip('{0} executable not found'.format(executable))
-
-    return lambda func: func
-
-
-def module_exists(module_name):
-    """Test if a module is importable."""
-
-    try:
-        __import__(module_name)
-    except ImportError:
-        return False
-    else:
-        return True
-
 
 
 @unittest.skipUnless(module_exists('webassets'), "webassets isn't installed")
@@ -66,13 +36,14 @@ class TestWebAssets(unittest.TestCase):
             'PLUGINS': [assets],
             'THEME': THEME_DIR,
             'LOCALE': locale.normalize('en_US'),
+            'CACHE_CONTENT': False
         }
         if override:
             settings.update(override)
 
         self.settings = read_settings(override=settings)
         pelican = Pelican(settings=self.settings)
-        pelican.run()
+        mute(True)(pelican.run)()
 
     def tearDown(self):
         rmtree(self.temp_path)


### PR DESCRIPTION
Fixes `assets` plugin according to the changes in Pelican 3.5 (see getpelican/pelican#1523). This should allow the use of `assets` plugin without the need for `ASSET_SOURCE_PATHS` setting in 3.5+.