### PR TITLE
Update for tipue search 5

### DIFF
--- a/tipue_search/README.md
+++ b/tipue_search/README.md
@@ -42,13 +42,13 @@ Tipue Search serializes the generated HTML into JSON. Format of JSON is as follo
         { 
             "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.",
             "tags": "Example Category",
-            "loc" : "http://oncrashreboot.com/plugin-example.html",
+            "url" : "http://oncrashreboot.com/plugin-example.html",
             "title": "Everything you want to know about Lorem Ipsum"
         },
         { 
             "text": "Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.",
             "tags": "Example Category",
-            "loc" : "http://oncrashreboot.com/plugin-example-2.html",
+            "url" : "http://oncrashreboot.com/plugin-example-2.html",
             "title": "Review of the book Lorem Ipsum"
         }
     ]

--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -57,7 +57,7 @@ class Tipue_Search_JSON_Generator(object):
         node = {'title': page_title,
                 'text': page_text,
                 'tags': page_category,
-                'loc': page_url}
+                'url': page_url}
 
         self.json_nodes.append(node)
 


### PR DESCRIPTION
As per [official documentation](http://www.tipue.com/search/docs/?d=20) `loc` field has been renamed to `url`.