### PR TITLE
Add (require 'json) to org_reader.el

### DIFF
--- a/org_reader/org_reader.el
+++ b/org_reader/org_reader.el
@@ -1,3 +1,4 @@
+(require 'json)
 (require 'org)
 (defun org->pelican (filename backend)
   (progn


### PR DESCRIPTION
json is needed for org_reader to work. This seems the natural place to ensure this dependency is fullfilled.
Solves the issue discussed in issue #1668.