### PR TITLE
remove undesired <html> and <body> tags in extract_toc

### DIFF
--- a/extract_toc/extract_toc.py
+++ b/extract_toc/extract_toc.py
@@ -41,6 +41,8 @@ def extract_toc(content):
         toc.extract()
         content._content = soup.decode()
         content.toc = toc.decode()
+        if content.toc.startswith('<html>'):
+            content.toc = content.toc[12:-14]
 
 
 def register():


### PR DESCRIPTION
BeautifulSoup produces some `<html>` and `<body>` tags that need to be removed.