### PR TITLE
Change Panorama plugin submodule URL scheme from git to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,7 +54,7 @@
 	url = https://github.com/joachimneu/pelican-jinja2content.git
 [submodule "panorama"]
 	path = panorama
-	url = git://github.com/romainx/panorama.git
+	url = https://github.com/romainx/panorama.git
 [submodule "pelican-genealogy"]
 	path = pelican-genealogy
 	url = https://github.com/zappala/pelican-genealogy


### PR DESCRIPTION
Changed panorama git submodule url from git to https. In an effort to be able to use pelican-plugins as a submodule. 
Before when attempting to setup a github pages blog I got the error,   
> The submodule registered for `./panorama` could not be cloned. Make sure it's using https:// and that it's a public repo. For more information, see https://help.github.com/articles/page-build-failed-invalid-submodule.
  
So I made the panorama submodule url public, tested it and it worked for me. 