### PR TITLE
Add Photos to the plugin list, plus minor improvements

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -148,6 +148,8 @@ Pelican YouTube           Enables you to embed YouTube videos in your pages and 
 
 pelicanfly                Lets you type things like `i ♥ :fa-coffee:` in your Markdown documents and have it come out as little Font Awesome icons in the browser
 
+Photos                    Add a photo or a gallery of photos to an article, or include photos in the body text. Resize photos as needed.
+
 Pin to top                Pin Pelican's article(s) to top "Sticky article"
 
 PlantUML                  Allows you to define UML diagrams directly into rst documents using the great PlantUML tool

--- a/photos/README.md
+++ b/photos/README.md
@@ -144,9 +144,9 @@ Add the following to the template `base.html`, before the closing HTML `</body>`
 
 ## Known use cases
 
-<pxquim.pt> uses Photos and the plug-in Sub-parts to publish 600 photo galleries with 40,000 photos. Photos keeps the high-resolution photos separate from the site articles.
+[pxquim.pt](http://pxquim.pt/) uses Photos and the plug-in Sub-parts to publish 600 photo galleries with 40,000 photos. Photos keeps the high-resolution photos separate from the site articles.
 
-<pxquim.com> uses sub-parts to cover conferences, where it makes sense to have a sub-part for each speaker.
+[pxquim.com](http://pxquim.com/) uses sub-parts to cover conferences, where it makes sense to have a sub-part for each speaker.
 
 ## Alternatives
 

--- a/photos/photos.py
+++ b/photos/photos.py
@@ -98,7 +98,9 @@ def detect_content(content):
         if what == 'photo':
             if value.startswith('/'):
                 value = value[1:]
-            path = os.path.join(settings['PHOTO_LIBRARY'], value)
+            path = os.path.join(
+                        os.path.expanduser(settings['PHOTO_LIBRARY']),
+                        value)
             if not os.path.isfile(path):
                 logger.error('photos: No photo %s', path)
             else:
@@ -130,7 +132,9 @@ def detect_content(content):
 def process_gallery_photo(generator, article, gallery):
     if gallery.startswith('/'):
         gallery = gallery[1:]
-    dir_gallery = os.path.join(generator.settings['PHOTO_LIBRARY'], gallery)
+    dir_gallery = os.path.join(
+                    os.path.expanduser(generator.settings['PHOTO_LIBRARY']),
+                    gallery)
     if os.path.isdir(dir_gallery):
         logger.info('photos: Gallery detected: %s', gallery)
         dir_photo = os.path.join('photos', gallery.lower())
@@ -139,7 +143,7 @@ def process_gallery_photo(generator, article, gallery):
                            msg='photos: No EXIF for gallery %s')
         captions = read_notes(os.path.join(dir_gallery, 'captions.txt'))
         article.photo_gallery = []
-        for pic in os.listdir(dir_gallery):
+        for pic in sorted(os.listdir(dir_gallery)):
             if pic.startswith('.'): continue
             if pic.endswith('.txt'): continue
             photo = os.path.splitext(pic)[0].lower() + '.jpg'
@@ -158,6 +162,8 @@ def process_gallery_photo(generator, article, gallery):
                 os.path.join(dir_gallery, pic),
                 os.path.join(dir_thumb, thumb),
                 generator.settings['PHOTO_THUMB'])
+    else:
+        logger.error('photos: Gallery does not exist: %s at %s', gallery, dir_gallery)
 
 
 def process_gallery_filename(generator, article, gallery):
@@ -165,7 +171,9 @@ def process_gallery_filename(generator, article, gallery):
         gallery = gallery[1:]
     else:
         gallery = os.path.join(article.relative_dir, gallery)
-    dir_gallery = os.path.join(generator.settings['PHOTO_LIBRARY'], gallery)
+    dir_gallery = os.path.join(
+                    os.path.expanduser(generator.settings['PHOTO_LIBRARY']),
+                    gallery)
     if os.path.isdir(dir_gallery):
         logger.info('photos: Gallery detected: %s', gallery)
         dir_photo = gallery.lower()
@@ -174,7 +182,7 @@ def process_gallery_filename(generator, article, gallery):
                            msg='photos: No EXIF for gallery %s')
         captions = read_notes(os.path.join(dir_gallery, 'captions.txt'))
         article.photo_gallery = []
-        for pic in os.listdir(dir_gallery):
+        for pic in sorted(os.listdir(dir_gallery)):
             if pic.startswith('.'): continue
             if pic.endswith('.txt'): continue
             photo = pic.lower()
@@ -189,6 +197,8 @@ def process_gallery_filename(generator, article, gallery):
                 os.path.join(dir_gallery, pic),
                 os.path.join(dir_thumb, thumb),
                 generator.settings['PHOTO_THUMB'])
+    else:
+        logger.error('photos: Gallery does not exist: %s at %s', gallery, dir_gallery)
 
 
 def detect_gallery(generator):
@@ -206,7 +216,9 @@ def detect_gallery(generator):
 def process_image_photo(generator, article, image):
     if image.startswith('/'):
         image = image[1:]
-    path = os.path.join(generator.settings['PHOTO_LIBRARY'], image)
+    path = os.path.join(
+                os.path.expanduser(generator.settings['PHOTO_LIBRARY']),
+                image)
     if os.path.isfile(path):
         photo = os.path.splitext(image)[0].lower() + 'a.jpg'
         thumb = os.path.splitext(image)[0].lower() + 't.jpg'


### PR DESCRIPTION
Following suggestions by Stéphane Goujet:

- PHOTO_LIBRARY accepts tilde syntax, such as ~/Pictures.
- Missing galleries report an error.
- Photos are always sorted galleries, instead of just on Mac OS X.
- Markdown deviant syntax was fixed.