### PR TITLE
Add Pelican Persian date plugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "org_pandoc_reader"]
 	path = org_pandoc_reader
 	url = https://github.com/jo-tham/org_pandoc_reader.git
+[submodule "pelican_persian_date"]
+	path = pelican_persian_date
+	url = https://github.com/ziaa/pelican_persian_date.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -128,6 +128,8 @@ Pelican Gist tag          Easily embed GitHub Gists in your Pelican articles
 
 Pelican Page Order        Adds a ``page_order`` attribute to all pages if one is not defined.
 
+Pelican Persian date      Converts ``article.locale_date`` attribute from Gregorian calendar into Solar Hijri calendar which is the official calendar of Iran and Afghanistan.
+
 Pelican comment system    Allows you to add static comments to your articles
 
 Pelican Vimeo             Enables you to embed Vimeo videos in your pages and articles


### PR DESCRIPTION
This plugin converts `article.locale_date` attribute
from Gregorian calendar into [Solar Hijri calendar](https://en.wikipedia.org/wiki/Solar_Hijri_calendar) (AKA Jalali calendar, Persian calendar, Iranian calendar) which is the official calendar of Iran and Afghanistan.