### PR TITLE
Add txt2tags reader plugin

### DIFF
--- a/txt2tags_reader/LICENSE
+++ b/txt2tags_reader/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/txt2tags_reader/README.md
+++ b/txt2tags_reader/README.md
@@ -1,0 +1,12 @@
+# txt2tags_reader
+A [txt2tags] reader plugin for the [Pelican static site generator](http://docs.getpelican.com/en/latest/).
+
+Requirements
+------------
+[txt2tags] in $PATH
+
+Installation
+------------
+Instructions on installing pelican plugins can be found in the [pelican plugin manual](https://github.com/getpelican/pelican-plugins/blob/master/Readme.rst).
+
+[txt2tags]:http://txt2tags.org/

--- a/txt2tags_reader/__init__.py
+++ b/txt2tags_reader/__init__.py
@@ -1,0 +1,1 @@
+from .txt2tags_reader import *

--- a/txt2tags_reader/txt2tags_reader.py
+++ b/txt2tags_reader/txt2tags_reader.py
@@ -1,0 +1,42 @@
+import subprocess
+from pelican import signals
+from pelican.readers import BaseReader
+from pelican.utils import pelican_open
+
+class Txt2tagsReader(BaseReader):
+    enabled = True
+    file_extensions = ['t2t', 'txt2tags']
+
+    def read(self, filename):
+        with pelican_open(filename) as fp:
+            text = list(fp.splitlines())
+
+        metadata = {}
+        for i, line in enumerate(text):
+            kv = line.split(':', 1)
+            if len(kv) == 2:
+                name, value = kv[0].lower(), kv[1].strip()
+                metadata[name] = self.process_metadata(name, value)
+            else:
+                content = "\n".join(text[i:])
+                break
+
+        t2t_cmd = [r"txt2tags", r"--encoding=utf-8", r"--target=html", r"--infile=-", r"--outfile=-"]
+
+        proc = subprocess.Popen(t2t_cmd,
+                                stdin = subprocess.PIPE,
+                                stdout = subprocess.PIPE)
+
+        output = proc.communicate(content.encode('utf-8'))[0].decode('utf-8')
+        status = proc.wait()
+        if status:
+            raise subprocess.CalledProcessError(status, t2t_cmd)
+
+        return output, metadata
+
+def add_reader(readers):
+    for ext in Txt2tagsReader.file_extensions:
+        readers.reader_classes[ext] = Txt2tagsReader
+
+def register():
+    signals.readers_init.connect(add_reader)


### PR DESCRIPTION
Would you mind if I add this txt2tags reader into the 'pelican-plugins' repository? I don't find any existing plugin for this. Please correct me if I am wrong.