### PR TITLE
org_reader plugin. Publishes Emacs Org-mode files.

### DIFF
--- a/org_reader/LICENSE
+++ b/org_reader/LICENSE
@@ -1,0 +1,12 @@
+Copyright 2015 Matthew Snyder, http://msnyder.info
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/org_reader/README.md
+++ b/org_reader/README.md
@@ -1,0 +1,21 @@
+# Org Reader
+
+Publish Emacs Org files alongside the rest of your website or blag.
+
+- `ORG_READER_EMACS_LOCATION`: Required. Location of Emacs binary.
+
+- `ORG_READER_EMACS_SETTINGS`: Optional. An absolute path to an Elisp file, to
+  run per invocation. Useful for initializing the `package` Emacs library if
+  that's where your Org mode comes from, or any modifications to Org Export-
+  related variables.
+
+- `ORG_READER_BACKEND`: Optional. A custom backend to provide to Org. Defaults
+  to 'html.
+
+To provide metadata to Pelican, provide the following header in your Org file:
+
+	#+TITLE: The Title Of This BlogPost
+	#+DATE: 2001-01-01
+	#+CATEGORY: comma, separated, list, of, tags
+
+The slug is automatically the filename of the Org file.

--- a/org_reader/__init__.py
+++ b/org_reader/__init__.py
@@ -1,0 +1,1 @@
+from .org_reader import *

--- a/org_reader/org_reader.el
+++ b/org_reader/org_reader.el
@@ -1,0 +1,12 @@
+(require 'org)
+(defun org->pelican (filename backend)
+  (progn
+    (save-excursion
+      (find-file filename)
+      (let ((properties (org-export-get-environment)))
+        (princ (json-encode 
+                (list 
+                 :date (org-timestamp-format (car (plist-get properties :date)) "%Y-%m-%d")
+                 :category (cdr (assoc "CATEGORY" org-file-properties))
+                 :post (org-export-as backend nil nil t)
+                 :title (substring-no-properties (car (plist-get properties :title))))))))))

--- a/org_reader/org_reader.py
+++ b/org_reader/org_reader.py
@@ -1,0 +1,91 @@
+"""
+Org Reader
+==========
+
+Version 1.0.
+
+Relevant Pelican settings:
+
+- ORG_READER_EMACS_LOCATION: Required. Location of Emacs binary.
+
+- ORG_READER_EMACS_SETTINGS: Optional. An absolute path to an Elisp file, to
+  run per invocation. Useful for initializing the `package` Emacs library if
+  that's where your Org mode comes from, or any modifications to Org Export-
+  related variables.
+
+- ORG_READER_BACKEND: Optional. A custom backend to provide to Org. Defaults
+  to 'html.
+
+To provide metadata to Pelican, provide the following header in your Org file:
+
+#+TITLE: The Title Of This BlogPost
+#+DATE: 2001-01-01
+#+CATEGORY: comma, separated, list, of, tags
+
+The slug is automatically the filename of the Org file.
+"""
+import os
+import json
+import logging
+import subprocess
+from pelican import readers
+from pelican import signals
+from pelican import settings
+
+
+ELISP = os.path.join(os.path.dirname(__file__), 'org_reader.el')
+LOG = logging.getLogger(__name__)
+
+class OrgReader(readers.BaseReader):
+    enabled = True
+
+    EMACS_ARGS = ["--batch"]
+    ELISP_EXEC = "(org->pelican \"{0}\" {1})"
+
+    file_extensions = ['org']
+
+    def __init__(self, settings):
+        super(OrgReader, self).__init__(settings)
+        assert 'ORG_READER_EMACS_LOCATION' in self.settings, \
+            "No ORG_READER_EMACS_LOCATION specified in settings"
+
+    def read(self, filename):
+        LOG.info("Reading Org file {0}".format(filename))
+        cmd = [self.settings['ORG_READER_EMACS_LOCATION']]
+        cmd.extend(self.EMACS_ARGS)
+
+        if 'ORG_READER_EMACS_SETTINGS' in self.settings:
+            cmd.append('-l')
+            cmd.append(self.settings['ORG_READER_EMACS_SETTINGS'])
+
+        backend = self.settings.get('ORG_READER_BACKEND', "'html")
+
+        cmd.append('-l')
+        cmd.append(ELISP)
+
+        cmd.append('--eval')
+        cmd.append(self.ELISP_EXEC.format(filename, backend))
+
+        LOG.debug("OrgReader: running command `{0}`".format(cmd))
+
+        json_result = subprocess.check_output(cmd)
+        json_output = json.loads(json_result)
+
+        slug, e = os.path.splitext(os.path.basename(filename))
+
+        metadata = {'title': json_output['title'],
+                    'tags': json_output['category'] or '',
+                    'slug': slug,
+                    'date': json_output['date']}
+
+        parsed = {}
+        for key, value in metadata.items():
+            parsed[key] = self.process_metadata(key, value)
+
+        return json_output['post'], parsed
+
+def add_reader(readers):
+    readers.reader_classes['org'] = OrgReader
+
+def register():
+    signals.readers_init.connect(add_reader)


### PR DESCRIPTION
org_reader plugin, for reading Emacs Org-mode files for publishing as articles in Pelican.