### PR TITLE
RFC: Add support for exporting Markdown articles as PDF. Refs #573

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -128,7 +128,7 @@ Optimize images           Applies lossless compression on JPEG and PNG images
 
 Page View                 Pull page view count from Google Analytics.
 
-PDF generator             Automatically exports RST articles and pages as PDF files
+PDF generator             Automatically exports articles and pages as PDF files
 
 PDF Images                If an img tag contains a PDF, EPS or PS file as a source, this plugin generates a PNG preview which will then act as a link to the original file.
 

--- a/pdf/Readme.rst
+++ b/pdf/Readme.rst
@@ -2,15 +2,19 @@
 PDF Generator
 -------------
 
-The PDF Generator plugin automatically exports RST articles and pages
-as PDF files as part of the site-generation process. PDFs are saved to
-output/pdf/
+The PDF Generator plugin automatically exports articles and pages as PDF files
+as part of the site-generation process. PDFs are saved to output/pdf/
 
 Requirements
 ------------
 You should ensure you have the ``rst2pdf`` module installed::
 
 	pip install rst2pdf
+
+If you are converting Markdown sources to PDF, you also need the ``xhtml2pdf``
+module::
+
+    pip install xhtml2pdf
 
 Usage
 -----

--- a/pdf/Readme.rst
+++ b/pdf/Readme.rst
@@ -9,7 +9,7 @@ Requirements
 ------------
 You should ensure you have the ``rst2pdf`` module installed::
 
-	pip install rst2pdf
+    pip install rst2pdf
 
 If you are converting Markdown sources to PDF, you also need the ``xhtml2pdf``
 module::
@@ -21,8 +21,8 @@ Usage
 To customize the pdf output, you can use the following settings in your
 configuration file::
 
-	PDF_STYLE = ''
-	PDF_STYLE_PATH = ''
+    PDF_STYLE = ''
+    PDF_STYLE_PATH = ''
 
 ``PDF_STYLE_PATH`` defines a new path where rst2pdf will look for style sheets,
 while ``PDF_STYLE`` defines which style you want to use. For a description of

--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -10,17 +10,31 @@ from __future__ import unicode_literals, print_function
 
 from pelican import signals
 from pelican.generators import Generator
-from rst2pdf.createpdf import RstToPdf
+from pelican.readers import MarkdownReader
 
 import os
 import logging
 
 logger = logging.getLogger(__name__)
 
+import xhtml2pdf.util
+if 'pyPdf' not in dir(xhtml2pdf.util):
+    try:
+        from xhtml2pdf.util import PyPDF2
+        xhtml2pdf.util.pyPdf = PyPDF2
+    except ImportError:
+        logger.error('Failed to monkeypatch xhtml2pdf. ' +
+                     'You have missing dependencies')
+        raise
+
+from rst2pdf.createpdf import RstToPdf
+
 
 class PdfGenerator(Generator):
-    """Generate PDFs on the output dir, for all articles and pages coming from
-    rst"""
+    "Generate PDFs on the output dir, for all articles and pages"
+
+    supported_md_fields = ['date', 'summary']
+
     def __init__(self, *args, **kwargs):
         super(PdfGenerator, self).__init__(*args, **kwargs)
 
@@ -36,16 +50,44 @@ class PdfGenerator(Generator):
 
         self.pdfcreator = RstToPdf(breakside=0,
                                    stylesheets=pdf_style,
-                                   style_path=pdf_style_path)
+                                   style_path=pdf_style_path,
+                                   raw_html=True)
 
     def _create_pdf(self, obj, output_path):
-        if obj.source_path.endswith('.rst'):
-            filename = obj.slug + ".pdf"
-            output_pdf = os.path.join(output_path, filename)
-            # print('Generating pdf for', obj.source_path, 'in', output_pdf)
+        filename = obj.slug + '.pdf'
+        output_pdf = os.path.join(output_path, filename)
+        mdreader = MarkdownReader(self.settings)
+        _, ext = os.path.splitext(obj.source_path)
+        if ext == '.rst':
             with open(obj.source_path) as f:
-                self.pdfcreator.createPdf(text=f.read(), output=output_pdf)
-            logger.info(' [ok] writing %s' % output_pdf)
+                text = f.read()
+            header = str()
+        elif ext[1:] in mdreader.file_extensions and mdreader.enabled:
+            text, meta = mdreader.read(obj.source_path)
+            header = str()
+
+            if 'title' in meta:
+                title = meta['title']
+                header = title + '\n' + '#' * len(title) + '\n\n'
+                del meta['title']
+
+            for k in meta.keys():
+                # We can't support all fields, so we strip the ones that won't
+                # look good
+                if k not in self.supported_md_fields:
+                    del meta[k]
+
+            header += '\n'.join([':%s: %s' % (k, meta[k]) for k in meta])
+            header += '\n\n.. raw:: html\n\n\t'
+            text = text.replace('\n', '\n\t')
+        else:
+            # We don't support this format
+            logger.warn('Ignoring unsupported file ' + obj.source_path)
+            return
+
+        logger.info(' [ok] writing %s' % output_pdf)
+        self.pdfcreator.createPdf(text=(header+text),
+                                  output=output_pdf)
 
     def generate_context(self):
         pass

--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -34,7 +34,7 @@ from rst2pdf.createpdf import RstToPdf
 class PdfGenerator(Generator):
     "Generate PDFs on the output dir, for all articles and pages"
 
-    supported_md_fields = ['date', 'summary']
+    supported_md_fields = ['date']
 
     def __init__(self, *args, **kwargs):
         super(PdfGenerator, self).__init__(*args, **kwargs)

--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -3,7 +3,7 @@
 PDF Generator
 -------
 
-The pdf plugin generates PDF files from RST sources.
+The pdf plugin generates PDF files from RST and Markdown sources.
 '''
 
 from __future__ import unicode_literals, print_function

--- a/pdf/test_pdf.py
+++ b/pdf/test_pdf.py
@@ -39,3 +39,4 @@ class TestPdfGeneration(unittest.TestCase):
 
     def test_existence(self):
         assert os.path.exists(os.path.join(self.temp_path, 'pdf', 'this-is-a-super-article.pdf'))
+        assert os.path.exists(os.path.join(self.temp_path, 'pdf', 'a-markdown-powered-article.pdf'))


### PR DESCRIPTION
This is the newest iteration of my previous improvement to the PDF plugin.

In my local tests, Markdown articles & pages are converted just fine. With the exception of template pages, which I have no idea how to convert.

Another drawback is that absolute image references aren't handled automatically.