### PR TITLE
New plugin: section numbering

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -180,6 +180,8 @@ Representative image      Extracts a representative image (i.e, featured image) 
 
 RMD Reader                Create posts via knitr RMarkdown files
 
+Section number            Adds section number to the article's context, in the form of `2.3.3` Sections are indicated by `<h1>-<h6>` in the parsed html format.
+
 Share post                Creates share URLs of article
 
 Simple footnotes          Adds footnotes to blog posts

--- a/section_number/Readme.md
+++ b/section_number/Readme.md
@@ -1,0 +1,39 @@
+Section number
+---------------
+
+This plugin adds section number to the article's context, in the form of `X.X.X`. Sections are indicated by `<h1>-<h6>` in the parsed html format. 
+
+# Setting
+
+By default, up to 3 levels of sections are numbered. You can customize this value by defining `SECTION_NUMBER_MAX` in your setting file:
+
+```
+SECTION_NUMBER_MAX = 5
+```
+
+# caution
+
+The first section in the article will be marked as the top section level. Namely, if `<h3>` is the first encountered section, no `<h1>` or `<h2>` is supposed to exist. Else, exception may be thrown out.
+
+# Example
+the following markdown content:
+```
+# section
+blabla
+## subsection
+blabla
+## subsection
+blabla
+# section
+blabla
+```
+will be
+
+>#1 section
+>blabla
+>##1.1 subsection
+>blabla
+>##1.2 subsection
+>blabla
+>#2 section
+>blabla

--- a/section_number/__init__.py
+++ b/section_number/__init__.py
@@ -1,0 +1,1 @@
+from .section_number import *

--- a/section_number/section_number.py
+++ b/section_number/section_number.py
@@ -1,0 +1,89 @@
+"""
+Section number plugin for Pelican
+================================
+Adds section numbers to section titles of the article
+"""
+
+from pelican import signals, contents
+
+
+def _extract_level(text, idx):
+    end = text.find(">", idx)
+
+    if end == -1:
+        return (idx, -1)
+
+    try:
+        level = int(text[idx : end])
+        return (end, level)
+
+    except:
+        return (idx, -1)
+
+
+def _level_str(level_nums, level_max):
+    ret = u''
+
+    if len(level_nums) > level_max:
+        return ret
+
+    for n in level_nums:
+        ret += str(n) + '.'
+
+    return ret[:-1] + ' '
+
+
+def _insert_title_number(text, level_max):
+    ret = u''
+    idx = 0
+    levels = []
+    level_nums = []
+
+    while True:
+        idx = text.find("<h", idx)
+        if idx == -1:
+            break
+
+        (idx, level) = _extract_level(text, idx + 2)
+
+        if level == -1:
+            continue
+
+        if not levels:
+            levels += [level]
+            level_nums += [1]
+
+        elif level == levels[-1]:
+            level_nums[-1] += 1
+
+        elif level < levels[-1]:
+            while level < levels[-1]:
+                levels.pop()
+                level_nums.pop()
+            level_nums[-1] += 1
+
+        else:
+            while level > levels[-1]:
+                levels += [levels[-1] + 1]
+                level_nums += [1]
+
+        text = text[:idx+1] + _level_str(level_nums, level_max) + text[idx+1:]
+
+    #print text.encode('gb2312')
+    return text
+
+
+def process_content(content):
+    if content._content is None:
+        return
+
+    level_max = content.settings.get('SECTION_NUMBER_MAX', 3)
+    
+    if level_max <= 0:
+        return
+
+    content._content = _insert_title_number(content._content, level_max)
+
+
+def register():
+    signals.content_object_init.connect(process_content)


### PR DESCRIPTION
For some themes, the relationship between different sections can be vague. This plugin add section number to the section title. To make it looks like below:

# 1 bla
## 1.1 bla
## 1.2 bla
# 2 bla