### PR TITLE
Relative import for code_include

### DIFF
--- a/code_include/__init__.py
+++ b/code_include/__init__.py
@@ -1,1 +1,1 @@
-from code_include import *
+from .code_include import *


### PR DESCRIPTION
This PR makes code_include plugin compatible with python3 import statement syntax.