### PR TITLE
Add the Link Class plugin as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,3 +76,6 @@
 [submodule "multimarkdown_reader"]
 	path = multimarkdown_reader
 	url = https://github.com/dames57/multimarkdown_reader.git
+[submodule "linkclass"]
+	path = linkclass
+	url = https://github.com/rlaboiss/pelican-linkclass.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -100,6 +100,8 @@ Interlinks                Lets you add frequently used URLs to your markup using
 
 Libravatar                Allows inclusion of user profile pictures from libravatar.org
 
+Link Class                Allows the insertion of class attributes into the <a> generated elements (Markdown only)
+
 Liquid-style tags         Allows liquid-style tags to be inserted into markdown within Pelican documents
 
 Multi parts posts         Allows you to write multi-part posts


### PR DESCRIPTION
I [created](https://github.com/rlaboiss/pelican-linkclass) a new plugin for Pelican for allowing the inclusion of a class attribute to the generated <a> HTML elements.  This plugin insert different class names for the internal or external (i.e. starting with `https?://`) links in the Markdown article source. This allow separate styling for the two kinds of links.  See the [documentation](https://github.com/rlaboiss/pelican-linkclass/blob/master/Readme.md) for details.

The plugin comes with a unit testing suite. In the commit associated with the present pull request, I specified the path of the submodule as `linkclass`.  This is necessary for the unit testing working properly.  Besides, it provides a shorter name for the plugin (`linkclass` instead of `pelican-linkclass`, which is the name of my repository).

Also, I have added a line in the Plugin Description table in the top-level `Readme.rst`.
