### PR TITLE
Update plugin to enhance privacy with video embeds

### DIFF
--- a/video_privacy_enhancer/Readme.md
+++ b/video_privacy_enhancer/Readme.md
@@ -30,20 +30,42 @@ I'm also grateful to the authors of the plugins in the pelican-plugins repo; bei
 
 YouTube videos that are embedded in a website are capable of placing a cookie (or using other tracking methods) on a visitor's computer even if that visitor does not play the movie. For certain sites that deal with political or other potentially sensitive topics, this automatic tracking could raise privacy concerns among users. Thus, this plugin fetches and stores, on your server, a copy of the thumbnail image of each embedded YouTube video on your website. It then displays that image instead of the video until the user "opts-in" to watching the video by clicking on the thumbnail (at which point the image is replaced by the youtube embed iframe).
 
-This plugin allows the shortcode **`!youtube(video_id)`** (for example, `!youtube(2XID_W4neJo)` for the video available at [https://www.youtube.com/watch?v=2XID_W4neJo](https://www.youtube.com/watch?v=2XID_W4neJo)) to be used in any Pelican page or article. During the `make html` process, the plugin will find every instance of the shortcode, and for each instance, will automatically download the video's thumbnail from YouTube if it hasn't been downloaded previously, and will save the thumbnail to the Pelican output folder (by default, to /output/images/youtube-thumbnails). It will then replace the shortcode with the thumbnail image. A jQuery script then watches for thumbnail image clicks; when a user clicks a thumbnail image, the jQuery script will fade the image out, and replace it with the actual youtube video iframe.
+This plugin allows video shortcodes to be used in any Pelican page or article.
+
+The currently-allowed shortcodes are as follows:
+
+* **YouTube:** `!youtube(video_id)`
+* **Vimeo:** `!vimeo(video_id)`
+
+For example, `!youtube(2XID_W4neJo)` can be used to embed and privacy-protect the video available at [https://www.youtube.com/watch?v=2XID_W4neJo](https://www.youtube.com/watch?v=2XID_W4neJo). During the `make html` process, the plugin will find every instance of each supported shortcode, and for each instance, will automatically download the video's thumbnail if it hasn't been downloaded previously, and will save the thumbnail to the Pelican output folder (by default, to /output/images/video-thumbnails). It will then replace the shortcode with the thumbnail image. A jQuery script then watches for thumbnail image clicks; when a user clicks a thumbnail image, the jQuery script will fade the image out, and replace it with the actual video iframe.
 
 YouTube does have a ["privacy-enhanced mode"](https://support.google.com/youtube/answer/171780?expand=PrivacyEnhancedMode#privacy) that purports not to place cookies on a user's page until the user clicks on a video. However, if you are a website author who wants to *ensure* that no cookies are initially placed, this plugin puts that power in your hands.
 
 
 ## Usage
 
-`!youtube(2XID_W4neJo)` written anywhere in the content of a page or post will become `<img class="youtube-embed-dummy-image" id="2XID_W4neJo" src="YOUR_SITEURL/images/youtube-thumbnails/2XID_W4neJo.jpg" alt="Embedded Video - Click to view" title="Embedded Video - Click to view"></img>` during the `make html` process ('YOUR_SITEURL' is replaced by your actual `SITEURL` from pelicanconf.py). The plugin will take care of downloading `2XID_W4neJo.jpg`.
+`!youtube(2XID_W4neJo)` written anywhere in the content of a page or post will become `<img class="video-embed-dummy-image" id="2XID_W4neJo" src="YOUR_SITEURL/images/video-thumbnails/2XID_W4neJo.jpg" alt="Embedded Video - Click to view" title="Embedded Video - Click to view"></img>` during the `make html` process ('YOUR_SITEURL' is replaced by your actual `SITEURL` from pelicanconf.py). The plugin will take care of downloading `2XID_W4neJo.jpg`.
 
-The plugin comes with an example jQuery file to copy into your theme's static folder. **With this jQuery script, anytime a thumbnail image is clicked by a user, the thumbnail will fade out and then be replaced by the actual video embed.** Thus, the `<img>...</img>` code above will become `<iframe width="853" height="480" src="//www.youtube-nocookie.com/embed/2XID_W4neJo" frameborder="0" allowfullscreen></iframe>` when clicked.
+The plugin comes with an example jQuery file to copy into your theme's static folder. **With this jQuery script, anytime a thumbnail image is clicked by a user, the thumbnail will fade out and then be replaced by the actual video embed.** Thus, the `<img>...</img>` code above will become `<iframe width="853" height="480" src="https://www.youtube-nocookie.com/embed/2XID_W4neJo" frameborder="0" allowfullscreen></iframe>` when clicked.
 
 To set the plugin up, just read the instructions at the top of youtube_privacy_enhancer.py. That file also includes some example CSS to copy into your theme's CSS file, as well as a setting or two for you to look over.
+
+**If you would like to add support for a new video service,** there are just a few steps:
+
+1. Look up how to download the thumbnail for a video from that service (e.g., through searching through the documentation for that service).
+2. Write a function in video_service_thumbnail_url_generating_functions.py (you can use one of the existing functions there as a template) that, when given the ID of a video from that service, will give back the URL for that video's thumbnail.
+3. Add the video service's name, shortcode, and name of the function you just created to the dictionary in the "SETTINGS" section of video_privacy_enhancer.py (you can use the existing entries in the dictionary as templates).
+4. Add the video service's name and URL to embed videos for it (you can find this using the "Share" button in many video websites) to the jQuery code that you copied from `video_privacy_enhancer_jQuery.js` when you first set up the plugin by following the instructions at the top of video_privacy_enhancer.py.
 
 
 ## To Do
 
-As noted in an EFF [blog post](https://www.eff.org/deeplinks/2010/08/upgrade-mytube "EFF blog post about updates to MyTube"), the Drupal MyTube plugin from which this plugin takes its idea is capable of handling videos not only from YouTube, but also from Vimeo, Comedy Central, and other sites. It would be nice to expand this Pelican plugin in the future to do the same. In addition, the code could likely be refactored to make extending the plugin easier.
+As noted in an EFF [blog post](https://www.eff.org/deeplinks/2010/08/upgrade-mytube "EFF blog post about updates to MyTube"), the Drupal MyTube plugin from which this plugin takes its idea is capable of handling videos not only from YouTube and Vimeo but also Comedy Central and other sites. It would be nice to expand this Pelican plugin in the future to do the same.
+
+## Changelog
+
+* 2015-07-16: 
+	* Added support for Vimeo videos, refactored all of the code to make it easier to extend the plugin for new video services in the future.
+	* **NOTE WELL:** If you were using this plugin before this change, please note that several changes have been made that may require you to update your Pelican site:
+		1. The example CSS has changed to use 'embedded_privacy_video' instead of 'embedded_youtube_video', as well as 'video-embed-dummy-image' instead of 'youtube-embed-dummy-image'.
+		2. The default thumbnail directory has been changed from 'youtube-thumbnails' to 'video-thumbnails'.

--- a/video_privacy_enhancer/video_privacy_enhancer.py
+++ b/video_privacy_enhancer/video_privacy_enhancer.py
@@ -10,128 +10,170 @@ For more information on this plugin, please see the attached Readme.md file.
 """
 
 """
-SETTINGS
+LIBRARIES FOR PYTHON TO USE
 """
-
-# Do not use a leading or trailing slash below (e.g., use "images/video-thumbnails"):
-output_directory_for_thumbnails = "images/video-thumbnails"
-
-""" 
-In order for this plugin to work optimally, you need to do just a few things:
-
-1. Enable the plugn in pelicanconf.py (see http://docs.getpelican.com/en/3.3.0/plugins.html for documentation):  
-    PLUGIN_PATH = "/pelican-plugins"  
-    PLUGINS = ["video_privacy_enhancer"]
-
-2a. If necessary, install jQuery on your site (See https://stackoverflow.com/questions/1458349/installing-jquery -- the jQuery base file should go into your Pelican themes 'static' directory)
-
-2b. Copy the jQuery file in this folder into, for example, your_theme_folder/static/video_privacy_enhancer_jQuery.js, and add a line like this to the <head></head> element of your website's base.html (or equivalent) template:
-    `<script src="{{ SITEURL }}/theme/video_privacy_enhancer_jquery.js"></script> <!--Load jQuery functions for the Video Privacy Enhancer Pelican plugin -->`
-
-3. Choose a default video embed size and add corresponding CSS to your theme's CSS file:
-
-Youtube allows the following sizes in its embed GUI (as of this writing, in March 2014). I recommend choosing one, and then having the iframe for the actual video embed match it (so that it's a seamless transition). This can be handled with CSS in both cases, so I haven't hard-coded it here:
-    1280 W x 720 H
-    853 W x 480 H
-    640 W x 360 H
-    560 W x 315 H
-
-Here's an example to add to your CSS file:
-
-```
-/* For use with the video-privacy-enhancer Pelican plugin */
-img.video-embed-dummy-image.
-iframe.embedded_youtube_video {
-    width: 843px;
-    max-height: 480px;
-
-    /* Center the element on the screen */
-    display: block;
-    margin-top: 2em;
-    margin-bottom: 2em;
-    margin-left: auto;
-    margin-right: auto;
-}
-iframe.embedded_youtube_video {
-    width: 843px;
-    height: 480px;
-}
-```
-
-"""
-
-
-"""
-END SETTINGS
-"""
-
 
 from pelican import signals # For making this plugin work with Pelican.
 
 import os.path # For checking whether files are present in the filesystem.
 
 import re # For using regular expressions.
-import urllib # For downloading the video thumbnails.
 
 import logging
 logger = logging.getLogger(__name__) # For using logger.debug() to log errors or other notes.
 
+import urllib 
+
+import video_service_thumbnail_url_generating_functions as video_thumbnail_functions # These are functions defined in 'video_service_thumbnail_url_generating_functions.py', which is located in the same directory as this file. 
+
+"""
+END OF LIBRARIES
+"""
+
+"""
+SETTINGS
+"""
+
+# Do not use a leading or trailing slash below (e.g., use "images/video-thumbnails"):
+output_directory_for_thumbnails = "images/video-thumbnails"
+
+# See the note above re: adding support for other video services to this list.
+supported_video_services = {
+	"youtube": {
+		"shortcode_not_including_exclamation_point": "youtube",
+		"function_for_generating_thumbnail_url": video_thumbnail_functions.generate_thumbnail_download_link_youtube,
+	},
+	"vimeo": {
+		"shortcode_not_including_exclamation_point": "vimeo",
+		"function_for_generating_thumbnail_url": video_thumbnail_functions.generate_thumbnail_download_link_vimeo,
+	},
+}
+
+""" 
+In order for this plugin to work optimally, you need to do just a few things:
+
+1. Enable the plugn in pelicanconf.py (see http://docs.getpelican.com/en/3.3.0/plugins.html for documentation):  
+	PLUGIN_PATH = "/pelican-plugins"  
+	PLUGINS = ["video_privacy_enhancer"]
+
+2a. If necessary, install jQuery on your site (See https://stackoverflow.com/questions/1458349/installing-jquery -- the jQuery base file should go into your Pelican themes 'static' directory)
+
+2b. Copy the jQuery file in this folder into, for example, your_theme_folder/static/video_privacy_enhancer_jQuery.js, and add a line like this to the <head></head> element of your website's base.html (or equivalent) template:
+	`<script src="{{ SITEURL }}/theme/video_privacy_enhancer_jquery.js"></script> <!--Load jQuery functions for the Video Privacy Enhancer Pelican plugin -->`
+
+3. Choose a default video embed size and add corresponding CSS to your theme's CSS file:
+
+Youtube allows the following sizes in its embed GUI (as of this writing, in March 2014). I recommend choosing one, and then having the iframe for the actual video embed match it (so that it's a seamless transition). This can be handled with CSS in both cases, so I haven't hard-coded it here:
+	1280 W x 720 H
+	853 W x 480 H
+	640 W x 360 H
+	560 W x 315 H
+
+Here's an example to add to your CSS file:
+
+```
+/* For use with the video-privacy-enhancer Pelican plugin */
+img.video-embed-dummy-image,
+iframe.embedded_privacy_video {
+	width: 853px;
+	max-height: 480px;
+
+	/* Center the element on the screen */
+	display: block;
+	margin-top: 2em;
+	margin-bottom: 2em;
+	margin-left: auto;
+	margin-right: auto;
+}
+iframe.embedded_privacy_video {
+	width: 843px;
+	height: 480px;
+}
+```
+
+"""
+
+"""
+END SETTINGS
+"""
 
 # A function to check whtether output_directory_for_thumbnails (a variable set above in the SETTINGS section) exists. If it doesn't exist, we'll create it.
 def check_for_thumbnail_directory(pelican_output_path):
-    # Per http://stackoverflow.com/a/84173, check if a file exists. isfile() works on files, and exists() works on files and directories.
-    try:
-        if not os.path.exists(pelican_output_path + "/" + output_directory_for_thumbnails): # If the directory doesn't exist already...
-            os.makedirs(pelican_output_path + "/" + output_directory_for_thumbnails) # Create the directory to hold the video thumbnails.
-            return True
-    except:
-        print logger.debug("Error in checking if thumbnail folder exists and making the directory if it doesn't.") # In case something goes wrong.
-        return False
+	# Per http://stackoverflow.com/a/84173, check if a file exists. isfile() works on files, and exists() works on files and directories.
+	try:
+		if not os.path.exists(pelican_output_path + "/" + output_directory_for_thumbnails): # If the directory doesn't exist already...
+			os.makedirs(pelican_output_path + "/" + output_directory_for_thumbnails) # Create the directory to hold the video thumbnails.
+			return True
+	except Exception as e:
+		logger.error("Video Privacy Enhancer Plugin: Error in checking if thumbnail folder exists and making the directory if it doesn't: %s", e) # In case something goes wrong.
+		return False
 
 
-# A function to download the video thumbnail from YouTube (currently the only supported video platform):
-def download_thumbnail(video_id_from_shortcode, pelican_output_path):
-    # Check if the thumbnail directory exists already:
-    check_for_thumbnail_directory(pelican_output_path)
-    
-    # Check if the thumbnail for this video exists already (if it's been previously downloaded). If it doesn't, download it:
-    if not os.path.exists(pelican_output_path + "/" + output_directory_for_thumbnails + "/" + video_id_from_shortcode + ".jpg"): # If the thumbnail doesn't already exist...
-        urllib.urlretrieve("https://img.youtube.com/vi/" + video_id_from_shortcode + "/0.jpg", pelican_output_path + "/" + output_directory_for_thumbnails + "/" + video_id_from_shortcode + ".jpg") # Download the thumbnail. This follows the instructions at http://www.reelseo.com/youtube-thumbnail-image/ for downloading YouTube thumbnail images.
+def download_thumbnail(video_id_from_shortcode, video_thumbnail_url, video_service_name, pelican_output_path):
+	# Check if the thumbnail directory exists already:
+	check_for_thumbnail_directory(pelican_output_path)
+	
+	# Check if the thumbnail for this video exists already (if it's been previously downloaded). If it doesn't, download it:
+	if not os.path.exists(pelican_output_path + "/" + output_directory_for_thumbnails + "/" + video_service_name + "_" + video_id_from_shortcode + ".jpg"): # If the thumbnail doesn't already exist...
+		urllib.urlretrieve(video_thumbnail_url, pelican_output_path + "/" + output_directory_for_thumbnails + "/" + video_service_name + "_" + video_id_from_shortcode + ".jpg") # Download the thumbnail. This follows the instructions at http://www.reelseo.com/youtube-thumbnail-image/ for downloading YouTube thumbnail images.
 
 
-# A function to read through each page and post as it comes through from Pelican, find all instances of `!youtube(...)`, and change it into an HTML <img> element with the video thumbnail.
-def process_youtube_shortcodes(data_passed_from_pelican):
-    if data_passed_from_pelican._content: # If the item passed from Pelican has a "content" attribute (i.e., if it's not an image file or something else like that). NOTE: data_passed_from_pelican.content (without an underscore in front of 'content') seems to be read-only, whereas data_passed_from_pelican._content is able to be overwritten. This is somewhat explained in an IRC log from 2013-02-03 from user alexis to user webdesignhero_ at https://botbot.me/freenode/pelican/2013-02-01/?tz=America/Los_Angeles.
-        full_content_of_page_or_post = data_passed_from_pelican._content
-    else:
-        return # Exit the function, essentially passing over the (non-text) file.
+# A function to read through each page and post as it comes through from Pelican, find all instances of a shortcode (e.g., `!youtube(...)`) and change it into an HTML <img> element with the video thumbnail.
+# 'dictionary_of_services' below should be the dictionary defined in the settings above, which includes the service's name as the dictionary key, and, for each service, has a dictionary containing 'shortcode_to_search_for_not_including_exclamation_point' and 'function_for_generating_thumbnail_url'
+def process_shortcodes(data_passed_from_pelican):
+	dictionary_of_services = supported_video_services # This should be defined in the settings section above.
+	
+	# Good for debugging:
+	logger.debug("Video Privacy Enhancer Plugin: Using the following dictionary of video services:")
+	logger.debug(dictionary_of_services)
+	
+	if not data_passed_from_pelican._content: # If the item passed from Pelican has a "content" attribute (i.e., if it's not an image file or something else like that). NOTE: data_passed_from_pelican.content (without an underscore in front of 'content') seems to be read-only, whereas data_passed_from_pelican._content is able to be overwritten. This is somewhat explained in an IRC log from 2013-02-03 from user alexis to user webdesignhero_ at https://botbot.me/freenode/pelican/2013-02-01/?tz=America/Los_Angeles.
+		return # Exit the function, essentially passing over the (non-text) file.
+	
+	# Loop through services (e.g., youtube, vimeo), processing the output for each:
+	for video_service_name, video_service_information in dictionary_of_services.iteritems():
+		
+		# Good for debugging:
+		logger.debug("Video Privacy Enhancer Plugin: Currently processing the following video service information:")
+		logger.debug(video_service_name)
+		
+		logger.debug("Video Privacy Enhancer Plugin: The name of the current service being processed is '" + video_service_name + "'")
+		
+		shortcode_to_search_for_not_including_exclamation_point = video_service_information['shortcode_not_including_exclamation_point']
+		logger.debug("Video Privacy Enhancer Plugin: Currently looking for the shortcode '" + shortcode_to_search_for_not_including_exclamation_point + "'")
+		
+		function_for_generating_thumbnail_url = video_service_information['function_for_generating_thumbnail_url']
+		logger.debug("Video Privacy Enhancer Plugin: Using the following function name to get thumbnails for the current video service:")
+		logger.debug(function_for_generating_thumbnail_url)
+		
+		all_instances_of_the_shortcode = re.findall('\!' + shortcode_to_search_for_not_including_exclamation_point + '.*?\)', data_passed_from_pelican._content) # Use a regular expression to find every instance of, e.g., '!youtube' followed by anything up to the first matching ')'.
+		
+		if(len(all_instances_of_the_shortcode) > 0): # If the article/page HAS any shortcodes, go on. Otherwise, don't (to do so would inadvertantly wipe out the output content for that article/page).
+			replace_shortcode_in_text = "" # This just gives this an initial value before going into the loop below.
 
-    all_instances_of_the_youtube_shortcode = re.findall('\!youtube.*?\)', full_content_of_page_or_post) # Use a regular expression to find every instance of '!youtube' followed by anything up to the first matching ')'.
+			# Go through each shortcode instance that we found above, and parse it:
+			for shortcode_to_parse in all_instances_of_the_shortcode:
 
-    if(len(all_instances_of_the_youtube_shortcode) > 0): # If the article/page HAS any shortcodes, go on. Otherwise, don't (to do so would inadvertantly wipe out the output content for that article/page).
-        replace_shortcode_in_text = "" # This just gives this an initial value before going into the loop below.
-
-        # Go through each shortcode instance that we found above, and parse it:
-        for youtube_shortcode_to_parse in all_instances_of_the_youtube_shortcode:
-
-            video_id_from_shortcode = re.findall('(?<=youtube\().*?(?=\))', youtube_shortcode_to_parse)[0] # Get what's inside of the parentheses in '!youtube(...).'
-            
-            # print "Video ID is " + video_id_from_shortcode # Good for debugging purposes.
-            
-            # Use the Pelican pelicanconf.py settings:
-            pelican_output_path = data_passed_from_pelican.settings['OUTPUT_PATH']
-            pelican_site_url = data_passed_from_pelican.settings['SITEURL']
-
-            # Download the video thumbnail if it's not already on the filesystem:            
-            download_thumbnail(video_id_from_shortcode, pelican_output_path)
-
-            # Replace '!youtube(...)' with '<img>...</img>'. Note that the <img> is given a class that the jQuery file mentioned at the top of this file will watch over. Any time an image with that class is clicked, the jQuery function will trigger and turn it into the full video embed.
-            replace_shortcode_in_text = re.sub(r'\!youtube\(' + video_id_from_shortcode + '\)', r'<img class="youtube-embed-dummy-image" id="' + video_id_from_shortcode + '" src="' +  pelican_site_url + '/' + output_directory_for_thumbnails + '/' + video_id_from_shortcode + '.jpg" alt="Embedded Video - Click to view" title="Embedded Video - Click to view"></img>', full_content_of_page_or_post)
-
-        # Replace the content of the page or post with our now-updated content (having gone through all instances of the !youtube() shortcode and updated them all, exiting the loop above.
-        data_passed_from_pelican._content = replace_shortcode_in_text
+				video_id_from_shortcode = re.findall('(?<=' + shortcode_to_search_for_not_including_exclamation_point + '\().*?(?=\))', shortcode_to_parse)[0] # Get what's inside of the parentheses in, e.g., '!youtube(...).'
+				
+				# print "Video ID is " + video_id_from_shortcode # Good for debugging purposes.
+				
+				# Use the Pelican pelicanconf.py settings:
+				pelican_output_path = data_passed_from_pelican.settings['OUTPUT_PATH']
+				pelican_site_url = data_passed_from_pelican.settings['SITEURL']
+				
+				# Download the video thumbnail if it's not already on the filesystem:
+				video_thumbnail_url = function_for_generating_thumbnail_url(video_id_from_shortcode)
+				
+				download_thumbnail(video_id_from_shortcode, video_thumbnail_url, video_service_name, pelican_output_path)
+				
+				# Replace the shortcode (e.g., '!youtube(...)') with '<img>...</img>'. Note that the <img> is given a class that the jQuery file mentioned at the top of this file will watch over. Any time an image with that class is clicked, the jQuery function will trigger and turn it into the full video embed.
+				replace_shortcode_in_text = re.sub(r'\!' + shortcode_to_search_for_not_including_exclamation_point + '\(' + video_id_from_shortcode + '\)', r'<img class="video-embed-dummy-image" id="' + video_id_from_shortcode + '" src="' +  pelican_site_url + '/' + output_directory_for_thumbnails + '/' + video_service_name + '_' + video_id_from_shortcode + '.jpg" alt="Embedded Video - Click to view" title="Embedded Video - Click to view" embed-service="' + video_service_name + '"></img>', data_passed_from_pelican._content)
+				
+				# Replace the content of the page or post with our now-updated content (having gone through all instances of the shortcode and updated them all, exiting the loop above.
+				data_passed_from_pelican._content = replace_shortcode_in_text
 
 
 # Make Pelican work (see http://docs.getpelican.com/en/3.3.0/plugins.html#how-to-create-plugins):
 def register():
-    signals.content_object_init.connect(process_youtube_shortcodes)
+	signals.content_object_init.connect(process_shortcodes)

--- a/video_privacy_enhancer/video_privacy_enhancer_jquery.js
+++ b/video_privacy_enhancer/video_privacy_enhancer_jquery.js
@@ -1,17 +1,37 @@
 $(document).ready(function() {
 // NOTE WELL: This is wrapped in a `$(document).ready(function() {...})` function (i.e., a "Document Ready" function that starts a section that won't load until the rest of the document/page has loaded (i.e., is "ready")). HOWEVER, this makes it so that jQuery functions from different .js files here are not able to see and talk to functions within this Document Ready function. Within a Document Ready function, functions and variables lose global scope. See http://stackoverflow.com/a/6547906 for more information.
     
+///////////////////////////
+// SETTINGS
+///////////////////////////
+
+	// NOTE WELL: It's expected to use the code 'VIDEO_ID_GOES_HERE' in the URLs below where the video ID should go. This phrase will be replaced by the video id below.
+	// NOTE WELL: The URLS below should have 'http://' or 'https://' in front of them:
+	var dictionary_of_embed_urls_for_different_services = {
+		"youtube" : 'https://www.youtube-nocookie.com/embed/VIDEO_ID_GOES_HERE',
+		"vimeo" : 'https://player.vimeo.com/video/VIDEO_ID_GOES_HERE'
+	};
+
+///////////////////////////
+// END OF SETTINGS
+///////////////////////////
+
+
 // Whenever a link for an image created with the video_privacy_enhancer plugin is clicked, transform it into a video embed:
-$('body').on("click",'img.youtube-embed-dummy-image',function(event) // Whenever an image with the class "youtube-embed-dummy-image" is clicked...
+$('body').on("click",'img.video-embed-dummy-image',function(event) // Whenever an image with the class "video-embed-dummy-image" is clicked...
 	{
 	    // '$(this)' below refers to the image that's been clicked. Before we go down into the function below, where the definition/scope of '$(this)' will change, we'll set it in a variable so that we can refer to it within the function below.
 	    var image_that_was_clicked = $(this);
 	    
-	    var youtube_video_id = $(this).attr('id'); // This assumes that the img ID attribute is set to the youtube video id.
+	    var video_id = $(this).attr('id'); // This assumes that the img ID attribute is set to the (e.g., youtube, Vimeo, etc.) video id.
+		var service_name = $(this).attr('embed-service'); // This assumes that the 'embed-service' attribute is set to a name (e.g., youtube, vimeo), and that that name is in the dictionary below.
+		
+		
+		var src_for_this_video = dictionary_of_embed_urls_for_different_services[service_name].replace("VIDEO_ID_GOES_HERE", video_id);
 
-        // Fade out the image, and replace it with the iframe embed code for the actual YouTube video:
+        // Fade out the image, and replace it with the iframe embed code for the actual video:
 	    $(this).fadeOut(250, function() {
-	        image_that_was_clicked.replaceWith('<iframe class="embedded_youtube_video" src="//www.youtube-nocookie.com/embed/' + youtube_video_id + '" frameborder="0" allowfullscreen></iframe>') // This will automatically show again.
+	        image_that_was_clicked.replaceWith('<iframe class="embedded_privacy_video" src="' + src_for_this_video + '" frameborder="0" allowfullscreen></iframe>') // This will automatically show again.
 			}); // End fadeOut.
 	});
 

--- a/video_privacy_enhancer/video_service_thumbnail_url_generating_functions.py
+++ b/video_privacy_enhancer/video_service_thumbnail_url_generating_functions.py
@@ -1,0 +1,32 @@
+"""A function for each service to download the video thumbnail
+
+Each function should accept one argument (the video id from that service) and should return the download URL for the video's thumbnail.
+
+"""
+
+"""
+LIBRARIES
+"""
+
+import urllib # For downloading the video thumbnails. Not as clean as, e.g., the requests module, but installed by default in many Python distributions.
+
+import json
+
+"""
+END OF LIBRARIES
+"""
+
+def generate_thumbnail_download_link_youtube(video_id_from_shortcode):
+	"""Thumbnail URL generator for YouTube videos."""
+	
+	thumbnail_download_link="https://img.youtube.com/vi/" + video_id_from_shortcode + "/0.jpg"
+	return thumbnail_download_link
+
+def generate_thumbnail_download_link_vimeo(video_id_from_shortcode):
+	"""Thumbnail URL generator for Vimeo videos."""
+	
+	# Following the Vimeo API at https://developer.vimeo.com/api#video-request, we need to request the video's metadata and get the thumbnail from that. To do this, we'll use the requests module both to get and parse the JSON for this task.
+	video_metadata = urllib.urlopen("https://vimeo.com/api/v2/video/" + video_id_from_shortcode + ".json") # Download the video's metadata in JSON format.
+	video_metadata_parsed = json.load(video_metadata) # Parse the JSON
+	video_thumbnail_large_location = video_metadata_parsed[0]['thumbnail_large'] # Go into the JSON and get the URL of the thumbnail.
+	return video_thumbnail_large_location	


### PR DESCRIPTION
Updated the Video Privacy Enhancer plugin, which downloads thumbnails of videos so that users don't get tracking cookies embedded on their systems until they explicitly "opt-in" to watching the video by clicking the thumbnail, at which point the image is changed into the actual iframe video embed. YouTube and Vimeo are now both supported (with the shortcodes `!youtube(video_id)` and `!vimeo(video_id)`, respectively), and the plugin and its documentation are now *much* easier to extend for other video services.