### PR TITLE
adds instruction to w3c_validate

### DIFF
--- a/w3c_validate/README.md
+++ b/w3c_validate/README.md
@@ -22,6 +22,10 @@ validated.
 * [py_w3c](https://pypi.python.org/pypi/py_w3c/0.1.0), which can be installed with pip:
 
     $ pip install py_w3c
+    
+## Instructions
+
+Add `w3c_validate` to your config file's plugins after installing dependencies - `PLUGINS = ['w3c_validate']`
 
 ## TODO
 


### PR DESCRIPTION
adds a simple instruction message. useful for neophytes who might confuse w3c_validate vs wc3_validate from the `wc3_validate.py` file vs the plugin name.

re-do of pull request https://github.com/getpelican/pelican-plugins/pull/397 for neatness.