### PR TITLE
Share post: fix twitter quoting and add Diaspora* support

### DIFF
--- a/share_post/README.md
+++ b/share_post/README.md
@@ -51,6 +51,8 @@ Template Example
 <section>
     <p id="post-share-links">
         Share on:
+        <a href="{{article.share_post['diaspora']}}" target="_blank" title="Share on Diaspora">Diaspora*</a>
+        ❄
         <a href="{{article.share_post['twitter']}}" target="_blank" title="Share on Twitter">Twitter</a>
         ❄
         <a href="{{article.share_post['facebook']}}" target="_blank" title="Share on Facebook">Facebook</a>

--- a/share_post/share_post.py
+++ b/share_post/share_post.py
@@ -38,7 +38,7 @@ def share_post(content):
     url = article_url(content)
     summary = article_summary(content)
 
-    tweet = quote(('%s %s' % (title, url)).encode('utf-8'))
+    tweet = ('%s%s%s' % (title, quote(' '), url)).encode('utf-8')
     facebook_link = 'http://www.facebook.com/sharer/sharer.php?s=100&amp;p%%5Burl%%5D=%s' % url
     gplus_link = 'https://plus.google.com/share?url=%s' % url
     twitter_link = 'http://twitter.com/home?status=%s' % tweet

--- a/share_post/share_post.py
+++ b/share_post/share_post.py
@@ -39,12 +39,15 @@ def share_post(content):
     summary = article_summary(content)
 
     tweet = ('%s%s%s' % (title, quote(' '), url)).encode('utf-8')
+    diaspora_link = 'https://sharetodiaspora.github.io/?title=%s&url=%s' % (title, url)
     facebook_link = 'http://www.facebook.com/sharer/sharer.php?s=100&amp;p%%5Burl%%5D=%s' % url
     gplus_link = 'https://plus.google.com/share?url=%s' % url
     twitter_link = 'http://twitter.com/home?status=%s' % tweet
     mail_link = 'mailto:?subject=%s&amp;body=%s' % (title, url)
 
-    share_links = {'twitter': twitter_link,
+    share_links = {
+                   'diaspora': diaspora_link,
+                   'twitter': twitter_link,
                    'facebook': facebook_link,
                    'google-plus': gplus_link,
                    'email': mail_link


### PR DESCRIPTION
This fixes double quoting in the produced Twitter URL and adds Diaspora* support.