### PR TITLE
Add missing PagesGenerator import to Summary plugin

### DIFF
--- a/summary/summary.py
+++ b/summary/summary.py
@@ -8,7 +8,7 @@ body of your articles.
 
 from __future__ import unicode_literals
 from pelican import signals
-from pelican.generators import ArticlesGenerator, StaticGenerator
+from pelican.generators import ArticlesGenerator, StaticGenerator, PagesGenerator
 
 def initialized(pelican):
     from pelican.settings import DEFAULT_CONFIG


### PR DESCRIPTION
The summary plugin crashed for me due to missing PagesGenerator import. importing it explicitly Resolves the issue