### PR TITLE
Mathjax configuration option: Allow automatic line breaks

### DIFF
--- a/render_math/Readme.md
+++ b/render_math/Readme.md
@@ -54,6 +54,9 @@ sequences. **Default Value**: True
 rendering LaTex. If set to `Tex`, then the TeX code is used as the preview 
 (which will be visible until it is processed by MathJax). **Default Value**: `Tex`
  * `color`: controls the color of the mathjax rendered font. **Default Value**: `black`
+ * `linebreak_automatic`: Mathjax will try to *intelligently* break up any displayed math
+(Note: It will not work for inline math). This is very useful for a responsive site. It
+is turned off by default due to it potentially being CPU expensive. **Default Value**: False
 
 For example, in settings.py, the following would make math render in blue and
 displaymath align to the left:

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -50,6 +50,7 @@ def process_settings(pelicanobj):
     mathjax_settings['process_escapes'] = 'true'  # controls whether escapes are processed
     mathjax_settings['latex_preview'] = 'TeX'  # controls what user sees while waiting for LaTex to render
     mathjax_settings['color'] = 'black'  # controls color math is rendered in
+    mathjax_settings['linebreak_automatic'] = 'false'  # Set to false by default for performance reasons (see http://docs.mathjax.org/en/latest/output.html#automatic-line-breaking)
 
     # Source for MathJax: Works boths for http and https (see http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn)
     mathjax_settings['source'] = "'//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
@@ -87,6 +88,9 @@ def process_settings(pelicanobj):
             mathjax_settings[key] = value
 
         if key == 'color' and isinstance(value, basestring):
+            mathjax_settings[key] = value
+        
+        if key == 'linebreak_automatic' and isinstance(value, basestring):
             mathjax_settings[key] = value
 
     return mathjax_settings

--- a/render_math/mathjax_script_template
+++ b/render_math/mathjax_script_template
@@ -19,7 +19,7 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
         "        preview: '{latex_preview}'," +
         "    }}, " +
         "    'HTML-CSS': {{ " +
-        "        styles: {{ '.MathJax_Display, .MathJax .mo, .MathJax .mi, .MathJax .mn': {{color: '{color} ! important'}} }}" +
+        "        styles: {{ '.MathJax_Display, .MathJax .mo, .MathJax .mi, .MathJax .mn': {{color: '{color} ! important'}} }}, linebreaks: {{ automatic: {linebreak_automatic}, width: 'container' }}" +
         "    }} " +
         "}}); ";
     (document.body || document.getElementsByTagName('head')[0]).appendChild(mathjaxscript);


### PR DESCRIPTION
Ability for automatic line breaks to be controlled in the plugin configuration