### PR TITLE
Reading external files using include_code tag from liquid_tags crashes with following letters: ç, á, ó..

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -80,7 +80,7 @@ only allowed if a title is also given.
     {% include_code /path/to/code.py lines:1-10 :hidefilename: Test Example %}
 
 This example will show the first 10 lines of the file while hiding the actual
-filename.
+filename. UTF-8 encoding is assumed for code files.
 
 The script must be in the ``code`` subdirectory of your content folder:
 this default location can be changed by specifying

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -33,10 +33,6 @@ import re
 import os
 from .mdx_liquid_tags import LiquidTags
 
-import sys
-reload(sys) 
-sys.setdefaultencoding('utf8')
-
 SYNTAX = "{% include_code /path/to/code.py [lang:python] [lines:X-Y] [:hidefilename:] [title] %}"
 FORMAT = re.compile(r"""
 ^(?:\s+)?                          # Allow whitespace at beginning
@@ -80,7 +76,7 @@ def include_code(preprocessor, tag, markup):
     if not os.path.exists(code_path):
         raise ValueError("File {0} could not be found".format(code_path))
 
-    with open(code_path) as fh:
+    with open(code_path, encoding='utf-8') as fh:
         if lines:
             code = fh.readlines()[first_line - 1: last_line]
             code[-1] = code[-1].rstrip()

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -33,6 +33,9 @@ import re
 import os
 from .mdx_liquid_tags import LiquidTags
 
+import sys
+reload(sys) 
+sys.setdefaultencoding('utf8')
 
 SYNTAX = "{% include_code /path/to/code.py [lang:python] [lines:X-Y] [:hidefilename:] [title] %}"
 FORMAT = re.compile(r"""

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -29,6 +29,9 @@ in the STATIC_PATHS setting, e.g.:
 
 [1] https://github.com/imathis/octopress/blob/master/plugins/include_code.rb
 """
+from __future__ import unicode_literals
+
+from io import open
 import re
 import os
 from .mdx_liquid_tags import LiquidTags


### PR DESCRIPTION
when external code has letters like ç, á, ó etc (brazilian case) include_code tag from liquid_tags crashes. Set to be always utf-8. I do not know if it is the best solution, however it worked well for me. 