### PR TITLE
Libravatar: use fenced code blocks

### DIFF
--- a/libravatar/Readme.md
+++ b/libravatar/Readme.md
@@ -17,13 +17,15 @@ the article's metadata.
 
 In ReSTructuredText:
 
-    :::rst
-    :email: bart.simpson@example.com
+```rst
+:email: bart.simpson@example.com
+```
 
 In Markdown:
 
-    :::text
-    Email: bart.simpson@example.com
+```markdown
+Email: bart.simpson@example.com
+```
 
 If the avatar for the specified email address is not found at Libravatar,
 it is searched at [Gravatar](http://www.gravatar.com).  If it is not found
@@ -38,12 +40,13 @@ instance, you can add the following to a template file (for example, to the
 `article_infos.html` template file of the notmyidea theme), just before the
 infomation about the author:
 
-    :::html
-    {% if article.author_libravatar %}
-    <div align="center">
-            <img src="{{ article.author_libravatar }}">
-    </div>
-    {% endif %}
+```html
+{% if article.author_libravatar %}
+<div align="center">
+        <img src="{{ article.author_libravatar }}">
+</div>
+{% endif %}
+```
 
 ## Settings
 


### PR DESCRIPTION
Please, merge this commit, which only changes the formatting of Markdown code blocks in the Readme.md file.  I was using the code block conventions of Pelican, which obviously does not work on Github.  I am using now fenced code blocks.