### PR TITLE
liquid_tags: Add soundcloud plugin

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -51,7 +51,15 @@ To insert a Flickr image to a post, follow these steps:
 3. Add FLICKR_API_KEY to your config
 4. Add this to your document:
 
-    {% flickr image_id [small|medium|large] ["alt text"|'alt text'] %}
+    ``{% flickr image_id [small|medium|large] ["alt text"|'alt text'] %}``
+
+## Soundcloud Tag
+To insert a Soundcloud Widget to a post, follow these steps:
+
+1. Enable ``liquid_tags.soundcloud``
+2. Add this to your document:
+
+    ``{% soundcloud track_url %}``
 
 ## Youtube Tag
 To insert youtube video into a post, enable the

--- a/liquid_tags/soundcloud.py
+++ b/liquid_tags/soundcloud.py
@@ -1,0 +1,59 @@
+"""
+Soundcloud Tag
+--------------
+This implements a Liquid-style soundcloud tag for Pelican.
+
+It asks the official Soundcloud-API for the widget html code.
+
+Syntax
+------
+`{% soundcloud track_url %}`
+
+Example
+-------
+`{% soundcloud https://soundcloud.com/luftmentsh/hakotel %}`
+
+Output
+------
+`<iframe width="100%" height="400" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?visual=true&url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F33875102&show_artwork=true"></iframe>`
+"""
+from .mdx_liquid_tags import LiquidTags
+import re
+import json
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib import urlopen
+
+
+SYNTAX = '{% soundcloud track_url %}'
+PARSE_SYNTAX = re.compile(r'(?P<track_url>https?://soundcloud.com/[\S]+)')
+
+
+def get_widget(track_url):
+    r = urlopen(
+        'http://soundcloud.com/oembed',
+        data='format=json&url={}'.format(track_url).encode('utf-8'))
+
+    return json.loads(r.read().decode('utf-8'))['html']
+
+
+def match_it(markup):
+    match = PARSE_SYNTAX.search(markup)
+    if match:
+        return match.groupdict()
+    else:
+        raise ValueError('Error processing input. '
+                         'Expected syntax: {}'.format(SYNTAX))
+
+
+@LiquidTags.register('soundcloud')
+def soundcloud(preprocessor, tag, markup):
+    track_url = match_it(markup)['track_url']
+
+    return get_widget(track_url)
+
+
+# ---------------------------------------------------
+# This import allows image tag to be a Pelican plugin
+from liquid_tags import register

--- a/liquid_tags/test_soundcloud.py
+++ b/liquid_tags/test_soundcloud.py
@@ -1,0 +1,27 @@
+from . import soundcloud
+import pytest
+
+
+@pytest.mark.parametrize('input,expected', [
+    ('https://soundcloud.com/forss/in-paradisum',
+     dict(track_url='https://soundcloud.com/forss/in-paradisum')),
+    ('http://soundcloud.com/forss/in-paradisum',
+     dict(track_url='http://soundcloud.com/forss/in-paradisum')),
+    ('https://soundcloud.com/toroymoi/real-love-ft-kool-ad',
+     dict(track_url='https://soundcloud.com/toroymoi/real-love-ft-kool-ad')),
+    ('https://soundcloud.com/capturedtracks/sets/wild-nothing-nocturne',
+     dict(track_url=('https://soundcloud.com/capturedtracks/'
+                     'sets/wild-nothing-nocturne')))
+])
+def test_match_it(input, expected):
+    assert soundcloud.match_it(input) == expected
+
+
+@pytest.mark.parametrize('input', [
+    'http://foobar.com',
+    'foobar',
+    'https://google.com'
+])
+def test_match_it_exception(input):
+    with pytest.raises(ValueError):
+        soundcloud.match_it(input)


### PR DESCRIPTION
The soundcloud plugin uses the official soundcloud API to get the widget
html tag. Also added tests.