### PR TITLE
rmd_reader: handle backslashes in filenames

### DIFF
--- a/rmd_reader/rmd_reader.py
+++ b/rmd_reader/rmd_reader.py
@@ -22,6 +22,8 @@ class RmdReader(readers.BaseReader):
     # some content and the associated metadata.
     def read(self, filename):
         """Parse content and metadata of markdown files"""
+        # replace single backslashes with double backslashes
+        filename = filename.replace('\\', '\\\\')        
         # parse Rmd file - generate md file
         md_filename = filename.replace('.Rmd', '.aux').replace('.rmd', '.aux')
         robjects.r("""


### PR DESCRIPTION
on windows machines, rmd filenames that include `c:\Users` will raise an error unless `\` are replaced with `\\`