### PR TITLE
add Archives per category plugin

### DIFF
--- a/archives_per_category/Readme.rst
+++ b/archives_per_category/Readme.rst
@@ -1,0 +1,42 @@
+Archives per category
+=====================
+
+This plugin allows you to create period archives for selected (or all) categories.
+It works pretty like normal period archives.
+
+Settings
+--------
+
+.. code:: python
+    PLUGIN_PATHS = ('plugins',)
+    PLUGINS = ('archives_per_category',)
+
+    # Categories to archive, if not set, archive them all. Categories could be
+    # defined by name or slug.
+    CATEGORIES_TO_ARCHIVE = ('misc', 'Python')
+
+    YEAR_ARCHIVES_PER_CATEGORY_SAVE_AS = 'category_archives/{category}/{date:%Y}/index.html'
+    MONTH_ARCHIVES_PER_CATEGORY_SAVE_AS = 'category_archives/{category}/{date:%Y-%m}/index.html'
+    DAY_ARCHIVES_PER_CATEGORY_SAVE_AS = 'category_archives/{category}/{date:%Y-%m-%d}/index.html'
+
+
+Template
+--------
+
+Template is quite similiar to period archive's template. You could use the same
+variables, plus `category` and `category-slug`.
+
+Plugin looks for templates in this order 1. 'archives_per_category',
+2. 'period_archives', 3. 'archives'.
+
+.. code:: html
+    {% extends "base.html" %}
+    {% block content %}
+      <h1>Archives for {{ category }} {{ period | reverse | join(' ') }}</h1>
+      <dl>
+        {% for article in dates %}
+        <dt>{{ article.locale_date }}</dt>
+        <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
+        {% endfor %}
+      </dl>
+    {% endblock %}

--- a/archives_per_category/Readme.rst
+++ b/archives_per_category/Readme.rst
@@ -8,6 +8,7 @@ Settings
 --------
 
 .. code:: python
+
     PLUGIN_PATHS = ('plugins',)
     PLUGINS = ('archives_per_category',)
 
@@ -30,6 +31,7 @@ Plugin looks for templates in this order 1. 'archives_per_category',
 2. 'period_archives', 3. 'archives'.
 
 .. code:: html
+
     {% extends "base.html" %}
     {% block content %}
       <h1>Archives for {{ category }} {{ period | reverse | join(' ') }}</h1>

--- a/archives_per_category/Readme.rst
+++ b/archives_per_category/Readme.rst
@@ -25,7 +25,7 @@ Template
 --------
 
 Template is quite similiar to period archive's template. You could use the same
-variables, plus `category` and `category-slug`.
+variables, plus :code:`{{ category }}` and :code:`{{ category-slug }}`.
 
 Plugin looks for templates in this order 1. 'archives_per_category',
 2. 'period_archives', 3. 'archives'.

--- a/archives_per_category/__init__.py
+++ b/archives_per_category/__init__.py
@@ -1,0 +1,1 @@
+from .archives_per_category import *

--- a/archives_per_category/archives_per_category.py
+++ b/archives_per_category/archives_per_category.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+Archives per category plugin for Pelican
+========================================
+
+This plugin allows you to create separate archives for selected categories.
+"""
+from __future__ import unicode_literals
+
+import calendar
+import six
+
+from itertools import groupby
+from operator import attrgetter
+from functools import partial
+
+from pelican import signals
+
+
+def generate_archives_per_category(generator, writer):
+    """Generate per-year, per-month, and per-day archives for defined
+    categories.
+    """
+    try:
+        template = generator.get_template('archives_per_category')
+    except Exception:
+        try:
+            template = generator.get_template('period_archives')
+        except Exception:
+            template = generator.get_template('archives')
+
+    categories_to_archive = generator.settings.get('CATEGORIES_TO_ARCHIVE')
+
+    period_save_as = {
+        'year': generator.settings.get('YEAR_ARCHIVES_PER_CATEGORY_SAVE_AS'),
+        'month': generator.settings.get('MONTH_ARCHIVES_PER_CATEGORY_SAVE_AS'),
+        'day': generator.settings.get('DAY_ARCHIVES_PER_CATEGORY_SAVE_AS')
+    }
+
+    period_date_key = {
+        'year': attrgetter('date.year'),
+        'month': attrgetter('date.year', 'date.month'),
+        'day': attrgetter('date.year', 'date.month', 'date.day')
+    }
+
+    def _generate_archives_per_category(dates, key, save_as_fmt):
+        """Generate period category archives from `dates`, grouped by `key` and
+        written to `save_as`.
+        """
+        write = partial(writer.write_file,
+                        relative_urls=generator.settings['RELATIVE_URLS'])
+
+        for _period, group in groupby(dates, key=key):
+            archive = list(group)
+
+            def get_category(item): return item.category
+            for category, articles in groupby(archive, lambda x: x.category):
+                if (categories_to_archive is not None and
+                        (category not in categories_to_archive and
+                         category.slug not in categories_to_archive)):
+                    # Skip unwanted categories defined by name or slug
+                    continue
+
+                date = archive[0].date
+                save_as = save_as_fmt.format(date=date, category=category.slug)
+                context = generator.context.copy()
+
+                context["category"] = category
+                context["category-slug"] = category.slug
+
+                if key == period_date_key['year']:
+                    context["period"] = (_period,)
+                else:
+                    month_name = calendar.month_name[_period[1]]
+                    if not six.PY3:
+                        month_name = month_name.decode('utf-8')
+                    if key == period_date_key['month']:
+                        context["period"] = (_period[0], month_name)
+                    else:
+                        context["period"] = (_period[0], month_name,
+                                             _period[2])
+
+                write(save_as, template, context, dates=archive, blog=True)
+
+    for period in 'year', 'month', 'day':
+        save_as = period_save_as[period]
+        if save_as:
+            key = period_date_key[period]
+            _generate_archives_per_category(generator.dates, key, save_as)
+
+
+def register():
+    signals.article_writer_finalized.connect(generate_archives_per_category)


### PR DESCRIPTION
This plugin allows you to create period archives for selected (or all) categories.
It works pretty like normal period archives.