### PR TITLE
Summary: add SUMMARY_USE_FIRST_PARAGRAPH

### DIFF
--- a/summary/Readme.rst
+++ b/summary/Readme.rst
@@ -26,6 +26,9 @@ beginning marker was found, it starts at the top of the body. It is possible
 to leave out the end marker instead, in which case the summary will start at the
 beginning marker and continue to the end of the body.
 
+If no beginning or end marker is found, and if ``SUMMARY_USE_FIRST_PARAGRAPH``
+is enabled in the settings, the summary will be the first paragraph of the post.
+
 The plugin also sets a ``has_summary`` attribute on every article. It is True
 for articles with an explicitly-defined summary, and False otherwise.  (It is
 also False for an article truncated by ``SUMMARY_MAX_LENGTH``.)  Your templates

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -16,11 +16,13 @@ def initialized(pelican):
                               '<!-- PELICAN_BEGIN_SUMMARY -->')
     DEFAULT_CONFIG.setdefault('SUMMARY_END_MARKER',
                               '<!-- PELICAN_END_SUMMARY -->')
+    DEFAULT_CONFIG.setdefault('SUMMARY_USE_FIRST_PARAGRAPH', False)
     if pelican:
         pelican.settings.setdefault('SUMMARY_BEGIN_MARKER',
                                     '<!-- PELICAN_BEGIN_SUMMARY -->')
         pelican.settings.setdefault('SUMMARY_END_MARKER',
                                     '<!-- PELICAN_END_SUMMARY -->')
+        pelican.settings.setdefault('SUMMARY_USE_FIRST_PARAGRAPH', False)
 
 def extract_summary(instance):
     # if summary is already specified, use it
@@ -35,6 +37,8 @@ def extract_summary(instance):
 
     begin_marker = instance.settings['SUMMARY_BEGIN_MARKER']
     end_marker   = instance.settings['SUMMARY_END_MARKER']
+    use_first_paragraph = instance.settings['SUMMARY_USE_FIRST_PARAGRAPH']
+    remove_markers = True
 
     content = instance._content
     begin_summary = -1
@@ -42,6 +46,12 @@ def extract_summary(instance):
     if begin_marker:
         begin_summary = content.find(begin_marker)
     if end_marker:
+        end_summary = content.find(end_marker)
+
+    if begin_summary == -1 and end_summary == -1 and use_first_paragraph:
+        begin_marker, end_marker = '<p>', '</p>'
+        remove_markers = False
+        begin_summary = content.find(begin_marker)
         end_summary = content.find(end_marker)
 
     if begin_summary == -1 and end_summary == -1:
@@ -59,11 +69,12 @@ def extract_summary(instance):
 
     summary = content[begin_summary:end_summary]
 
-    # remove the markers from the content
-    if begin_summary:
-        content = content.replace(begin_marker, '', 1)
-    if end_summary:
-        content = content.replace(end_marker, '', 1)
+    if remove_markers:
+        # remove the markers from the content
+        if begin_summary:
+            content = content.replace(begin_marker, '', 1)
+        if end_summary:
+            content = content.replace(end_marker, '', 1)
 
     instance._content = content
     instance._summary = summary

--- a/summary/test_summary.py
+++ b/summary/test_summary.py
@@ -18,6 +18,7 @@ class TestSummary(unittest.TestCase):
     def setUp(self):
         super(TestSummary, self).setUp()
         pelican.settings.DEFAULT_CONFIG['SUMMARY_MAX_LENGTH'] = None
+        pelican.settings.DEFAULT_CONFIG['SUMMARY_USE_FIRST_PARAGRAPH'] = False
 
         summary.register()
         summary.initialized(None)
@@ -78,6 +79,17 @@ class TestSummary(unittest.TestCase):
         # test both the summary and the marker removal
         self.assertEqual(page.summary, TEST_SUMMARY)
         self.assertEqual(page.content, 'FOOBAR' + TEST_SUMMARY + TEST_CONTENT)
+
+    def test_use_first_paragraph(self):
+        page_kwargs = self._copy_page_kwargs()
+        del page_kwargs['metadata']['summary']
+        pelican.settings.DEFAULT_CONFIG['SUMMARY_USE_FIRST_PARAGRAPH'] = True
+        page_kwargs['content'] = '<p>' + TEST_SUMMARY + '</p>' + TEST_CONTENT
+        page = Page(**page_kwargs)
+        summary.extract_summary(page)
+        # test both the summary and the marker removal
+        self.assertEqual(page.summary, TEST_SUMMARY)
+        self.assertEqual(page.content, '<p>' + TEST_SUMMARY + '</p>' + TEST_CONTENT)
 
 
 if __name__ == '__main__':

--- a/summary/test_summary.py
+++ b/summary/test_summary.py
@@ -10,12 +10,14 @@ TEST_SUMMARY = generate_lorem_ipsum(n=1, html=False)
 
 
 from pelican.contents import Page
+import pelican.settings
 
 import summary
 
 class TestSummary(unittest.TestCase):
     def setUp(self):
         super(TestSummary, self).setUp()
+        pelican.settings.DEFAULT_CONFIG['SUMMARY_MAX_LENGTH'] = None
 
         summary.register()
         summary.initialized(None)
@@ -49,6 +51,7 @@ class TestSummary(unittest.TestCase):
         page_kwargs['content'] = (
             TEST_SUMMARY + '<!-- PELICAN_END_SUMMARY -->' + TEST_CONTENT)
         page = Page(**page_kwargs)
+        summary.extract_summary(page)
         # test both the summary and the marker removal
         self.assertEqual(page.summary, TEST_SUMMARY)
         self.assertEqual(page.content, TEST_SUMMARY + TEST_CONTENT)
@@ -59,6 +62,7 @@ class TestSummary(unittest.TestCase):
         page_kwargs['content'] = (
             'FOOBAR<!-- PELICAN_BEGIN_SUMMARY -->' + TEST_CONTENT)
         page = Page(**page_kwargs)
+        summary.extract_summary(page)
         # test both the summary and the marker removal
         self.assertEqual(page.summary, TEST_CONTENT)
         self.assertEqual(page.content, 'FOOBAR' + TEST_CONTENT)
@@ -70,6 +74,11 @@ class TestSummary(unittest.TestCase):
                 'FOOBAR<!-- PELICAN_BEGIN_SUMMARY -->' + TEST_SUMMARY +
                 '<!-- PELICAN_END_SUMMARY -->' + TEST_CONTENT)
         page = Page(**page_kwargs)
+        summary.extract_summary(page)
         # test both the summary and the marker removal
         self.assertEqual(page.summary, TEST_SUMMARY)
         self.assertEqual(page.content, 'FOOBAR' + TEST_SUMMARY + TEST_CONTENT)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Makes it possible to only use the first paragraph of a post as its summary if no marker is found.