### PR TITLE
libravatar: Encode email address before hashing

### DIFF
--- a/libravatar/libravatar.py
+++ b/libravatar/libravatar.py
@@ -42,7 +42,9 @@ def add_libravatar (generator, metadata):
     if metadata ['email']:
 
         ## Compose URL using the MD5 hash
-        md5 = hashlib.md5 (metadata ['email'].lower ()).hexdigest ()
+        ## (the ascii encoding is necessary for Python3)
+        email = metadata ['email'].lower ().encode ('ascii')
+        md5 = hashlib.md5 (email).hexdigest ()
         url = 'http://cdn.libravatar.org/avatar/' + md5
 
         ## Add eventual "missing picture" option


### PR DESCRIPTION
With Python 3, the libravatar plugin yields the following error:

    Unicode-objects must be encoded before hashing

This is caused by the fact that the email string obtained from the header of the content file is stored as a Unicode object in the metadata list in Python 3.  The string must then be encoded before being passed to the `hashlib.md5` function.  According to the current standard, only ASCII characters should appear in email addresses, so encoding `metadata['email']` into ASCII will make the plugin work with both Python 2 and Python 3.