### PR TITLE
Ability to hide mathjax message and render math in translations

### DIFF
--- a/render_math/Readme.md
+++ b/render_math/Readme.md
@@ -97,6 +97,8 @@ when setting `responsive_align` to `True`. **Default Value**: 768
 Requires [BeautifulSoup4](http://www.crummy.com/software/BeautifulSoup/bs4/doc/) be installed. **Default Value**: `True`
  * `force_tls`: [boolean] forces mathjax script to load from cdn using https. If set to false, will use document.location.protocol
 **Default Value**: `False`
+ * `message_style`: [string] This value controls the verbosity of the messages in the lower left-hand corner. Set it to `None` to eliminate all messages.
+**Default Value**: normal
 
 #### Settings Examples
 Make math render in blue and displaymath align to the left:

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -56,7 +56,7 @@ def process_settings(pelicanobj):
     # will be used for
 
     # Default settings
-    mathjax_settings['auto_insert'] = True  # if set to true, it will insert mathjax script automatically into content without needing to alter the template. 
+    mathjax_settings['auto_insert'] = True  # if set to true, it will insert mathjax script automatically into content without needing to alter the template.
     mathjax_settings['align'] = 'center'  # controls alignment of of displayed equations (values can be: left, right, center)
     mathjax_settings['indent'] = '0em'  # if above is not set to 'center', then this setting acts as an indent
     mathjax_settings['show_menu'] = 'true'  # controls whether to attach mathjax contextual menu
@@ -70,6 +70,7 @@ def process_settings(pelicanobj):
     mathjax_settings['mathjax_font'] = 'default'  # forces mathjax to use the specified font.
     mathjax_settings['process_summary'] = BeautifulSoup is not None  # will fix up summaries if math is cut off. Requires beautiful soup
     mathjax_settings['force_tls'] = 'false'  # will force mathjax to be served by https - if set as False, it will only use https if site is served using https
+    mathjax_settings['message_style'] = 'normal'  # This value controls the verbosity of the messages in the lower left-hand corner. Set it to "none" to eliminate all messages
 
     # Source for MathJax
     mathjax_settings['source'] = "'//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
@@ -108,6 +109,9 @@ def process_settings(pelicanobj):
 
         if key == 'show_menu' and isinstance(value, bool):
             mathjax_settings[key] = 'true' if value else 'false'
+
+        if key == 'message_style':
+            mathjax_settings[key] = value if value is not None else 'none'
 
         if key == 'auto_insert' and isinstance(value, bool):
             mathjax_settings[key] = value
@@ -244,7 +248,7 @@ def process_mathjax_script(mathjax_settings):
     """Load the mathjax script template from file, and render with the settings"""
 
     # Read the mathjax javascript template from file
-    with open (os.path.dirname(os.path.realpath(__file__)) 
+    with open (os.path.dirname(os.path.realpath(__file__))
             + '/mathjax_script_template', 'r') as mathjax_script_template:
         mathjax_template = mathjax_script_template.read()
 
@@ -333,7 +337,7 @@ def process_rst_and_summaries(content_generators):
 
     for generator in content_generators:
         if isinstance(generator, generators.ArticlesGenerator):
-            for article in generator.articles:
+            for article in generator.articles + generator.translations:
                 rst_add_mathjax(article)
                 #optionally fix truncated formulae in summaries.
                 if process_summary.mathjax_script is not None:

--- a/render_math/mathjax_script_template
+++ b/render_math/mathjax_script_template
@@ -8,12 +8,12 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
         indent = (screen.width < {responsive_break}) ? "0em" : indent;
         linebreak = (screen.width < {responsive_break}) ? 'true' : linebreak;
     }}
-    
+
     var mathjaxscript = document.createElement('script');
     var location_protocol = ({force_tls}) ? 'https' : document.location.protocol;
     if (location_protocol !== 'http' && location_protocol !== 'https') location_protocol = 'https:';
     mathjaxscript.id = 'mathjaxscript_pelican_#%@#$@#';
-    mathjaxscript.type = 'text/javascript'; 
+    mathjaxscript.type = 'text/javascript';
     mathjaxscript.src = location_protocol + {source};
     mathjaxscript[(window.opera ? "innerHTML" : "text")] =
         "MathJax.Hub.Config({{" +
@@ -24,6 +24,7 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
         "    displayAlign: '"+ align +"'," +
         "    displayIndent: '"+ indent +"'," +
         "    showMathMenu: {show_menu}," +
+        "    messageStyle: '{message_style}'," +
         "    tex2jax: {{ " +
         "        inlineMath: [ ['\\\\(','\\\\)'] ], " +
         "        displayMath: [ ['$$','$$'] ]," +


### PR DESCRIPTION
Two additions:

 1. User can now control message_style attribute of mathjax
 2. Translations are now also included for rendering math