### PR TITLE
Have relevant plugins use all_generators_finalized signal

### DIFF
--- a/clean_summary/clean_summary.py
+++ b/clean_summary/clean_summary.py
@@ -8,18 +8,18 @@ also adds option to include an image by default if one exists in your article
 
 from pelican import signals
 from pelican.contents import Content, Article
+from pelican.generators import ArticlesGenerator
 from bs4 import BeautifulSoup
 from six import text_type
 
+def init(pelican):
+    global maximum_images
+    global minimum_one
+    maximum_images = pelican.settings.get('CLEAN_SUMMARY_MAXIMUM', 0)
+    minimum_one = pelican.settings.get('CLEAN_SUMMARY_MINIMUM_ONE', False)
+
+
 def clean_summary(instance):
-    if "CLEAN_SUMMARY_MAXIMUM" in instance.settings:
-        maximum_images = instance.settings["CLEAN_SUMMARY_MAXIMUM"]
-    else:
-        maximum_images = 0
-    if "CLEAN_SUMMARY_MINIMUM_ONE" in instance.settings:
-        minimum_one = instance.settings['CLEAN_SUMMARY_MINIMUM_ONE']
-    else:
-        minimum_one = False
     if type(instance) == Article:
         summary = instance.summary
         summary = BeautifulSoup(instance.summary, 'html.parser')
@@ -34,5 +34,19 @@ def clean_summary(instance):
                 summary.insert(0, first_image)
         instance._summary = text_type(summary)
 
+
+def run_plugin(generators):
+    for generator in generators:
+        if isinstance(generator, ArticlesGenerator):
+            for article in generator.articles:
+                clean_summary(article)
+
+
 def register():
-    signals.content_object_init.connect(clean_summary)
+    signals.initialized.connect(init)
+    try:
+        signals.all_generators_finalized.connect(run_plugin)
+    except AttributeError:
+        # NOTE: This may result in #314 so shouldn't really be relied on
+        # https://github.com/getpelican/pelican-plugins/issues/314
+        signals.content_object_init.connect(clean_summary)

--- a/read_more_link/read_more_link.py
+++ b/read_more_link/read_more_link.py
@@ -11,6 +11,7 @@ For more information, please visit: http://vuongnguyen.com/creating-inline-read-
 
 from pelican import signals, contents
 from pelican.utils import truncate_html_words
+from pelican.generators import ArticlesGenerator
 
 try:
     from lxml.html import fragment_fromstring, fragments_fromstring, tostring
@@ -63,9 +64,22 @@ def insert_read_more_link(instance):
     else:
         summary = truncate_html_words(instance.content, SUMMARY_MAX_LENGTH)
 
-    if summary<instance.content:
+    if summary != instance.content:
         read_more_link = READ_MORE_LINK_FORMAT.format(url=instance.url, text=READ_MORE_LINK)
         instance._summary = insert_into_last_element(summary, read_more_link)
 
+
+def run_plugin(generators):
+    for generator in generators:
+        if isinstance(generator, ArticlesGenerator):
+            for article in generator.articles:
+                insert_read_more_link(article)
+
+
 def register():
-    signals.content_object_init.connect(insert_read_more_link)
+    try:
+        signals.all_generators_finalized.connect(run_plugin)
+    except AttributeError:
+        # NOTE: This may result in #314 so shouldn't really be relied on
+        # https://github.com/getpelican/pelican-plugins/issues/314
+        signals.content_object_init.connect(insert_read_more_link)

--- a/share_post/share_post.py
+++ b/share_post/share_post.py
@@ -27,16 +27,11 @@ def article_url(content):
     return quote(('%s/%s' % (site_url, content.url)).encode('utf-8'))
 
 
-def article_summary(content):
-    return quote(BeautifulSoup(content.summary, 'html.parser').get_text().strip().encode('utf-8'))
-
-
 def share_post(content):
     if isinstance(content, contents.Static):
         return
     title = article_title(content)
     url = article_url(content)
-    summary = article_summary(content)
 
     tweet = ('%s%s%s' % (title, quote(' '), url)).encode('utf-8')
     diaspora_link = 'https://sharetodiaspora.github.io/?title=%s&url=%s' % (title, url)

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -8,6 +8,7 @@ body of your articles.
 
 from __future__ import unicode_literals
 from pelican import signals
+from pelican.generators import ArticlesGenerator, StaticGenerator
 
 def initialized(pelican):
     from pelican.settings import DEFAULT_CONFIG
@@ -21,7 +22,7 @@ def initialized(pelican):
         pelican.settings.setdefault('SUMMARY_END_MARKER',
                                     '<!-- PELICAN_END_SUMMARY -->')
 
-def content_object_init(instance):
+def extract_summary(instance):
     # if summary is already specified, use it
     # if there is no content, there's nothing to do
     if hasattr(instance, '_summary'):
@@ -35,7 +36,6 @@ def content_object_init(instance):
     begin_marker = instance.settings['SUMMARY_BEGIN_MARKER']
     end_marker   = instance.settings['SUMMARY_END_MARKER']
 
-    # extract out our summary
     content = instance._content
     begin_summary = -1
     end_summary = -1
@@ -69,6 +69,22 @@ def content_object_init(instance):
     instance._summary = summary
     instance.has_summary = True
 
+
+def run_plugin(generators):
+    for generator in generators:
+        if isinstance(generator, ArticlesGenerator):
+            for article in generator.articles:
+                extract_summary(article)
+        elif isinstance(generator, PagesGenerator):
+            for page in generator.pages:
+                extract_summary(page)
+
+
 def register():
     signals.initialized.connect(initialized)
-    signals.content_object_init.connect(content_object_init)
+    try:
+        signals.all_generators_finalized.connect(run_plugin)
+    except AttributeError:
+        # NOTE: This results in #314 so shouldn't really be relied on
+        # https://github.com/getpelican/pelican-plugins/issues/314
+        signals.content_object_init.connect(extract_summary)


### PR DESCRIPTION
`clean_summary`, `read_more_link`, `representative_image`, `summary` plugins now use `all_generators_finalized` signal so as to avoid issue #314. They fallback to current behavior if said signal is not yet available.

See also: https://github.com/getpelican/pelican/pull/1616