### PR TITLE
Fix bug in Thumbnailer When IMG_PATH has trailing slash

### DIFF
--- a/thumbnailer/test_thumbnails.py
+++ b/thumbnailer/test_thumbnails.py
@@ -1,7 +1,7 @@
 from thumbnailer import _resizer
 from unittest import TestCase, main
 import os.path as path
-from PIL import Image, ImageChops
+from PIL import Image
 
 class ThumbnailerTests(TestCase):
 
@@ -44,6 +44,11 @@ class ThumbnailerFilenameTest(TestCase):
         """Test a file that is in the root of img_path."""
 
         r = _resizer('square', '100', self.img_path)
+        new_name = r.get_thumbnail_name(self.path('sample_image.jpg'))
+        self.assertEqual('sample_image_square.jpg', new_name)
+
+    def testRootWithSlash(self):
+        r = _resizer('square', '100', self.img_path + '/')
         new_name = r.get_thumbnail_name(self.path('sample_image.jpg'))
         self.assertEqual('sample_image_square.jpg', new_name)
 

--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -131,8 +131,6 @@ def resize_thumbnails(pelican):
         return
 
     in_path = _image_path(pelican)
-    out_path = path.join(pelican.settings['OUTPUT_PATH'],
-                         pelican.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR))
 
     sizes = pelican.settings.get('THUMBNAIL_SIZES', DEFAULT_THUMBNAIL_SIZES)
     resizers = dict((k, _resizer(k, v, in_path)) for k,v in sizes.items())
@@ -142,16 +140,23 @@ def resize_thumbnails(pelican):
             if not filename.startswith('.'):
                 for name, resizer in resizers.items():
                     in_filename = path.join(dirpath, filename)
-                    logger.debug("Processing thumbnail {0}=>{1}".format(filename, name))
-                    if pelican.settings.get('THUMBNAIL_KEEP_NAME', False):
-                        if pelican.settings.get('THUMBNAIL_KEEP_TREE', False):
-                            resizer.resize_file_to(
-                                in_filename, 
-                                path.join(out_path, name, path.dirname(path.relpath(in_filename, in_path))), True)
-                        else:
-                            resizer.resize_file_to(in_filename, path.join(out_path, name), True)
-                    else:
-                        resizer.resize_file_to(in_filename, out_path)
+                    out_path = get_out_path(pelican, in_path, in_filename, name)
+                    resizer.resize_file_to(
+                        in_filename,
+                        out_path, pelican.settings.get('THUMBNAIL_KEEP_NAME'))
+
+
+def get_out_path(pelican, in_path, in_filename, name):
+    out_path = path.join(pelican.settings['OUTPUT_PATH'],
+                         pelican.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR))
+    logger.debug("Processing thumbnail {0}=>{1}".format(in_filename, name))
+    if pelican.settings.get('THUMBNAIL_KEEP_NAME', False):
+        if pelican.settings.get('THUMBNAIL_KEEP_TREE', False):
+            return path.join(out_path, name, path.dirname(path.relpath(in_filename, in_path)))
+        else:
+            return path.join(out_path, name)
+    else:
+        return out_path
 
 
 def _image_path(pelican):

--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -147,21 +147,21 @@ def resize_thumbnails(pelican):
 
 
 def get_out_path(pelican, in_path, in_filename, name):
-    out_path = path.join(pelican.settings['OUTPUT_PATH'],
+    base_out_path = path.join(pelican.settings['OUTPUT_PATH'],
                          pelican.settings.get('THUMBNAIL_DIR', DEFAULT_THUMBNAIL_DIR))
     logger.debug("Processing thumbnail {0}=>{1}".format(in_filename, name))
     if pelican.settings.get('THUMBNAIL_KEEP_NAME', False):
         if pelican.settings.get('THUMBNAIL_KEEP_TREE', False):
-            return path.join(out_path, name, path.dirname(path.relpath(in_filename, in_path)))
+            return path.join(base_out_path, name, path.dirname(path.relpath(in_filename, in_path)))
         else:
-            return path.join(out_path, name)
+            return path.join(base_out_path, name)
     else:
-        return out_path
+        return base_out_path
 
 
 def _image_path(pelican):
     return path.join(pelican.settings['PATH'],
-        pelican.settings.get("IMAGE_PATH", DEFAULT_IMAGE_DIR))
+        pelican.settings.get("IMAGE_PATH", DEFAULT_IMAGE_DIR)).rstrip('/')
 
 
 def expand_gallery(generator, metadata):


### PR DESCRIPTION
When ```pelican.settings.IMG_PATH``` has a trailing slash, Thumbnailer chops off the first letter of the thumbnail name. This PR contains a failing test demonstrating the issue:

```
AssertionError: 'sample_image_square.jpg' != 'ample_image_square.jpg' 
```

This PR then fixes the bug.