### PR TITLE
org_reader: Correct date format info in README

### DIFF
--- a/org_reader/README.md
+++ b/org_reader/README.md
@@ -16,7 +16,7 @@ Publish Emacs Org files alongside the rest of your website or blag.
 To provide metadata to Pelican, provide the following header in your Org file:
 
 	#+TITLE: The Title Of This BlogPost
-	#+DATE: 2001-01-01
+	#+DATE: <2001-01-01>
 	#+CATEGORY: comma, separated, list, of, tags
 
 The slug is automatically the filename of the Org file.


### PR DESCRIPTION
It is necessary to use a date format org understands. Therefore the `<>` around the date. Otherwise it won't be recognized as org-property and the date will always be set to 11 January 2030. 