### PR TITLE
better_figures_and_images: bug fix: broken path by os.path.join()

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -55,9 +55,17 @@ def content_object_init(instance):
                 # search src path list
                 # 1. Build the source image filename from PATH
                 # 2. Build the source image filename from STATIC_PATHS
+
+                # if img_path start with '/', remove it.
+                img_path = os.path.sep.join([el for el in img_path.split("/") if len(el) > 0])
+
+                # style: {filename}/static/foo/bar.png
                 src = os.path.join(instance.settings['PATH'], img_path, img_filename)
                 src_candidates = [src]
+
+                # style: {filename}../static/foo/bar.png
                 src_candidates += [os.path.join(instance.settings['PATH'], static_path, img_path, img_filename) for static_path in instance.settings['STATIC_PATHS']]
+
                 src_candidates = [f for f in src_candidates if path.isfile(f) and access(f, R_OK)]
 
                 if not src_candidates:


### PR DESCRIPTION
my static file syntax, 
`{filename}../static/sample/sidetail-sora.gif`
```
path = '/home/haruna/devel/libsora.so/content'
image_path = '../static/sample'
image_filename = 'sidetail-sora.gif'

os.path.join(path, image_path, image_filename)
# /home/haruna/devel/libsora.so/content/../static/sample/sidetail-sora.gif
```

Pelican original static file syntax,
`{filename}/static/sample/sidetail-sora.gif`
```
path = '/home/sora/devel/libsora.so/content'
image_path = '/static/sample'
image_filename = 'sidetail-sora.gif'

os.path.join(path, image_path, image_filename)
# /static/sample/sidetail-sora.gif
# lost path information
```

os.path.join ignore previous path if path element is absolute path.
so, if img_path start with '/', os.path.join is broken. so remove first '/'.

This bug is caused by me. 
I did't use standard static file syntax.
My previous pull request works on only my document.

Previous code is `src = instance.settings['PATH'] + img_path + '/' + img_filename`
I replace this code to `os.path.join()`.

@xenithorb test fixed code and works well.
@justinmayer would you check this commit?

Related link
* https://github.com/getpelican/pelican-plugins/pull/599