### PR TITLE
share_post plugin: add share-to-linkedin support

### DIFF
--- a/share_post/share_post.py
+++ b/share_post/share_post.py
@@ -43,6 +43,10 @@ def share_post(content):
     facebook_link = 'http://www.facebook.com/sharer/sharer.php?s=100&amp;p%%5Burl%%5D=%s' % url
     gplus_link = 'https://plus.google.com/share?url=%s' % url
     twitter_link = 'http://twitter.com/home?status=%s' % tweet
+    linkedin_link = 'https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s&summary=%s&source=%s' % (
+        url, title, summary, url
+    )
+
     mail_link = 'mailto:?subject=%s&amp;body=%s' % (title, url)
 
     share_links = {
@@ -50,6 +54,7 @@ def share_post(content):
                    'twitter': twitter_link,
                    'facebook': facebook_link,
                    'google-plus': gplus_link,
+                    'linkedin': linkedin_link,
                    'email': mail_link
                    }
     content.share_post = share_links
@@ -57,3 +62,5 @@ def share_post(content):
 
 def register():
     signals.content_object_init.connect(share_post)
+
+


### PR DESCRIPTION
added share to linkedin support, I'll add some new features like enable/disable links and order settings (all optional with default values) via pelicanconf.py


salu2.