### PR TITLE
Add ga_page_view plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -103,3 +103,6 @@
 [submodule "category_order"]
 	path = category_order
 	url = https://github.com/jhshi/pelican.plugins.category_order.git
+[submodule "ga_page_view"]
+	path = ga_page_view
+	url = https://github.com/jhshi/pelican.plugins.ga_page_view.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -124,6 +124,8 @@ Open graph                Generates Open Graph tags for your articles
 
 Optimize images           Applies lossless compression on JPEG and PNG images
 
+Page View                 Pull page view count from Google Analytics.
+
 PDF generator             Automatically exports RST articles and pages as PDF files
 
 PDF Images                If an img tag contains a PDF, EPS or PS file as a source, this plugin generates a PNG preview which will then act as a link to the original file.


### PR DESCRIPTION
This plugin pulls the page view information from Google Analytics and add the page view count as a meta of article or page.

See a live example here:

http://jhshi.me/

Note that each post has its own page view count.