### PR TITLE
Add premailer_for_newsletters to repository

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -33,183 +33,185 @@ or you can ``import`` the plugin directly and give that::
 Plugin descriptions
 ===================
 
-========================  ===========================================================
-Plugin                    Description
-========================  ===========================================================
-Always modified           Copy created date metadata into modified date for easy "latest updates" indexes
+==========================  ===========================================================
+Plugin                      Description
+==========================  ===========================================================
+Always modified             Copy created date metadata into modified date for easy "latest updates" indexes
 
-AsciiDoc reader           Use AsciiDoc to write your posts.
+AsciiDoc reader             Use AsciiDoc to write your posts.
 
-Asset management          Use the Webassets module to manage assets such as CSS and JS files.
+Asset management            Use the Webassets module to manage assets such as CSS and JS files.
 
-Auto Pages                Generate custom content for generated Author, Category, and Tag pages (e.g. author biography)
+Auto Pages                  Generate custom content for generated Author, Category, and Tag pages (e.g. author biography)
 
-Backref Translate         Add a new attribute (``is_translation_of``) to every article/page (which is a translation) pointing back to the original article/page which is being translated
+Backref Translate           Add a new attribute (``is_translation_of``) to every article/page (which is a translation) pointing back to the original article/page which is being translated
 
-Better code samples       Wraps all `table` blocks with a class attribute `.codehilitetable` in an additional `div` of class `.hilitewrapper`. It thus permits to style codeblocks better, especially to make them scrollable.
+Better code samples         Wraps all `table` blocks with a class attribute `.codehilitetable` in an additional `div` of class `.hilitewrapper`. It thus permits to style codeblocks better, especially to make them scrollable.
 
-Better figures/samples    Adds a `style="width: ???px; height: auto;"` attribute to any `<img>` tags in the content
+Better figures/samples      Adds a `style="width: ???px; height: auto;"` attribute to any `<img>` tags in the content
 
-bootstrapify              Automatically add bootstraps default classes to your content
+bootstrapify                Automatically add bootstraps default classes to your content
 
-Category Order            Order categories (and tags) by the number of articles in that category (or tag).
+Category Order              Order categories (and tags) by the number of articles in that category (or tag).
 
-CJK auto spacing          Inserts spaces between Chinese/Japanese/Korean characters and English words
+CJK auto spacing            Inserts spaces between Chinese/Japanese/Korean characters and English words
 
-Clean summary             Cleans your summary of excess images
+Clean summary               Cleans your summary of excess images
 
-Code include              Includes Pygments highlighted code in reStructuredText
+Code include                Includes Pygments highlighted code in reStructuredText
 
-Collate content           Makes categories of content available to the template as lists through a `collations` attribute
+Collate content             Makes categories of content available to the template as lists through a `collations` attribute
 
-Creole reader             Allows you to write your posts using the wikicreole syntax
+Creole reader               Allows you to write your posts using the wikicreole syntax
 
-Custom article URLs       Adds support for defining different default URLs for different categories
+Custom article URLs         Adds support for defining different default URLs for different categories
 
-Disqus static comments    Adds a disqus_comments property to all articles. Comments are fetched at generation time using disqus API
+Disqus static comments      Adds a disqus_comments property to all articles. Comments are fetched at generation time using disqus API
 
-Encrypt content           Password protect pages and articles
+Encrypt content             Password protect pages and articles
 
-Extract table of content  Extracts table of contents (ToC) from `article.content`
+Extract table of content    Extracts table of contents (ToC) from `article.content`
 
-Feed Summary              Allows article summaries to be used in ATOM and RSS feeds instead of the entire article
+Feed Summary                Allows article summaries to be used in ATOM and RSS feeds instead of the entire article
 
-Filetime from git         Uses git commit to determine page date
+Filetime from git           Uses git commit to determine page date
 
-Figure References         Provides a system to number and references figures
+Figure References           Provides a system to number and references figures
 
-Gallery                   Allows an article to contain an album of pictures
+Gallery                     Allows an article to contain an album of pictures
 
-Gist directive            This plugin adds a ``gist`` reStructuredText directive.
+Gist directive              This plugin adds a ``gist`` reStructuredText directive.
 
-GitHub activity           On the template side, you just have to iterate over the ``github_activity`` variable
+GitHub activity             On the template side, you just have to iterate over the ``github_activity`` variable
 
-Global license            Allows you to define a ``LICENSE`` setting and adds the contents of that license variable to the article's context
+Global license              Allows you to define a ``LICENSE`` setting and adds the contents of that license variable to the article's context
 
-Goodreads activity        Lists books from your Goodreads shelves
+Goodreads activity          Lists books from your Goodreads shelves
 
-GooglePlus comments       Adds GooglePlus comments to Pelican
+GooglePlus comments         Adds GooglePlus comments to Pelican
 
