### PR TITLE
Add csv loader to easily import tables in Pelican templates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,3 +76,6 @@
 [submodule "multimarkdown_reader"]
 	path = multimarkdown_reader
 	url = https://github.com/dames57/multimarkdown_reader.git
+[submodule "pelican-loadcsv"]
+	path = pelican-loadcsv
+	url = https://github.com/e9t/pelican-loadcsv.git


### PR DESCRIPTION
I've made a CSV loader to use in Pelican's templates.

Basic usage is as follows:

    {% csv 'data-sbp.csv' %}
or

<pre>
{% csv '''
a,b,c,d,e
1,1,1,1,1
2,2,2,2,2
3,3,3,3,3
4,4,4,4,4
5,5,5,5,5
'''%}
</pre>