### PR TITLE
render_math plugin: force_tls option, prepend protocol to CDN

### DIFF
--- a/render_math/Readme.md
+++ b/render_math/Readme.md
@@ -95,6 +95,8 @@ is less than `responsive_break` (see below) and if so, sets `align` to `left`, `
 when setting `responsive_align` to `True`. **Default Value**: 768
  * `process_summary`: [boolean] ensures math will render in summaries and fixes math in that were cut off.
 Requires [BeautifulSoup4](http://www.crummy.com/software/BeautifulSoup/bs4/doc/) be installed. **Default Value**: `True`
+ * `force_tls`: [boolean] forces mathjax script to load from cdn using https. If set to false, will use document.location.protocol
+**Default Value**: `False`
 
 #### Settings Examples
 Make math render in blue and displaymath align to the left:

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -69,8 +69,9 @@ def process_settings(pelicanobj):
     mathjax_settings['responsive_break'] = '768'  # The break point at which it math is responsively aligned (in pixels)
     mathjax_settings['mathjax_font'] = 'default'  # forces mathjax to use the specified font.
     mathjax_settings['process_summary'] = BeautifulSoup is not None  # will fix up summaries if math is cut off. Requires beautiful soup
+    mathjax_settings['force_tls'] = 'false'  # will force mathjax to be served by https - if set as False, it will only use https if site is served using https
 
-    # Source for MathJax: Works boths for http and https (see http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn)
+    # Source for MathJax
     mathjax_settings['source'] = "'//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
 
     # Get the user specified settings
@@ -148,7 +149,10 @@ def process_settings(pelicanobj):
         
         if key == 'responsive' and isinstance(value, bool):
             mathjax_settings[key] = 'true' if value else 'false'
-        
+
+	if key == 'force_tls' and isinstance(value, bool):
+            mathjax_settings[key] = 'true' if value else 'false'       
+ 
         if key == 'responsive_break' and isinstance(value, int):
             mathjax_settings[key] = str(value)
 

--- a/render_math/mathjax_script_template
+++ b/render_math/mathjax_script_template
@@ -10,9 +10,11 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
     }}
     
     var mathjaxscript = document.createElement('script');
+    var location_protocol = ({force_tls}) ? 'https' : document.location.protocol;
+    if (location_protocol !== 'http' && location_protocol !== 'https') location_protocol = 'https:';
     mathjaxscript.id = 'mathjaxscript_pelican_#%@#$@#';
-    mathjaxscript.type = 'text/javascript';
-    mathjaxscript.src = {source};
+    mathjaxscript.type = 'text/javascript'; 
+    mathjaxscript.src = location_protocol + {source};
     mathjaxscript[(window.opera ? "innerHTML" : "text")] =
         "MathJax.Hub.Config({{" +
         "    config: ['MMLorHTML.js']," +


### PR DESCRIPTION
Will not leave cdn protocol as a default value of the document's protocol. Now, user can force tls protocol and document protocol will be forceably pre-pended to CDN.