### PR TITLE
tipue_search: fix also for template pages

### DIFF
--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -82,8 +82,8 @@ class Tipue_Search_JSON_Generator(object):
         node = {'title': page_title,
                 'text': page_text,
                 'tags': page_category,
-                'loc': page_url}
-        
+                'url': page_url}
+
         self.json_nodes.append(node)
 
 


### PR DESCRIPTION
The last update only fixed the index for articles, while leaving pages in the old format.