### PR TITLE
Fix tipue_search crash due to encoding mismatch

### DIFF
--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -64,7 +64,7 @@ class Tipue_Search_JSON_Generator(object):
 
     def create_tpage_node(self, srclink):
 
-        srcfile = open(os.path.join(self.output_path, self.tpages[srclink]))
+        srcfile = open(os.path.join(self.output_path, self.tpages[srclink]), encoding='utf-8')
         soup = BeautifulSoup(srcfile, 'html.parser')
         page_text = soup.get_text()
 


### PR DESCRIPTION
In korean windows environment, below error occur if use tipue_search.

```
CRITICAL: UnicodeDecodeError: 'cp949' codec can't decode byte 0xec in position 3786: illegal multibyte sequence
Traceback (most recent call last):
  File "c:\python34\Lib\runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python34\Lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\devel\libsora.so\.venv\Scripts\pelican.exe\__main__.py", line 9, in <module>
  File "c:\devel\libsora.so\.venv\lib\site-packages\pelican\__init__.py", line 456, in main
    pelican.run()
  File "c:\devel\libsora.so\.venv\lib\site-packages\pelican\__init__.py", line 183, in run
    p.generate_output(writer)
  File "C:\devel\libsora.so\ext\pelican-plugins\tipue_search\tipue_search.py", line 99, in generate_output
    self.create_tpage_node(srclink)
  File "C:\devel\libsora.so\ext\pelican-plugins\tipue_search\tipue_search.py", line 68, in create_tpage_node
    soup = BeautifulSoup(srcfile, 'html.parser')
  File "c:\devel\libsora.so\.venv\lib\site-packages\bs4\__init__.py", line 175, in __init__
    markup = markup.read()
UnicodeDecodeError: 'cp949' codec can't decode byte 0xec in position 3786: illegal multibyte sequence
```

In korean windows environment, system default encoding is cp949.
BeautifulSoup4 can't parse cp949 file directly. But with read-binary option, it can open cp949.
I think that changing "r"(default option) to "rb" doesn't affect behavior in other environment.