### PR TITLE
PDF plugin: Add support for exporting Markdown articles as PDF. Refs #573

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -128,7 +128,7 @@ Optimize images           Applies lossless compression on JPEG and PNG images
 
 Page View                 Pull page view count from Google Analytics.
 
-PDF generator             Automatically exports RST articles and pages as PDF files
+PDF generator             Automatically exports articles and pages as PDF files
 
 PDF Images                If an img tag contains a PDF, EPS or PS file as a source, this plugin generates a PNG preview which will then act as a link to the original file.
 

--- a/pdf/Readme.rst
+++ b/pdf/Readme.rst
@@ -2,8 +2,8 @@
 PDF Generator
 -------------
 
-The PDF Generator plugin automatically exports reStructuredText articles and
-pages as PDF files as part of the site generation process. PDFs are saved to:
+The PDF Generator plugin automatically exports articles and pages as PDF files
+as part of the site generation process. PDFs are saved to:
 ``output/pdf/``
 
 Requirements
@@ -13,6 +13,11 @@ You should ensure you have the ``rst2pdf`` module installed, which can be
 accomplished via::
 
 	pip install rst2pdf
+
+If you are converting Markdown sources to PDF, you also need the ``xhtml2pdf``
+module, which can be installed with::
+
+	pip install xhtml2pdf
 
 Usage
 -----

--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -3,7 +3,7 @@
 PDF Generator
 -------
 
-The pdf plugin generates PDF files from RST sources.
+The pdf plugin generates PDF files from reStructuredText and Markdown sources.
 '''
 
 from __future__ import unicode_literals, print_function

--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -8,19 +8,34 @@ The pdf plugin generates PDF files from RST sources.
 
 from __future__ import unicode_literals, print_function
 
+from io import open
 from pelican import signals
 from pelican.generators import Generator
-from rst2pdf.createpdf import RstToPdf
+from pelican.readers import MarkdownReader
 
 import os
 import logging
 
 logger = logging.getLogger(__name__)
 
+import xhtml2pdf.util
+if 'pyPdf' not in dir(xhtml2pdf.util):
+    try:
+        from xhtml2pdf.util import PyPDF2
+        xhtml2pdf.util.pyPdf = PyPDF2
+    except ImportError:
+        logger.error('Failed to monkeypatch xhtml2pdf. ' +
+                     'You have missing dependencies')
+        raise
+
+from rst2pdf.createpdf import RstToPdf
+
 
 class PdfGenerator(Generator):
-    """Generate PDFs on the output dir, for all articles and pages coming from
-    rst"""
+    "Generate PDFs on the output dir, for all articles and pages"
+
+    supported_md_fields = ['date']
+
     def __init__(self, *args, **kwargs):
         super(PdfGenerator, self).__init__(*args, **kwargs)
 
@@ -36,16 +51,49 @@ class PdfGenerator(Generator):
 
         self.pdfcreator = RstToPdf(breakside=0,
                                    stylesheets=pdf_style,
-                                   style_path=pdf_style_path)
+                                   style_path=pdf_style_path,
+                                   raw_html=True)
 
     def _create_pdf(self, obj, output_path):
-        if obj.source_path.endswith('.rst'):
-            filename = obj.slug + ".pdf"
-            output_pdf = os.path.join(output_path, filename)
-            # print('Generating pdf for', obj.source_path, 'in', output_pdf)
-            with open(obj.source_path) as f:
-                self.pdfcreator.createPdf(text=f.read(), output=output_pdf)
-            logger.info(' [ok] writing %s' % output_pdf)
+        filename = obj.slug + '.pdf'
+        output_pdf = os.path.join(output_path, filename)
+        mdreader = MarkdownReader(self.settings)
+        _, ext = os.path.splitext(obj.source_path)
+        if ext == '.rst':
+            with open(obj.source_path, encoding='utf-8') as f:
+                text = f.read()
+            header = ''
+        elif ext[1:] in mdreader.file_extensions and mdreader.enabled:
+            text, meta = mdreader.read(obj.source_path)
+            header = ''
+
+            if 'title' in meta:
+                title = meta['title']
+                header = title + '\n' + '#' * len(title) + '\n\n'
+                del meta['title']
+
+            for k in meta.keys():
+                # We can't support all fields, so we strip the ones that won't
+                # look good
+                if k not in self.supported_md_fields:
+                    del meta[k]
+
+            header += '\n'.join([':%s: %s' % (k, meta[k]) for k in meta])
+            header += '\n\n.. raw:: html\n\n\t'
+            text = text.replace('\n', '\n\t')
+
+            # rst2pdf casts the text to str and will break if it finds
+            # non-escaped characters. Here we nicely escape them to XML/HTML
+            # entities before proceeding
+            text = text.encode('ascii', 'xmlcharrefreplace')
+        else:
+            # We don't support this format
+            logger.warn('Ignoring unsupported file ' + obj.source_path)
+            return
+
+        logger.info(' [ok] writing %s' % output_pdf)
+        self.pdfcreator.createPdf(text=(header+text),
+                                  output=output_pdf)
 
     def generate_context(self):
         pass

--- a/pdf/test_pdf.py
+++ b/pdf/test_pdf.py
@@ -6,17 +6,19 @@ import pdf
 
 from tempfile import mkdtemp
 from pelican import Pelican
+from pelican.readers import MarkdownReader
 from pelican.settings import read_settings
 from shutil import rmtree
 
 CUR_DIR = os.path.dirname(__file__)
 
+
 class TestPdfGeneration(unittest.TestCase):
     def setUp(self, override=None):
-        import pdf
         self.temp_path = mkdtemp(prefix='pelicantests.')
         settings = {
-            'PATH': os.path.join(os.path.dirname(CUR_DIR), '..', 'test_data', 'content'),
+            'PATH': os.path.join(os.path.dirname(CUR_DIR), '..', 'test_data',
+                                 'content'),
             'OUTPUT_PATH': self.temp_path,
             'PLUGINS': [pdf],
             'LOCALE': locale.normalize('en_US'),
@@ -30,12 +32,17 @@ class TestPdfGeneration(unittest.TestCase):
         try:
             pelican.run()
         except ValueError:
-            logging.warn('Relative links in the form of |filename|images/test.png are not yet handled by the pdf generator')
+            logging.warn('Relative links in the form of ' +
+                         '|filename|images/test.png are not yet handled by ' +
+                         ' the pdf generator')
             pass
-
 
     def tearDown(self):
         rmtree(self.temp_path)
 
     def test_existence(self):
-        assert os.path.exists(os.path.join(self.temp_path, 'pdf', 'this-is-a-super-article.pdf'))
+        assert os.path.exists(os.path.join(self.temp_path, 'pdf',
+                                           'this-is-a-super-article.pdf'))
+        if MarkdownReader.enabled:
+            assert os.path.exists(os.path.join(self.temp_path, 'pdf',
+                                  'a-markdown-powered-article.pdf'))


### PR DESCRIPTION
Third iteration of the feature that adds support for exporting Markdown articles and pages to PDF.

Changes:
 - Now only two commits
 - Only check whether an md source generates a PDF output if Markdown is enabled (in test code)