### PR TITLE
adds instruction message

### DIFF
--- a/w3c_validate/README.md
+++ b/w3c_validate/README.md
@@ -19,7 +19,7 @@ validated.
 
 ## Instructions
 
-Add `w3c_validate` to your config file's plugins after installing dependencies - `plugins = ['w3c_validate']`
+Add `w3c_validate` to your config file's plugins after installing dependencies - `PLUGINS = ['w3c_validate']`
 
 ## Dependencies
 

--- a/w3c_validate/README.md
+++ b/w3c_validate/README.md
@@ -17,6 +17,10 @@ are displayed. For example:
 flag. Otherwise, you will see errors (if any) but not the file currently being
 validated.
 
+## Instructions
+
+Add `w3c_validate` to your config file's plugins after installing dependencies - `plugins = ['w3c_validate']`
+
 ## Dependencies
 
 * [py_w3c](https://pypi.python.org/pypi/py_w3c/0.1.0), which can be installed with pip:


### PR DESCRIPTION
adds a simple instruction message. useful for neophytes who might confuse w3c_validate vs wc3_validate from the `wc3_validate.py` file vs the plugin name.