### PR TITLE
Add always_modified plugin

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -36,6 +36,8 @@ Plugin descriptions
 ========================  ===========================================================
 Plugin                    Description
 ========================  ===========================================================
+Always modified           Copy created date metadata into modified date for easy "latest updates" indexes
+
 AsciiDoc reader           Use AsciiDoc to write your posts.
 
 Asset management          Use the Webassets module to manage assets such as CSS and JS files.

--- a/always_modified/README.md
+++ b/always_modified/README.md
@@ -1,0 +1,14 @@
+# Always Modified
+
+Say you want to sort by modified date/time in a theme template, but not all
+your articles have modified date/timestamps explicitly defined in article
+metadata. This plugin facilitates that sorting by assuming the modified date
+(if undefined) is equal to the created date.
+
+## Usage
+
+1. Add ALWAYS_MODIFIED = True to your settings file.
+2. Now you can sort by modified date in your templates:
+
+    {% for article in articles|sort(reverse=True,attribute='modified') %}
+

--- a/always_modified/__init__.py
+++ b/always_modified/__init__.py
@@ -1,0 +1,1 @@
+from .always_modified import *

--- a/always_modified/always_modified.py
+++ b/always_modified/always_modified.py
@@ -1,0 +1,20 @@
+"""
+If "modified" date/time is not defined in article metadata, fall back to the "created" date.
+"""
+
+from pelican import signals
+from pelican.contents import Content, Article
+
+def add_modified(content):
+    if not isinstance(content, Article):
+        return
+    
+    if not content.settings.get('ALWAYS_MODIFIED', False):
+        return
+
+    if hasattr(content, 'date') and not hasattr(content, 'modified'):
+        content.modified = content.date
+        content.locale_modified = content.locale_date
+    
+def register():
+    signals.content_object_init.connect(add_modified)


### PR DESCRIPTION
Say you want to sort by *modified* date/time in a theme template, but not all your articles have modified date/timestamps explicitly defined in article metadata. This plugin facilitates this sorting by assuming the modified date (if undefined) is equal to the created date. _[Description edited as noted below —J.]_