### PR TITLE
Fixed usage of `iter_commits` in `git-wrapper.py`

### DIFF
--- a/filetime_from_git/git_wrapper.py
+++ b/filetime_from_git/git_wrapper.py
@@ -106,7 +106,7 @@ class _GitWrapper(_GitWrapperCommon):
 
             Alternatively enabling GIT_FILETIME_FOLLOW may also make your problem go away.
         '''
-        return list(self.repo.iter_commits(path=path))
+        return list(self.repo.iter_commits(paths=path))
 
     @staticmethod
     def get_commit_date(commit, tz_name):


### PR DESCRIPTION
GitPython renamed the method `commits` of object `Repo` to `iter_commits`. This
has been adressed in commit 47269dd35b9236de7fc84fa99fb9e41c8d975c05

But additionally the attribute `path` has been changed to `paths`. This has
been omitted in the previous commit and is fixed here.

See also [this comment by @a3nm][1].

[1]: https://github.com/getpelican/pelican-plugins/issues/384#issuecomment-68179848