### PR TITLE
render_math: Python 3, auto insert, and mathjax fonts

### DIFF
--- a/render_math/Readme.md
+++ b/render_math/Readme.md
@@ -20,6 +20,11 @@ Then add the following to settings.py:
 Your site is now capable of rendering math math using the mathjax JavaScript
 engine. No alterations to the template is needed, just use and enjoy!
 
+However, if you wish, you can set the `auto_insert` setting to `False` which
+will disable the mathjax script from being automatically inserted into the
+content. You would only want to do this if you had control over the template
+and wanted to insert the script manually.
+
 ### Typogrify
 In the past, using [Typgogrify](https://github.com/mintchaos/typogrify) would alter the math contents resulting
 in math that could not be rendered by MathJax. The only option was to ensure
@@ -44,12 +49,18 @@ The dictionary can be set with the following keys:
 
  * `align`: [string] controls how displayed math will be aligned. Can be set to either
 `'left'`, `'right'` or `'center'`. **Default Value**: `'center'`.
+ * `auto_insert`: [boolean] will insert the mathjax script into content that it is
+detected to have math in it. Setting it to false is not recommended.
+**Default Value**: `True`
  * `indent`: [string] if `align` not set to `'center'`, then this controls the indent
 level. **Default Value**: `'0em'`.
  * `show_menu`: [boolean] controls whether the mathjax contextual menu is shown.
 **Default Value**: `True`
  * `process_escapes`: [boolean] controls whether mathjax processes escape sequences.
 **Default Value**: `True`
+ * `mathjax_font`: [string] will force mathjax to use the chosen font. Current choices
+for the font is `sanserif`, `typewriter` or `fraktur`. If this is not set, it will
+use the default font settings. **Default Value**: `default`
  * `latex_preview`: [string] controls the preview message users are shown while mathjax is
 rendering LaTex. If set to `'Tex'`, then the TeX code is used as the preview 
 (which will be visible until it is processed by MathJax). **Default Value**: `'Tex'`

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -50,6 +50,7 @@ def process_settings(pelicanobj):
     # will be used for
 
     # Default settings
+    mathjax_settings['auto_insert'] = True  # if set to true, it will insert mathjax script automatically into content without needing to alter the template. 
     mathjax_settings['align'] = 'center'  # controls alignment of of displayed equations (values can be: left, right, center)
     mathjax_settings['indent'] = '0em'  # if above is not set to 'center', then this setting acts as an indent
     mathjax_settings['show_menu'] = 'true'  # controls whether to attach mathjax contextual menu
@@ -60,6 +61,7 @@ def process_settings(pelicanobj):
     mathjax_settings['tex_extensions'] = ''  # latex extensions that can be embedded inside mathjax (see http://docs.mathjax.org/en/latest/tex.html#tex-and-latex-extensions)
     mathjax_settings['responsive'] = 'false'  # Tries to make displayed math responsive
     mathjax_settings['responsive_break'] = '768'  # The break point at which it math is responsively aligned (in pixels)
+    mathjax_settings['mathjax_font'] = 'default'  # forces mathjax to use the specified font.
 
     # Source for MathJax: Works boths for http and https (see http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn)
     mathjax_settings['source'] = "'//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
@@ -78,7 +80,16 @@ def process_settings(pelicanobj):
     for key, value in ((key, settings[key]) for key in settings):
         # Iterate over dictionary in a way that is compatible with both version 2
         # and 3 of python
-        if key == 'align' and isinstance(value, basestring):
+
+        if key == 'align':
+            try:
+                typeVal = isinstance(value, basestring)
+            except NameError:
+                typeVal = isinstance(value, str)
+
+            if not typeVal:
+                continue
+
             if value == 'left' or value == 'right' or value == 'center':
                 mathjax_settings[key] = value
             else:
@@ -90,13 +101,32 @@ def process_settings(pelicanobj):
         if key == 'show_menu' and isinstance(value, bool):
             mathjax_settings[key] = 'true' if value else 'false'
 
-        if key == 'process_escapes' and isinstance(value, bool):
-            mathjax_settings[key] = 'true' if value else 'false'
-
-        if key == 'latex_preview' and isinstance(value, basestring):
+        if key == 'auto_insert' and isinstance(value, bool):
             mathjax_settings[key] = value
 
-        if key == 'color' and isinstance(value, basestring):
+        if key == 'process_escapes' and isinstance(value, bool):
+            mathjax_settings[key] = 'true' if value else 'false'
+        
+        if key == 'latex_preview':
+            try:
+                typeVal = isinstance(value, basestring)
+            except NameError:
+                typeVal = isinstance(value, str)
+
+            if not typeVal:
+                continue
+
+            mathjax_settings[key] = value
+        
+        if key == 'color':
+            try:
+                typeVal = isinstance(value, basestring)
+            except NameError:
+                typeVal = isinstance(value, str)
+
+            if not typeVal:
+                continue
+
             mathjax_settings[key] = value
         
         if key == 'linebreak_automatic' and isinstance(value, bool):
@@ -110,9 +140,35 @@ def process_settings(pelicanobj):
 
         if key == 'tex_extensions' and isinstance(value, list):
             # filter string values, then add '' to them
-            value = filter(lambda string: isinstance(string, basestring), value)
+            try:
+                value = filter(lambda string: isinstance(string, basestring), value)
+            except NameError:
+                value = filter(lambda string: isinstance(string, str), value)
+
             value = map(lambda string: "'%s'" % string, value)
             mathjax_settings[key] = ',' + ','.join(value)
+
+        if key == 'mathjax_font':
+            try:
+                typeVal = isinstance(value, basestring)
+            except NameError:
+                typeVal = isinstance(value, str)
+
+            if not typeVal:
+                continue
+
+            value = value.lower()
+
+            if value == 'sanserif':
+                value = 'SansSerif'
+            elif value == 'fraktur':
+                value = 'Fraktur'
+            elif value == 'typewriter':
+                value = 'Typewriter'
+            else:
+                value = 'default'
+
+            mathjax_settings[key] = value
 
     return mathjax_settings
 
@@ -168,6 +224,7 @@ def mathjax_for_markdown(pelicanobj, mathjax_settings):
     config = {}
     config['mathjax_script'] = process_mathjax_script(mathjax_settings)
     config['math_tag_class'] = 'math'
+    config['auto_insert'] = mathjax_settings['auto_insert']
 
     # Instantiate markdown extension and append it to the current extensions
     try:

--- a/render_math/mathjax_script_template
+++ b/render_math/mathjax_script_template
@@ -32,6 +32,22 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
         "        styles: {{ '.MathJax_Display, .MathJax .mo, .MathJax .mi, .MathJax .mn': {{color: '{color} ! important'}} }}," +
         "        linebreaks: {{ automatic: "+ linebreak +", width: '90% container' }}," +
         "    }}, " +
-        "}}); ";
+        "}}); " +
+        "if ('{mathjax_font}' !== 'default') {{" +
+            "MathJax.Hub.Register.StartupHook('HTML-CSS Jax Ready',function () {{" +
+                "var VARIANT = MathJax.OutputJax['HTML-CSS'].FONTDATA.VARIANT;" +
+                "VARIANT['normal'].fonts.unshift('MathJax_{mathjax_font}');" +
+                "VARIANT['bold'].fonts.unshift('MathJax_{mathjax_font}-bold');" +
+                "VARIANT['italic'].fonts.unshift('MathJax_{mathjax_font}-italic');" +
+                "VARIANT['-tex-mathit'].fonts.unshift('MathJax_{mathjax_font}-italic');" +
+            "}});" +
+            "MathJax.Hub.Register.StartupHook('SVG Jax Ready',function () {{" +
+                "var VARIANT = MathJax.OutputJax.SVG.FONTDATA.VARIANT;" +
+                "VARIANT['normal'].fonts.unshift('MathJax_{mathjax_font}');" +
+                "VARIANT['bold'].fonts.unshift('MathJax_{mathjax_font}-bold');" +
+                "VARIANT['italic'].fonts.unshift('MathJax_{mathjax_font}-italic');" +
+                "VARIANT['-tex-mathit'].fonts.unshift('MathJax_{mathjax_font}-italic');" +
+            "}});" +
+        "}}";
     (document.body || document.getElementsByTagName('head')[0]).appendChild(mathjaxscript);
 }}