-Gravatar                  Assigns the ``author_gravatar`` variable to the Gravatar URL and makes the variable available within the article's context
+Gravatar                    Assigns the ``author_gravatar`` variable to the Gravatar URL and makes the variable available within the article's context
 
-Gzip cache                Enables certain web servers (e.g., Nginx) to use a static cache of gzip-compressed files to prevent the server from compressing files during an HTTP call
+Gzip cache                  Enables certain web servers (e.g., Nginx) to use a static cache of gzip-compressed files to prevent the server from compressing files during an HTTP call
 
-Headerid                  This plugin adds an anchor to each heading so you can deeplink to headers in reStructuredText articles.
+Headerid                    This plugin adds an anchor to each heading so you can deeplink to headers in reStructuredText articles.
 
-HTML entities             Allows you to enter HTML entities such as &copy;, &lt;, &#149; inline in a RST document
+HTML entities               Allows you to enter HTML entities such as &copy;, &lt;, &#149; inline in a RST document
 
-HTML tags for rST         Allows you to use HTML tags from within reST documents
+HTML tags for rST           Allows you to use HTML tags from within reST documents
 
-I18N Sub-sites            Extends the translations functionality by creating internationalized sub-sites for the default site
+I18N Sub-sites              Extends the translations functionality by creating internationalized sub-sites for the default site
 
-ical                      Looks for and parses an ``.ics`` file if it is defined in a given page's ``calendar`` metadata.
+ical                        Looks for and parses an ``.ics`` file if it is defined in a given page's ``calendar`` metadata.
 
-Image Process             Automates the processing of images based on their class attributes
+Image Process               Automates the processing of images based on their class attributes
 
-Interlinks                Lets you add frequently used URLs to your markup using short keywords
+Interlinks                  Lets you add frequently used URLs to your markup using short keywords
 
-Libravatar                Allows inclusion of user profile pictures from libravatar.org
+Libravatar                  Allows inclusion of user profile pictures from libravatar.org
 
-Link Class                Allows the insertion of class attributes into generated <a> elements (Markdown only)
+Link Class                  Allows the insertion of class attributes into generated <a> elements (Markdown only)
 
-Liquid-style tags         Allows liquid-style tags to be inserted into markdown within Pelican documents
+Liquid-style tags           Allows liquid-style tags to be inserted into markdown within Pelican documents
 
-Load CSV                  Adds ``csv`` Jinja tag to display the contents of a CSV file as an HTML table
+Load CSV                    Adds ``csv`` Jinja tag to display the contents of a CSV file as an HTML table
 
-Multi parts posts         Allows you to write multi-part posts
+Multi parts posts           Allows you to write multi-part posts
 
-Markdown Inline Extend    Enables you to add customize inline patterns to your markdown
+Markdown Inline Extend      Enables you to add customize inline patterns to your markdown
 
-Neighbor articles         Adds ``next_article`` (newer) and ``prev_article`` (older) variables to the article's context
+Neighbor articles           Adds ``next_article`` (newer) and ``prev_article`` (older) variables to the article's context
 
-Open graph                Generates Open Graph tags for your articles
+Open graph                  Generates Open Graph tags for your articles
 
-Optimize images           Applies lossless compression on JPEG and PNG images
+Optimize images             Applies lossless compression on JPEG and PNG images
 
-Page View                 Pull page view count from Google Analytics.
+Page View                   Pull page view count from Google Analytics.
 
-PDF generator             Automatically exports articles and pages as PDF files
+PDF generator               Automatically exports articles and pages as PDF files
 
-PDF Images                If an img tag contains a PDF, EPS or PS file as a source, this plugin generates a PNG preview which will then act as a link to the original file.
+PDF Images                  If an img tag contains a PDF, EPS or PS file as a source, this plugin generates a PNG preview which will then act as a link to the original file.
 
-Pelican-flickr            Brings your Flickr photos & sets into your static website
+Pelican-flickr              Brings your Flickr photos & sets into your static website
 
-pelican_javascript        Allows you to embed Javascript and CSS files into individual articles
+pelican_javascript          Allows you to embed Javascript and CSS files into individual articles
 
-pelican-toc               Generates a Table of Contents and make it available to the theme via article.toc
+pelican-toc                 Generates a Table of Contents and make it available to the theme via article.toc
 
-Pelican Cite              Produces inline citations and a bibliography in articles and pages, using a BibTeX file.
+Pelican Cite                Produces inline citations and a bibliography in articles and pages, using a BibTeX file.
 
-Pelican Gist tag          Easily embed GitHub Gists in your Pelican articles
+Pelican Gist tag            Easily embed GitHub Gists in your Pelican articles
 
-Pelican Page Order        Adds a ``page_order`` attribute to all pages if one is not defined.
+Pelican Page Order          Adds a ``page_order`` attribute to all pages if one is not defined.
 
