### PR TITLE
Add new knitr settings for rmd_reader plugin

### DIFF
--- a/rmd_reader/Readme.md
+++ b/rmd_reader/Readme.md
@@ -39,6 +39,16 @@ The plugin detects RMD files ending with `.Rmd` or `.rmd` so you only have to wr
 
 This plugin calls R to process these files and generates markdown files that are processed by Pelican's `MarkdownReader` in order to generate html files from ordinary `.md` files.
 
+### Configuration
+
+`rmd_reader` has these 3 variables that can be set in `pelicanconf`.
+
+- `RMD_READER_CLEANUP` (`True`): The RMarkdown file is converted into a Markdown file with the extension `.aux` (to avoid conflicts while pelican is processing). This file is processed by pelican's MarkdownReader and is removed after that (the cleanup step). So if you want to check this file set `RMD_READER_CLEANUP=True`.
+- `RMD_READER_KNITR_QUIET` (`True`): sets `knitr`'s quiet argument.
+- `RMD_READER_KNITR_ENCODING` (`UTF-8`): sets `knitr`'s encoding argument.
+- `RMD_READER_KNITR_OPTS_CHUNK` (`None`): sets `knitr`'s `opts_chunk`.
+
+
 ### Plotting
 
 The code below must be pasted inside the `.Rmd` file in order to correctly set the `src` attribute of `img` tag.

--- a/rmd_reader/rmd_reader.py
+++ b/rmd_reader/rmd_reader.py
@@ -2,14 +2,15 @@
 
 import os
 import warnings
+import logging
+
+logger = logging.getLogger(__name__)
 
 from pelican import readers
 from pelican import signals
 from pelican import settings
 from pelican.utils import pelican_open
 from markdown import Markdown
-
-#import pelicanconf
 
 knitr = None
 rmd = False
@@ -23,33 +24,46 @@ def initsignal(pelicanobj):
         knitr = importr('knitr')
         idx = knitr.opts_knit.names.index('set')
         PATH = pelicanobj.settings.get('PATH','%s/content' % settings.DEFAULT_CONFIG.get('PATH'))
+        logger.debug("RMD_READER PATH = %s", PATH)
         knitr.opts_knit[idx](**{'base.dir': PATH})
-        idy = knitr.opts_chunk.names.index('set')
-        knitroptschunk = pelicanobj.settings.get('KNITR_OPTS_CHUNK',None)
+        idx = knitr.opts_chunk.names.index('set')
+        knitroptschunk = pelicanobj.settings.get('RMD_READER_KNITR_OPTS_CHUNK', None)
         if knitroptschunk is not None:     
-            knitr.opts_chunk[idy](**{str(k): v for k,v in knitroptschunk.iteritems()})
+            knitr.opts_chunk[idx](**{str(k): v for k,v in knitroptschunk.iteritems()})
         rmd = True
-    except ImportError:
+    except ImportError as ex:
         rmd = False
     
 class RmdReader(readers.BaseReader):
-    enabled = rmd
     file_extensions = ['Rmd', 'rmd']
+    
+    @property
+    def enabled():
+        global rmd
+        return rmd
 
     # You need to have a read method, which takes a filename and returns
     # some content and the associated metadata.
     def read(self, filename):
         """Parse content and metadata of markdown files"""
+        global knitr
+        QUIET = self.settings.get('RMD_READER_KNITR_QUIET', True)
+        ENCODING = self.settings.get('RMD_READER_KNITR_ENCODING', 'UTF-8')
+        CLEANUP = self.settings.get('RMD_READER_CLEANUP', True)
+        logger.debug("RMD_READER_KNITR_QUIET = %s", QUIET)
+        logger.debug("RMD_READER_KNITR_QUIET = %s", ENCODING)
+        logger.debug("RMD_READER_CLEANUP = %s", CLEANUP)
         # replace single backslashes with double backslashes
         filename = filename.replace('\\', '\\\\')
         # parse Rmd file - generate md file
         md_filename = filename.replace('.Rmd', '.aux').replace('.rmd', '.aux')
-        knitr.knit(filename, md_filename, quiet=True, encoding='UTF-8')
+        knitr.knit(filename, md_filename, quiet=QUIET, encoding=ENCODING)
         # read md file - create a MarkdownReader
         md_reader = readers.MarkdownReader(self.settings)
         content, metadata = md_reader.read(md_filename)
         # remove md file
-        os.remove(md_filename)
+        if CLEANUP:
+            os.remove(md_filename)
         return content, metadata
 
 def add_reader(readers):


### PR DESCRIPTION
Variables to interact with knitr:

RMD_READER_KNITR_QUIET (True): knitr's quiet argument
RMD_READER_KNITR_ENCODING (UTF-8): knitr's encoding argument
RMD_READER_KNITR_OPTS_CHUNK (None): knitr's opts_chunk settings

RMD_READER_CLEANUP (True): remove the markdown file generated by knitr

Included the property `RmdReader.enabled` to work with the global variable `rmd`.