--- a/render_math/pelican_mathjax_markdown_extension.py
+++ b/render_math/pelican_mathjax_markdown_extension.py
@@ -125,11 +125,13 @@ class PelicanMathJaxExtension(markdown.Extension):
             # Needed for markdown versions >= 2.5
             self.config['mathjax_script'] = ['', 'Mathjax JavaScript script']
             self.config['math_tag_class'] = ['math', 'The class of the tag in which mathematics is wrapped']
+            self.config['auto_insert'] = [True, 'Determines if mathjax script is automatically inserted into content']
             super(PelicanMathJaxExtension,self).__init__(**config)
         except AttributeError:
             # Markdown versions < 2.5
             config['mathjax_script'] = [config['mathjax_script'], 'Mathjax JavaScript script']
             config['math_tag_class'] = [config['math_tag_class'], 'The class of the tag in which mathematic is wrapped']
+            config['auto_insert'] = [config['auto_insert'], 'Determines if mathjax script is automatically inserted into content']
             super(PelicanMathJaxExtension,self).__init__(config)
 
         # Used as a flag to determine if javascript
@@ -152,4 +154,5 @@ class PelicanMathJaxExtension(markdown.Extension):
 
         # If necessary, add the JavaScript Mathjax library to the document. This must
         # be last in the ordered dict (hence it is given the position '_end')
-        md.treeprocessors.add('mathjax_addjavascript', PelicanMathJaxAddJavaScript(self), '_end')
+        if self.getConfig('auto_insert'):
+            md.treeprocessors.add('mathjax_addjavascript', PelicanMathJaxAddJavaScript(self), '_end')


### PR DESCRIPTION
This plugin is not compatible with Python 3. This PR will fix this problem. It also adds two new features
 
 1. mathjax_fonts - allows the forcing of fonts on the math
 2. auto_insert - allows template designers control over whether the mathjax script is automatically inserted