### PR TITLE
Don't generate the summary in share_posts.

### DIFF
--- a/share_post/share_post.py
+++ b/share_post/share_post.py
@@ -27,16 +27,11 @@ def article_url(content):
     return quote(('%s/%s' % (site_url, content.url)).encode('utf-8'))
 
 
-def article_summary(content):
-    return quote(BeautifulSoup(content.summary, 'html.parser').get_text().strip().encode('utf-8'))
-
-
 def share_post(content):
     if isinstance(content, contents.Static):
         return
     title = article_title(content)
     url = article_url(content)
-    summary = article_summary(content)
 
     tweet = ('%s%s%s' % (title, quote(' '), url)).encode('utf-8')
     diaspora_link = 'https://sharetodiaspora.github.io/?title=%s&url=%s' % (title, url)


### PR DESCRIPTION
The summary is unused, and requesting it seems to mess up creation of `{filename}` links.

This might fix #202 as well, but I was not having that issue.