### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,7 +73,6 @@
 [submodule "pelican-toc"]
 	path = pelican-toc
 	url = https://github.com/ingwinlu/pelican-toc
-
 [submodule "multimarkdown_reader"]
 	path = multimarkdown_reader
-	url = git@github.com:dames57/multimarkdown_reader.git
+	url = https://github.com/dames57/multimarkdown_reader.git


### PR DESCRIPTION
This very minor change fixes issue #479. The url for `multimarkdown_reader` (and all other urls) should use `https`.   