### PR TITLE
Add org_pandoc_reader submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 [submodule "loadcsv"]
 	path = loadcsv
 	url = https://github.com/e9t/pelican-loadcsv
+[submodule "org_pandoc_reader"]
+	path = org_pandoc_reader
+	url = https://github.com/jo-tham/org_pandoc_reader.git


### PR DESCRIPTION
Slight adaptation of [pandoc_reader](https://github.com/liob/pandoc_reader) for independent support of emacs org mode files.