-Pelican comment system    Allows you to add static comments to your articles
+Pelican comment system      Allows you to add static comments to your articles
 
-Pelican Vimeo             Enables you to embed Vimeo videos in your pages and articles
+Pelican Vimeo               Enables you to embed Vimeo videos in your pages and articles
 
-Pelican YouTube           Enables you to embed YouTube videos in your pages and articles
+Pelican YouTube             Enables you to embed YouTube videos in your pages and articles
 
-pelicanfly                Lets you type things like `i ♥ :fa-coffee:` in your Markdown documents and have it come out as little Font Awesome icons in the browser
+pelicanfly                  Lets you type things like `i ♥ :fa-coffee:` in your Markdown documents and have it come out as little Font Awesome icons in the browser
 
-Photos                    Add a photo or a gallery of photos to an article, or include photos in the body text. Resize photos as needed.
+Photos                      Add a photo or a gallery of photos to an article, or include photos in the body text. Resize photos as needed.
 
-Pin to top                Pin Pelican's article(s) to top "Sticky article"
+Pin to top                  Pin Pelican's article(s) to top "Sticky article"
 
-PlantUML                  Allows you to define UML diagrams directly into rst documents using the great PlantUML tool
+PlantUML                    Allows you to define UML diagrams directly into rst documents using the great PlantUML tool
 
-Post Revision             Extract article and page revision information from Git commit history
+Post Revision               Extract article and page revision information from Git commit history
 
-Post statistics           Calculates various statistics about a post and store them in an article.stats dictionary
+Post statistics             Calculates various statistics about a post and store them in an article.stats dictionary
 
-Random article            Generates a html file which redirect to a random article
+Premailer for newsletters   Automate the processing of files from pelican thought premailer which turns CSS blocks into style attributes.
 
-Read More link            Inserts an inline "read more" or "continue" link into the last html element of the object summary
+Random article              Generates a html file which redirect to a random article
 
-Related posts             Adds the ``related_posts`` variable to the article's context
+Read More link              Inserts an inline "read more" or "continue" link into the last html element of the object summary
 
-Markdown-metaYAML         Pelican reader to enable YAML-style metadata in markdown articles
+Related posts               Adds the ``related_posts`` variable to the article's context
 
-Math Render               Gives pelican the ability to render mathematics
+Markdown-metaYAML           Pelican reader to enable YAML-style metadata in markdown articles
 
-Panorama                  Creates charts from posts metadata
+Math Render                 Gives pelican the ability to render mathematics
 
-Replacer                  Replace a text of a generated HTML
+Panorama                    Creates charts from posts metadata
 
-Representative image      Extracts a representative image (i.e, featured image) from the article's summary or content
+Replacer                    Replace a text of a generated HTML
 
-RMD Reader                Create posts via knitr RMarkdown files
+Representative image        Extracts a representative image (i.e, featured image) from the article's summary or content
 
-Section number            Adds section numbers for article headers, in the form of ``2.3.3``
+RMD Reader                  Create posts via knitr RMarkdown files
 
-Share post                Creates share URLs of article
+Section number              Adds section numbers for article headers, in the form of ``2.3.3``
 
-Simple footnotes          Adds footnotes to blog posts
+Share post                  Creates share URLs of article
 
-Sitemap                   Generates plain-text or XML sitemaps
+Simple footnotes            Adds footnotes to blog posts
 
-Slim                      Render theme template files via Plim, a Python port of Slim, instead of Jinja
+Sitemap                     Generates plain-text or XML sitemaps
 
-Static comments           Allows you to add static comments to an article
+Slim                        Render theme template files via Plim, a Python port of Slim, instead of Jinja
 
-Subcategory               Adds support for subcategories
+Static comments             Allows you to add static comments to an article
 
-Sub parts                 Break a very long article in parts, without polluting the timeline with lots of small articles.
+Subcategory                 Adds support for subcategories
 
-Summary                   Allows easy, variable length summaries directly embedded into the body of your articles
+Sub parts                   Break a very long article in parts, without polluting the timeline with lots of small articles.
 
-tag_cloud                 Provides a tag_cloud
+Summary                     Allows easy, variable length summaries directly embedded into the body of your articles
 
-Thumbnailer               Creates thumbnails for all of the images found under a specific directory
+tag_cloud                   Provides a tag_cloud
 
-Tipue Search              Serializes generated HTML to JSON that can be used by jQuery plugin - Tipue Search
+Thumbnailer                 Creates thumbnails for all of the images found under a specific directory
 
-Touch                     Does a touch on your generated files using the date metadata from the content
+Tipue Search                Serializes generated HTML to JSON that can be used by jQuery plugin - Tipue Search
 
