### PR TITLE
Add category_order plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,3 +100,6 @@
 [submodule "backreftranslate"]
 	path = backreftranslate
 	url = https://github.com/daltonmatos/pelican-plugin-backref-translate
+[submodule "category_order"]
+	path = category_order
+	url = https://github.com/jhshi/pelican.plugins.category_order.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -52,6 +52,8 @@ Better figures/samples    Adds a `style="width: ???px; height: auto;"` attribute
 
 bootstrapify              Automatically add bootstraps default classes to your content, usefull for md generated tables
 
+Category Order            Order categories (and tags) by the number of articles in that category (or tag).
+
 CJK auto spacing          Inserts spaces between Chinese/Japanese/Korean characters and English words
 
 Clean summary             Cleans your summary of excess images


### PR DESCRIPTION
Sort categories (tags) by the number of articles in that category (tag).

See a live example here:

http://jhshi.me/blog/categories/index.html