### PR TITLE
Add exception for in-line encoded images

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -45,6 +45,9 @@ def content_object_init(instance):
                     img_path = img_path[10:]
                 elif img_path.startswith('/static'):
                     img_path = img_path[7:]
+                elif img_path.startswith('data:image'):
+                    # Image is encoded in-line (not a file).
+                    break
                 else:
                     logger.warning('Better Fig. Error: img_path should start with either {filename}, |filename| or /static')
 


### PR DESCRIPTION
Adds a simple exception for images which are encoded in-line (base64, etc). This allows Better Fig. to be used with the [Graphviz](http://blog.dornea.nu/2014/11/13/using-graphviz-with-pelican-and-liquid-tags/) plugin (which is exactly my use-case, heh).