### PR TITLE
Fix parsing of AsciiDoc attribute values by converting to unicode.

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -10,6 +10,7 @@ File extension should be ``.asc``, ``.adoc``, or ``asciidoc``.
 from pelican.readers import BaseReader
 from pelican.utils import pelican_open
 from pelican import signals
+import six
 
 try:
     # asciidocapi won't import on Py3
@@ -51,7 +52,7 @@ class AsciiDocReader(BaseReader):
         metadata = {}
         for name, value in ad.asciidoc.document.attributes.items():
             name = name.lower()
-            metadata[name] = self.process_metadata(name, value)
+            metadata[name] = self.process_metadata(name, six.text_type(value))
         if 'doctitle' in metadata:
             metadata['title'] = metadata['doctitle']
         return content, metadata

--- a/asciidoc_reader/test_asciidoc_reader.py
+++ b/asciidoc_reader/test_asciidoc_reader.py
@@ -41,7 +41,10 @@ class AsciiDocReaderTest(unittest.TestCase):
         }
 
         for key, value in expected.items():
-            self.assertEqual(value, page.metadata[key], key)
+            self.assertEqual(value, page.metadata[key], (
+                'Metadata attribute \'%s\' does not match expected value.\n'
+                'Expected: %s\n'
+                'Actual: %s') % (key, value, page.metadata[key]))
 
     def test_article_with_asc_options(self):
         # test to ensure the ASCIIDOC_OPTIONS is being used
@@ -58,3 +61,7 @@ class AsciiDocReaderTest(unittest.TestCase):
                     'the lazy dog&#8217;s back.</p>'
                     '</div>\n</div>\n</div>\n')
         self.assertEqual(page.content, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Currently, the AsciiDoc plugin's handling of attributes does not work with list values, such as tags. For example, the unit test currently gives the following error:

```
$ python2 -m asciidoc_reader.test_asciidoc_reader
F.
======================================================================
FAIL: test_article_with_asc_extension (__main__.AsciiDocReaderTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/media/D/Projects/Active/blog/pelican-plugins/asciidoc_reader/test_asciidoc_reader.py", line 47, in test_article_with_asc_extension
    'Actual: %s') % (key, value, page.metadata[key]))
AssertionError: Metadata attribute 'tags' does not match expected value.
Expected: [u'Linux', u'Python', u'Pelican']
Actual: [<Tag 'L'>, <Tag 'i'>, <Tag 'n'>, <Tag 'u'>, <Tag 'x'>, <Tag ','>, <Tag 'P'>, <Tag 'y'>, <Tag 't'>, <Tag 'h'>, <Tag 'o'>, <Tag 'e'>, <Tag 'l'>, <Tag 'c'>, <Tag 'a'>]

----------------------------------------------------------------------
Ran 2 tests in 0.325s

FAILED (failures=1)
```

This is because [ensure_metadata_list](https://github.com/getpelican/pelican/blob/master/pelican/readers.py#L70) in readers.py expects a value of type [six.text_type]( http://pythonhosted.org/six/#six.text_type), which is unicode in Python 2. However, the value returned from the AsciiDoc API is of type str, so it's treated as an iterable directly. Instead of being split on semicolons or commas, the tag attribute is split into individual characters.

This PR fixes this by converting attribute values returned from the AsciiDoc API into six.text_type. The unit test passes after the fix:

```
$ python2 -m asciidoc_reader.test_asciidoc_reader
..
----------------------------------------------------------------------
Ran 2 tests in 0.330s

OK
```