### PR TITLE
Add the Libravatar plugin as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,3 +76,6 @@
 [submodule "multimarkdown_reader"]
 	path = multimarkdown_reader
 	url = https://github.com/dames57/multimarkdown_reader.git
+[submodule "libravatar"]
+	path = libravatar
+	url = https://github.com/rlaboiss/pelican-libravatar.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -100,6 +100,8 @@ Interlinks                Lets you add frequently used URLs to your markup using
 
 Liquid-style tags         Allows liquid-style tags to be inserted into markdown within Pelican documents
 
+Libravatar                Allows inclusion of user profile pictures from libravatar.org
+
 Multi parts posts         Allows you to write multi-part posts
 
 Markdown Inline Extend    Enables you to add customize inline patterns to your markdown


### PR DESCRIPTION
I [have created](https://github.com/rlaboiss/pelican-libravatar) a new Pelican plugin for including user profile pictures from [Libravatar](http://www.libravatar.org).  This plugin is an improvement on the [gravatar](https://github.com/getpelican/pelican-plugins/tree/master/gravatar) plugin.  It is also a replacement for it, since Libravatar redirects to Gravatar when the user profile is not found in its database. As an improvement on the gravatar plugin, the libravatar plugin accepts configuration variables for setting the "missing image" default and the size of the picture. It comes also with a unit testing script.  In the commit associated with this pull request, the Plugin Description table of the top-level Readme.rst file has been updated accordingly.