### PR TITLE
Add commas indicating tuple to example

### DIFF
--- a/pelican_comment_system/doc/avatars.md
+++ b/pelican_comment_system/doc/avatars.md
@@ -17,8 +17,8 @@ The `value` of the dictionary is the path to the specific avatar.
 ##### Example
 ```python
 PELICAN_COMMENT_SYSTEM_AUTHORS = {
-	('John'): "images/authors/john.png",
-	('Tom'): "images/authors/tom.png",
+	('John',): "images/authors/john.png",
+	('Tom',): "images/authors/tom.png",
 }
 ```
 


### PR DESCRIPTION
Added commas to indicate a tuple in the example. 
Without them, loading of known author avatar will fail (at least it did for me).