### PR TITLE
liquid_tags: gram plugin Python 3 compatibility

### DIFF
--- a/liquid_tags/gram.py
+++ b/liquid_tags/gram.py
@@ -38,7 +38,10 @@ Output
     <img src="http://photos-c.ak.instagram.com/hphotos-ak-xaf1/t51.2885-15/917172_604907902963826_254280879_n.jpg" width="450" title="warehouse window title" alt="alt text" class="test_class instagram">
 """
 import re
-import urllib
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib import urlopen
 from .mdx_liquid_tags import LiquidTags
 
 SYNTAX = '{% gram shortcode [size] [width] [class name(s)] [title text | "title text" ["alt text"]] %}'
@@ -59,7 +62,7 @@ def gram(preprocessor, tag, markup):
     match = ReGram.search(markup)
     if match:
         attrs = dict([(key, val.strip())
-                      for (key, val) in match.groupdict().iteritems() if val])
+                      for (key, val) in match.groupdict().items() if val])
     else:
         raise ValueError('Error processing input. '
                          'Expected syntax: {0}'.format(SYNTAX))
@@ -75,7 +78,7 @@ def gram(preprocessor, tag, markup):
         url = url+size
         del attrs['size']
 
-    r = urllib.urlopen(url)
+    r = urlopen(url)
 
     if(r.getcode()==404):
         raise ValueError('%s isnt a photo.'%shortcode)
@@ -93,7 +96,7 @@ def gram(preprocessor, tag, markup):
     #print('updated dict: '+repr(attrs))
 
     # Return the formatted text
-    return '<img src="{0}"{1}>'.format(gram_url,' '.join(' {0}="{1}"'.format(key,val) for (key,val) in attrs.iteritems()))
+    return '<img src="{0}"{1}>'.format(gram_url,' '.join(' {0}="{1}"'.format(key,val) for (key,val) in attrs.items()))
 
 #----------------------------------------------------------------------
 # This import allows image tag to be a Pelican plugin


### PR DESCRIPTION
There were a few things to change. I changed the import to get it
working under python3 for urlopen and used items() instead of iteritems().