### PR TITLE
Allow render-math plugin to work for reST if Markdown is not installed

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -31,7 +31,13 @@ import os
 import sys
 
 from pelican import signals
-from . pelican_mathjax_markdown_extension import PelicanMathJaxExtension
+
+try:
+    from . pelican_mathjax_markdown_extension import PelicanMathJaxExtension
+except ImportError as e:
+    PelicanMathJaxExtension = None
+    print("\nMarkdown is not installed, so math only works in reStructuredText.\n")
+
 
 def process_settings(pelicanobj):
     """Sets user specified MathJax settings (see README for more details)"""
@@ -187,7 +193,8 @@ def pelican_init(pelicanobj):
     configure_typogrify(pelicanobj, mathjax_settings)
 
     # Configure Mathjax For Markdown
-    mathjax_for_markdown(pelicanobj, mathjax_settings)
+    if PelicanMathJaxExtension:
+        mathjax_for_markdown(pelicanobj, mathjax_settings)
 
     # Configure Mathjax For RST
     mathjax_for_rst(pelicanobj, mathjax_settings)


### PR DESCRIPTION
When markdown is not installed on the system, the render-math plugin doesn't work because it tries to import markdown.

I added exception handling so that users who don't use markdown (yet) can still use this plugin.

PS: I hope it is ok to create the pull request here instead of @barrysteyn 's personal repository...