### PR TITLE
share_post: Reverting removal of summary for the plugin to be usable

### DIFF
--- a/share_post/share_post.py
+++ b/share_post/share_post.py
@@ -27,11 +27,16 @@ def article_url(content):
     return quote(('%s/%s' % (site_url, content.url)).encode('utf-8'))
 
 
+def article_summary(content):
+    return quote(BeautifulSoup(content.summary, 'html.parser').get_text().strip().encode('utf-8'))
+
+
 def share_post(content):
     if isinstance(content, contents.Static):
         return
     title = article_title(content)
     url = article_url(content)
+    summary = article_summary(content)
 
     tweet = ('%s%s%s' % (title, quote(' '), url)).encode('utf-8')
     diaspora_link = 'https://sharetodiaspora.github.io/?title=%s&url=%s' % (title, url)


### PR DESCRIPTION
Otherwise code would not compile (`summary` variable is still used)

Closes #549 