### PR TITLE
Delay the string casting of the size parameter

### DIFF
--- a/libravatar/libravatar.py
+++ b/libravatar/libravatar.py
@@ -29,7 +29,7 @@ def initialize (pelicanobj):
 def add_libravatar (generator, metadata):
     """Article generator connector for the Libravatar plugin"""
     missing = generator.settings.get ('LIBRAVATAR_MISSING')
-    size = str (generator.settings.get ('LIBRAVATAR_SIZE'))
+    size = generator.settings.get ('LIBRAVATAR_SIZE')
 
     ## Check the presence of the Email header
     if 'email' not in metadata.keys ():
@@ -53,7 +53,7 @@ def add_libravatar (generator, metadata):
                 if size:
                     url = url + '&'
             if size:
-                url = url + 's=' + size
+                url = url + 's=' + str (size)
 
         ## Add URL to the article's metadata
         metadata ['author_libravatar'] = url

--- a/libravatar/test_libravatar.py
+++ b/libravatar/test_libravatar.py
@@ -72,14 +72,27 @@ class TestLibravatarURL (unittest.TestCase):
                 break
         assert found
 
-
 class TestLibravatarMissing (TestLibravatarURL):
     """Class for testing the Libravatar "missing picture" option"""
 
     def setUp (self, override = None):
         self.library = 'wavatar'
         TestLibravatarURL.setUp (self,
-                                  override = {'LIBRAVATAR_MISSING': 'wavatar'})
+                                  override = {'LIBRAVATAR_MISSING':
+                                              self.library})
 
     def test_url (self):
         TestLibravatarURL.test_url (self, '\?d=' + self.library)
+
+
+class TestLibravatarSize (TestLibravatarURL):
+    """Class for testing the Libravatar size option"""
+
+    def setUp (self, override = None):
+        self.size = 100
+        TestLibravatarURL.setUp (self,
+                                  override = {'LIBRAVATAR_SIZE': self.size})
+
+    def test_url (self):
+        TestLibravatarURL.test_url (self, '\?s=' + str (self.size))
+


### PR DESCRIPTION
This allows to honor the eventual "None" value of the LIBRAVATAR_SIZE
variable and transforming it into an string only after its value has
been asserted.

Also, add a unit test for exercising the LIBRAVATAR_SIZE variable.