### PR TITLE
Liquid tags: Support nbformat v4 (Jupyter/IPython 3.0)

### DIFF
--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -68,7 +68,7 @@ from pygments.formatters import HtmlFormatter
 from IPython.nbconvert.exporters import HTMLExporter
 from IPython.config import Config
 
-from IPython.nbformat import current as nbformat
+from IPython.nbformat import reader as nbformat
 
 try:
     from IPython.nbconvert.preprocessors import Preprocessor
@@ -209,11 +209,16 @@ class SubCell(Preprocessor):
 
     def preprocess(self, nb, resources):
         nbc = deepcopy(nb)
-        for worksheet in nbc.worksheets:
-            cells = worksheet.cells[:]
-            worksheet.cells = cells[self.start:self.end]
-        return nbc, resources
 
+        if LooseVersion(IPython.__version__) < '3.0':
+            for worksheet in nbc.worksheets:
+                cells = worksheet.cells[:]
+                worksheet.cells = cells[self.start:self.end]
+        else:
+            nbc.cells = nbc.cells[self.start:self.end]
+            
+        return nbc, resources
+            
     call = preprocess # IPython < 2.0
 
 
@@ -293,8 +298,7 @@ def notebook(preprocessor, tag, markup):
 
     # read and parse the notebook
     with open(nb_path) as f:
-        nb_text = f.read()
-    nb_json = nbformat.reads_json(nb_text)
+        nb_json = nbformat.read(f)
     (body, resources) = exporter.from_notebook_node(nb_json)
 
     # if we haven't already saved the header, save it here.


### PR DESCRIPTION
This change makes it possible to use nbformat v4 Notebooks.

Support for worksheets was dropped in nbformat v4. Compatibility for
older versions should be maintained although I didn't test.

Fixes #427 