### PR TITLE
RFC: Add support for exporting Markdown articles as PDF. Refs #573

### DIFF
--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -10,17 +10,36 @@ from __future__ import unicode_literals, print_function
 
 from pelican import signals
 from pelican.generators import Generator
-from rst2pdf.createpdf import RstToPdf
+from pelican.readers import MarkdownReader
 
 import os
 import logging
 
+try:
+    from markdown import Markdown
+except ImportError:
+    Markdown = False
+
 logger = logging.getLogger(__name__)
+
+import xhtml2pdf.util
+if 'pyPdf' not in dir(xhtml2pdf.util):
+    try:
+        from xhtml2pdf.util import PyPDF2
+        xhtml2pdf.util.pyPdf = PyPDF2
+    except ImportError:
+        logger.error('Failed to monkeypatch xhtml2pdf. ' +
+                     'You have missing dependencies')
+        raise
+
+from rst2pdf.createpdf import RstToPdf
 
 
 class PdfGenerator(Generator):
-    """Generate PDFs on the output dir, for all articles and pages coming from
-    rst"""
+    "Generate PDFs on the output dir, for all articles and pages"
+
+    supported_md_fields = ['date', 'summary']
+
     def __init__(self, *args, **kwargs):
         super(PdfGenerator, self).__init__(*args, **kwargs)
 
@@ -36,16 +55,44 @@ class PdfGenerator(Generator):
 
         self.pdfcreator = RstToPdf(breakside=0,
                                    stylesheets=pdf_style,
-                                   style_path=pdf_style_path)
+                                   style_path=pdf_style_path,
+                                   raw_html=True)
 
     def _create_pdf(self, obj, output_path):
-        if obj.source_path.endswith('.rst'):
-            filename = obj.slug + ".pdf"
-            output_pdf = os.path.join(output_path, filename)
-            # print('Generating pdf for', obj.source_path, 'in', output_pdf)
+        filename = obj.slug + '.pdf'
+        output_pdf = os.path.join(output_path, filename)
+        mdreader = MarkdownReader(self.settings)
+        _, ext = os.path.splitext(obj.source_path)
+        if ext == '.rst':
             with open(obj.source_path) as f:
-                self.pdfcreator.createPdf(text=f.read(), output=output_pdf)
-            logger.info(' [ok] writing %s' % output_pdf)
+                text = f.read()
+            header = str()
+        elif ext[1:] in mdreader.file_extensions and mdreader.enabled:
+            text, meta = mdreader.read(obj.source_path)
+            header = str()
+
+            if 'title' in meta:
+                title = meta['title']
+                header = title + '\n' + '#' * len(title) + '\n\n'
+                del meta['title']
+
+            for k in meta.keys():
+                # We can't support all fields, so we strip the ones that won't
+                # look good
+                if k not in self.supported_md_fields:
+                    del meta[k]
+
+            header += '\n'.join([':%s: %s' % (k, meta[k]) for k in meta])
+            header += '\n\n.. raw:: html\n\n\t'
+            text = text.replace('\n', '\n\t')
+        else:
+            # We don't support this format
+            logger.warn('Ignoring unsupported file ' + obj.source_path)
+            return
+
+        logger.info(' [ok] writing %s' % output_pdf)
+        self.pdfcreator.createPdf(text=(header+text),
+                                  output=output_pdf)
 
     def generate_context(self):
         pass

--- a/pdf/test_pdf.py
+++ b/pdf/test_pdf.py
@@ -39,3 +39,4 @@ class TestPdfGeneration(unittest.TestCase):
 
     def test_existence(self):
         assert os.path.exists(os.path.join(self.temp_path, 'pdf', 'this-is-a-super-article.pdf'))
+        assert os.path.exists(os.path.join(self.temp_path, 'pdf', 'a-markdown-powered-article.pdf'))


### PR DESCRIPTION
I'm not sure this is the best code we could have. If you think its style is a bit too much, please let me know.

This may be considered a hack, but it actually builds upon a documented feature
of rst2pdf: you can use raw HTML in your RST files and rst2pdf will parse them.

Therefore, the idea of this commit is:

 1- Load the markdown source files and the markdown reader;
 2- Convert the markdown file to an HTML representation;
 3- Massage the HTML a bit so it can be considered valid RST;
 4- Convert the newly-created RST to PDF.

For this feature to work, the use must have xhtml2pdf installed. A bug in
rst2pdf (https://github.com/rst2pdf/rst2pdf/issues/521) prevents it from
parsing raw HTML correctly, so we monkeypatch xhtml2pdf to provide the class
rst2pdf expects.