### PR TITLE
org_reader: move language's setting form `#+LANGUAGE lang` to `#+PROPERTY: LANGUAGE lang`

### DIFF
--- a/org_reader/README.md
+++ b/org_reader/README.md
@@ -20,7 +20,7 @@ the org file's header:
     #+DATE: 2001-01-01
     #+CATEGORY: blog-category
     #+AUTHOR: My Name
-    #+LANGUAGE: en
+    #+PROPERTY: LANGUAGE en
     #+PROPERTY: SUMMARY hello, this is the description
     #+PROPERTY: SLUG test_slug
     #+PROPERTY: MODIFIED [2015-12-29 Di]

--- a/org_reader/org_reader.el
+++ b/org_reader/org_reader.el
@@ -1,6 +1,7 @@
 (require 'json)
 (require 'org)
 (require 'ox)
+
 (defun org->pelican (filename backend)
   (progn
     (save-excursion
@@ -37,12 +38,12 @@
 
                  :author (substring-no-properties
                           (car (plist-get org-export-env ':author)))
-                 :language (plist-get org-export-env ':language)
 
                  ; org file properties
                  :category (cdr (assoc-string "CATEGORY" org-file-properties t))
 
                  ; custom org file properties, defined as #+PROPERTY: NAME ARG
+                 :language (cdr (assoc-string "LANGUAGE" org-file-properties t))
                  :save_as (cdr (assoc-string "SAVE_AS" org-file-properties t))
                  :tags (cdr (assoc-string "TAGS" org-file-properties t))
                  :summary (cdr (assoc-string "SUMMARY" org-file-properties t))

--- a/org_reader/org_reader.py
+++ b/org_reader/org_reader.py
@@ -23,7 +23,7 @@ the org file's header:
 #+DATE: 2001-01-01
 #+CATEGORY: blog-category
 #+AUTHOR: My Name
-#+LANGUAGE: en
+#+PROPERTY: LANGUAGE en
 #+PROPERTY: SUMMARY hello, this is the description
 #+PROPERTY: SLUG test_slug
 #+PROPERTY: MODIFIED [2015-12-29 Di]


### PR DESCRIPTION


If `#+LANGUAGE` is not in the ORG file, the default value is not None nor Empty, it will be the language of OS. This will change the filename to `{slug}-{language}.html`, and the ARTICLE_SAVE_AS in `publishconf.py` will not be used.