### PR TITLE
custom_article_urls: correctly handle draft status

### DIFF
--- a/custom_article_urls/custom_article_urls.py
+++ b/custom_article_urls/custom_article_urls.py
@@ -27,12 +27,16 @@ def custom_url(generator, metadata):
 
         if pattern_matched:
             #only alter url if hasn't been set in the metdata
+            ignore = False
             if ('url', 'save_as') in metadata:
                 """ if both url and save_as are set in the metadata already
                 then there is already a custom url set, skip this one
                 """
-                pass
-            else:
+                ignore = True
+            elif ('status' in metadata) and (metadata['status'] == 'draft'):
+                ignore = True
+
+            if not ignore:
                 temp_article = Article("", metadata=metadata)
                 url_format = pattern_matched['URL']
                 save_as_format = pattern_matched['SAVE_AS']


### PR DESCRIPTION
When an article's `status` metadata attribute is `draft`, don't render to the `custom_article_urls` location. Instead, treat the article like any other draft and render to whatever `DRAFT_SAVE_AS` specifies.

Fixes getpelican/pelican-plugins#660.