### PR TITLE
add post_revision plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -103,3 +103,6 @@
 [submodule "category_order"]
 	path = category_order
 	url = https://github.com/jhshi/pelican.plugins.category_order.git
+[submodule "post_revision"]
+	path = post_revision
+	url = https://github.com/jhshi/pelican.plugins.post_revision.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -154,6 +154,8 @@ Pin to top                Pin Pelican's article(s) to top "Sticky article"
 
 PlantUML                  Allows you to define UML diagrams directly into rst documents using the great PlantUML tool
 
+Post Revision             Extract article and page revision information from Git commit history.
+
 Post statistics           Calculates various statistics about a post and store them in an article.stats dictionary
 
 Random article            Generates a html file which redirect to a random article


### PR DESCRIPTION
Add post revision plugin, which enables you to show post revision history from Git commits.

See a live example here:

http://jhshi.me/2015/10/13/post-revision-plugin-for-pelican/index.html