### PR TITLE
Fix issue #484 by  detecting if the notebook is version >3.0 

### DIFF
--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -209,13 +209,15 @@ class SubCell(Preprocessor):
 
     def preprocess(self, nb, resources):
         nbc = deepcopy(nb)
-        for worksheet in nbc.worksheets:
-            cells = worksheet.cells[:]
-            worksheet.cells = cells[self.start:self.end]
+        if LooseVersion(IPython.__version__) < '3.0':         
+            for worksheet in nbc.worksheets:
+                cells = worksheet.cells[:]
+                worksheet.cells = cells[self.start:self.end]
+        else:
+            nbc.cells = nbc.cells[self.start:self.end]
         return nbc, resources
 
     call = preprocess # IPython < 2.0
-
 
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
Fix issue #484 by  detecting if the notebook is version >3.0  then passing all the cells directly, in previous version there was a extra hierarchy called worksheet that is removed in version 3.0