### PR TITLE
Add Backref Translate plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -97,3 +97,6 @@
 [submodule "md-metayaml"]
 	path = md-metayaml
 	url = https://github.com/joachimneu/pelican-md-metayaml
+[submodule "backreftranslate"]
+	path = backreftranslate
+	url = https://github.com/daltonmatos/pelican-plugin-backref-translate

--- a/Readme.rst
+++ b/Readme.rst
@@ -44,6 +44,8 @@ Asset management          Use the Webassets module to manage assets such as CSS 
 
 Auto Pages                Generate custom content for generated Author, Category, and Tag pages (e.g. author biography)
 
+Backref Translate         Add a new attribute (``is_translation_of``) to every article/page (which is a translation) pointing back to the original article/page which is being translated
+
 Better code samples       Wraps all `table` blocks with a class attribute `.codehilitetable` in an additional `div` of class `.hilitewrapper`. It thus permits to style codeblocks better, especially to make them scrollable.
 
 Better figures/samples    Adds a `style="width: ???px; height: auto;"` attribute to any `<img>` tags in the content


### PR DESCRIPTION

Adding a simple plugin which links the translation page/article back to the translated page/article.