### PR TITLE
Add ace-editor plugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -115,3 +115,6 @@
 [submodule "just_table"]
 	path = just_table
 	url = https://github.com/burakkose/just_table
+[submodule "ace_editor"]
+	path = ace_editor
+	url = https://github.com/mothsART/ace_editor.git


### PR DESCRIPTION
Hi,

I didn't find a quick and simple way to use ace editor (ace.c9.io) on Pelican.
suddenly, I created a plugin who works well on markdown and restructuredtext.

I add some features:

* url anchor (after some help : https://github.com/ajaxorg/ace/issues/2824)
* declaring *ace editor* settings on traditionnal *pelicanconf.py*
