### PR TITLE
filetime_from_git: Fix bad function call

### DIFF
--- a/filetime_from_git/filetime_from_git.py
+++ b/filetime_from_git/filetime_from_git.py
@@ -45,7 +45,7 @@ def filetime_from_git(content):
 
         if len(commits) == 0:
             # never commited, but staged
-            content.date = git.datetime_from_timestamp(
+            content.date = datetime_from_timestamp(
                 os.stat(path).st_ctime, content)
         else:
             # has commited


### PR DESCRIPTION
A really simple patch: `datetime_from_timestamp()` is not a function provided by the Git wrapper,
it's a module-level function of the calling module.