### PR TITLE
Tag cloud with badges

### DIFF
--- a/tag_cloud/test_data/article_3.md
+++ b/tag_cloud/test_data/article_3.md
@@ -1,0 +1,5 @@
+Title: Article3
+tags: pelican, plugins
+
+content3, yeah!
+

--- a/tag_cloud/test_data/article_4.md
+++ b/tag_cloud/test_data/article_4.md
@@ -1,0 +1,5 @@
+Title: Article4
+tags: pelican, fun
+
+content4, yeah!
+

--- a/tag_cloud/test_data/article_5.md
+++ b/tag_cloud/test_data/article_5.md
@@ -1,0 +1,5 @@
+Title: Article5
+tags: plugins, pelican, fun
+
+content5, yeah!
+

--- a/tag_cloud/test_tag_cloud.py
+++ b/tag_cloud/test_tag_cloud.py
@@ -1,4 +1,5 @@
-import unittest, os, sys
+import unittest
+import os
 import six
 import tag_cloud
 
@@ -8,6 +9,7 @@ from pelican.urlwrappers import Tag
 
 CUR_DIR = os.path.dirname(__file__)
 CONTENT_DIR = os.path.join(CUR_DIR, 'test_data')
+
 
 class TestTagCloudGeneration(unittest.TestCase):
 
@@ -25,59 +27,76 @@ class TestTagCloudGeneration(unittest.TestCase):
             path=CONTENT_DIR, theme=cls._settings['THEME'], output_path=None)
         cls.generator.generate_context()
 
-
     def test_tag_cloud_random(self):
+        self.generator.settings['TAG_CLOUD_STEPS'] = 10
+        self.generator.settings['TAG_CLOUD_BADGE'] = False
         tag_cloud.generate_tag_cloud(self.generator)
         expected = [
-                (Tag('plugins', self._settings), 1),
-                (Tag('fun', self._settings), 4),
-                (Tag('python', self._settings), 4),
-                (Tag('pelican', self._settings), 1)
-            ]
+            (Tag('pelican', self._settings), 1),
+            (Tag('plugins', self._settings), 2),
+            (Tag('fun', self._settings), 3),
+            (Tag('python', self._settings), 10)
+        ]
+        six.assertCountEqual(self, self.generator.tag_cloud, expected)
+
+    def test_tag_cloud_badge(self):
+        self.generator.settings['TAG_CLOUD_STEPS'] = 10
+        self.generator.settings['TAG_CLOUD_BADGE'] = True
+        tag_cloud.generate_tag_cloud(self.generator)
+        expected = [
+            (Tag('pelican', self._settings), 1, 5),
+            (Tag('plugins', self._settings), 2, 4),
+            (Tag('fun', self._settings), 3, 3),
+            (Tag('python', self._settings), 10, 1)
+        ]
         six.assertCountEqual(self, self.generator.tag_cloud, expected)
 
     def test_tag_cloud_alphabetical(self):
+        self.generator.settings['TAG_CLOUD_STEPS'] = 10
         self.generator.settings['TAG_CLOUD_SORTING'] = 'alphabetically'
         tag_cloud.generate_tag_cloud(self.generator)
         expected = [
-                (Tag('fun', self._settings), 4),
-                (Tag('pelican', self._settings), 1),
-                (Tag('plugins', self._settings), 1),
-                (Tag('python', self._settings), 4)
-            ]
+            (Tag('fun', self._settings), 3),
+            (Tag('pelican', self._settings), 1),
+            (Tag('plugins', self._settings), 2),
+            (Tag('python', self._settings), 10)
+        ]
         self.assertEqual(self.generator.tag_cloud, expected)
-    
+
     def test_tag_cloud_alphabetical_rev(self):
+        self.generator.settings['TAG_CLOUD_STEPS'] = 10
         self.generator.settings['TAG_CLOUD_SORTING'] = 'alphabetically-rev'
         tag_cloud.generate_tag_cloud(self.generator)
         expected = [
-                (Tag('python', self._settings), 4),
-                (Tag('plugins', self._settings), 1),
-                (Tag('pelican', self._settings), 1),
-                (Tag('fun', self._settings), 4)
-            ]
+            (Tag('python', self._settings), 10),
+            (Tag('plugins', self._settings), 2),
+            (Tag('pelican', self._settings), 1),
+            (Tag('fun', self._settings), 3)
+        ]
         self.assertEqual(self.generator.tag_cloud, expected)
 
     def test_tag_cloud_size(self):
+        self.generator.settings['TAG_CLOUD_STEPS'] = 10
         self.generator.settings['TAG_CLOUD_SORTING'] = 'size'
         tag_cloud.generate_tag_cloud(self.generator)
         expected = [
-                (Tag('pelican', self._settings), 1),
-                (Tag('plugins', self._settings), 1),
-                (Tag('fun', self._settings), 4),
-                (Tag('python', self._settings), 4)
-            ]
+            (Tag('pelican', self._settings), 1),
+            (Tag('plugins', self._settings), 2),
+            (Tag('fun', self._settings), 3),
+            (Tag('python', self._settings), 10)
+        ]
         self.assertEqual(self.generator.tag_cloud, expected)
 
     def test_tag_cloud_size_rev(self):
+        self.generator.settings['TAG_CLOUD_STEPS'] = 10
         self.generator.settings['TAG_CLOUD_SORTING'] = 'size-rev'
         tag_cloud.generate_tag_cloud(self.generator)
         expected = [
-                (Tag('fun', self._settings), 4),
-                (Tag('python', self._settings), 4),
-                (Tag('pelican', self._settings), 1),
-                (Tag('plugins', self._settings), 1)
-            ]
+            (Tag('python', self._settings), 10),
+            (Tag('fun', self._settings), 3),
+            (Tag('plugins', self._settings), 2),
+            (Tag('pelican', self._settings), 1)
+        ]
         self.assertEqual(self.generator.tag_cloud, expected)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi , I don't found an easy way to add a "badge" ( bootstrap terminology ) on my cloud of tags.
like this
![tags_with_badges](https://cloud.githubusercontent.com/assets/10601196/11451053/7839581c-95b7-11e5-91e3-48b7c4ab02a6.png)

That's why i propose this patch separate on 2 commits :
* With extension "**TAG_CLOUD_BADGE**" option
* Unit tests to cover before

I cleaned the two python files (**tag_cloud.py** and **test_tag_cloud.py**) after a **pep8** and **pyflake** checking...

I hope it will serve to other.

Best regards, Jérémie Ferry