### PR TITLE
Fix the pdf plugin's documentation

### DIFF
--- a/pdf/Readme.rst
+++ b/pdf/Readme.rst
@@ -11,15 +11,22 @@ Requirements
 You should ensure you have the ``rst2pdf`` module installed::
 
 	pip install rst2pdf
-	
+
 Usage
 -----
-In order to use this plugin you should add the following to your config file::
+To customize the pdf output, you can use the following settings in your
+configuration file::
 
 	PDF_STYLE = ''
 	PDF_STYLE_PATH = ''
 
+``PDF_STYLE_PATH`` defines a new path where rst2pdf will look for style sheets,
+while ``PDF_STYLE`` defines which style you want to use. For a description of
+the available styles, please read `rst2pdf's documentation`_.
+
+.. _rst2pdf's documentation: http://rst2pdf.ralsina.me/handbook.html#styles
+
 Known Issues
 ------------
-Relative links in the form of ``|filename|images/test.png`` are not yet handled 
+Relative links in the form of ``|filename|images/test.png`` are not yet handled
 by the pdf generator

--- a/pdf/Readme.rst
+++ b/pdf/Readme.rst
@@ -8,7 +8,7 @@ output/pdf/
 
 Requirements
 ------------
-You should ensure you have the ```rst2pdf`` module installed::
+You should ensure you have the ``rst2pdf`` module installed::
 
 	pip install rst2pdf
 	

--- a/pdf/Readme.rst
+++ b/pdf/Readme.rst
@@ -5,3 +5,21 @@ PDF Generator
 The PDF Generator plugin automatically exports RST articles and pages
 as PDF files as part of the site-generation process. PDFs are saved to
 output/pdf/
+
+Requirements
+------------
+You should ensure you have the ```rst2pdf`` module installed::
+
+	pip install rst2pdf
+	
+Usage
+-----
+In order to use this plugin you should add the following to your config file::
+
+	PDF_STYLE = ''
+	PDF_STYLE_PATH = ''
+
+Known Issues
+------------
+Relative links in the form of ``|filename|images/test.png`` are not yet handled 
+by the pdf generator


### PR DESCRIPTION
This builds on @dpetzel's work and just adds a link to rst2pdf documentation for styles. I've also tried to make it clear that defining style paths is optional.