### PR TITLE
Add mboxreader plugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -118,3 +118,6 @@
 [submodule "ace_editor"]
 	path = ace_editor
 	url = https://github.com/mothsART/ace_editor.git
+[submodule "pelican-mboxreader"]
+	path = pelican-mboxreader
+	url = https://github.com/TC01/pelican-mboxreader

--- a/Readme.rst
+++ b/Readme.rst
@@ -156,6 +156,8 @@ Pelican Cite              Produces inline citations and a bibliography in articl
 
 Pelican Gist tag          Easily embed GitHub Gists in your Pelican articles
 
+Pelican mboxreader        Lets you generate articles automatically via email, given a path to a Unix mbox.
+
 Pelican Page Order        Adds a ``page_order`` attribute to all pages if one is not defined.
 
 Pelican comment system    Allows you to add static comments to your articles


### PR DESCRIPTION
This is a plugin I wrote a while back but just recently cleaned up, ran through PEP8, submitted to PyPI and this repository.

Given a path to a Unix mbox, it implements a custom generator that runs over all emails in that mbox and turns them into Pelican articles. The main utility for me was to turn a Mailman archive into blog posts (we had an announcements email list that I wanted automatically mirrored to a Pelican site), but I could vaguely see other uses (some kind of auto submission system?).