-Twitter Bootstrap         Defines some rst directive that enable a clean usage of the twitter bootstrap CSS and Javascript components
+Touch                       Does a touch on your generated files using the date metadata from the content
 
-W3C validate              Submits generated HTML content to the W3C Markup Validation Service
-========================  ===========================================================
+Twitter Bootstrap           Defines some rst directive that enable a clean usage of the twitter bootstrap CSS and Javascript components
+
+W3C validate                Submits generated HTML content to the W3C Markup Validation Service
+==========================  ===========================================================
 
 
 Please refer to the ``Readme`` file in a plugin's folder for detailed information about

--- a/premailer_for_newsletters/Readme.rst
+++ b/premailer_for_newsletters/Readme.rst
@@ -1,0 +1,38 @@
+===========================
+ Premailer for Newsletters
+===========================
+
+``premailer_for_newsletters`` let you automate the processing of html generated
+files from pelican thought premailer which turns CSS blocks into style
+attributes.
+
+Requirements
+============
+
+``premailer_for_newsletters`` requires premailer which can be installed with pip:
+
+.. code-block:: sh
+
+   pip install premailer
+
+
+Usage
+=====
+
+``premailer_for_newsletters`` connects to the finalized signal which is invoked after
+all the generators are executed and just before pelican exits useful for custom
+post processing actions, such as: - minifying js/css assets. - notify/ping
+search engines with an updated sitemap.
+
+It pass the whole page to ``premailer`` and overwrite the result on the original
+output file.
+
+
+In order to use it, you need to define your ``PLUGIN_PATH`` and add
+``premailer_for_newsletters`` to the ``PLUGINS`` list : 
+
+.. code-block:: python
+
+  PLUGIN_PATHS = ['./pelican-plugins']
+  PLUGINS = ['premailer_for_newsletters', 'image_process']
+

--- a/premailer_for_newsletters/__init__.py
+++ b/premailer_for_newsletters/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*- #
+from .premailer_for_newsletters import *

--- a/premailer_for_newsletters/premailer_for_newsletters.py
+++ b/premailer_for_newsletters/premailer_for_newsletters.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*- #
+"""
+premailer for newsletters
+=========================
+
+This Pelican plugin process html generated files thought premailer
+which turns CSS blocks into style attributes.
+
+Intended is is to generate email newsletters with Pelican.
+
+See:
+ * Pelican : http://blog.getpelican.com/
+ * premailer : https://github.com/peterbe/premailer
+
+Author : Alexandre Norman - norman at xael.org
+Licence : GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+
+"""
+
+__author__ = 'Alexandre Norman (norman at xael.org)'
+__version__ = '1.0.0'
+__last_modification__ = '2015.12.13'
+
+
+import os
+from pelican import signals
+import logging
+
+
+__LOG__ = logging.getLogger(__name__)
+INCLUDE_TYPES = ['html']
+
+
+def register():
+    """
+    Register premailer
+    """
+    signals.finalized.connect(premailer_files)
+
+
+def premailer_files(pelican):
+    """
+    Run premailer on generated HTML file
+    :param pelican: pelican object
+    """
+    for dirpath, _, filenames in os.walk(pelican.settings['OUTPUT_PATH']):
+        for name in filenames:
+            if should_premailer(name):
+                filepath = os.path.join(dirpath, name)
+                go_premailer(filepath, pelican.settings['SITEURL'])
+
+
+def go_premailer(filename, siteurl):
+    """
+    Run premailer on given file
+    :param filename: the filename to validate
+    """
+    import premailer
+
+    # Read and process file
+    __LOG__.info(
+        "Processing premailer_for_newsletters for: {0}".format(filename)
+    )
+    try:
+        with open(filename, 'r') as rf:
+            p = premailer.Premailer(
+                rf.read(),
+                cssutils_logging_handler=__LOG__,
+                cssutils_logging_level=logging.INFO,
+                base_url=siteurl,
+            )
+            output = p.transform()
+    except:
+        __LOG__.error(
+            "Error in premailer_for_newsletters for: {0}".format(filename)
+        )
+    else:
+        # Write back file
+        with open(filename, 'w') as wf:
+            wf.write(output)
+
+
+def should_premailer(filename):
+    """
+    Check if the filename is a type of file that should be premailed.
+    :param filename: A file name to check against
+    """
+    for extension in INCLUDE_TYPES:
+        if filename.endswith(extension):
+            return True
+    return False

--- a/premailer_for_newsletters/requirements.txt
+++ b/premailer_for_newsletters/requirements.txt
@@ -1,0 +1,5 @@
+cssselect>=0.9.1          # via premailer
+cssutils>=1.0.1           # via premailer
+lxml>=3.5.0               # via premailer
+premailer>=2.9.6
+


### PR DESCRIPTION
A new plugin that let you automate the processing of html generated
files from pelican thought premailer which turns CSS blocks into style
attributes.