### PR TITLE
Better Images: Prevent errors when RESPONIVE_IMAGES is not set.

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -59,7 +59,7 @@ def content_object_init(instance):
                 im = Image.open(src)
                 extra_style = 'width: {}px; height: auto;'.format(im.size[0])
 
-                if instance.settings['RESPONSIVE_IMAGES']:
+                if 'RESPONSIVE_IMAGES' in instance.settings and instance.settings['RESPONSIVE_IMAGES']:
                     extra_style += ' max-width: 100%;'
 
                 if img.get('style'):


### PR DESCRIPTION
This fixes the case where RESPONSIVE_IMAGES is not set and you get
errors like this:

ERROR: Could not process ./my-blog-post.md
  | u'RESPONSIVE_IMAGES'