### PR TITLE
add toc plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,7 @@
 [submodule "replacer"]
 	path = replacer
 	url = https://github.com/narusemotoki/replacer
+[submodule "pelican-toc"]
+	path = pelican-toc
+	url = https://github.com/ingwinlu/pelican-toc
+

--- a/Readme.rst
+++ b/Readme.rst
@@ -112,6 +112,8 @@ PDF generator             Automatically exports RST articles and pages as PDF fi
 
 Pelican-flickr            Brings your Flickr photos & sets into your static website
 
+pelican-toc               Generates a Table of Contents and make it available to the theme via article.toc
+
 Pelican Gist tag          Easily embed GitHub Gists in your Pelican articles
 
 Pelican Page Order        Adds a ``page_order`` attribute to all pages if one is not defined.


### PR DESCRIPTION
Differences between pelican-toc and pelican-extract-toc

`extract-toc` uses a markdown extension to generate a toc and then extract it via beautifulsoup. This extension generates the toc itself, removing the need to write `[ToC]` in your articles.
