### PR TITLE
representative_image plugin. Let all kinds of pages use featured images.

### DIFF
--- a/representative_image/representative_image.py
+++ b/representative_image/representative_image.py
@@ -2,6 +2,7 @@ from pelican import signals
 from pelican.contents import Content, Article
 from bs4 import BeautifulSoup
 
+
 def images_extraction(instance):
     representativeImage = None
     if type(instance) == Article:
@@ -19,16 +20,17 @@ def images_extraction(instance):
         if len(images) > 0:
             # set _summary field which is based on metadata. summary field is only based on article's content and not settable
             instance._summary = unicode(soup)
-        
+
         # If there are no image in summary, look for it in the content body
         if not representativeImage:
             soup = BeautifulSoup(instance.content, 'html.parser')
             imageTag = soup.find('img')
             if imageTag:
                 representativeImage = imageTag['src']
-        
+
         # Set the attribute to content instance
         instance.featured_image = representativeImage
+
 
 def register():
     signals.content_object_init.connect(images_extraction)

--- a/representative_image/representative_image.py
+++ b/representative_image/representative_image.py
@@ -1,11 +1,11 @@
 from pelican import signals
-from pelican.contents import Content, Article
+from pelican.contents import Article, Draft, Page
 from bs4 import BeautifulSoup
 
 
 def images_extraction(instance):
     representativeImage = None
-    if type(instance) == Article:
+    if type(instance) in (Article, Draft, Page):
         if 'image' in instance.metadata:
             representativeImage = instance.metadata['image']
 


### PR DESCRIPTION
I might be wrong, but I don't see why only Articles could use featured images. So I expanded it to Articles, Pages and Drafts.