### PR TITLE
filetime_from_git: Use relative imports

### DIFF
--- a/filetime_from_git/filetime_from_git.py
+++ b/filetime_from_git/filetime_from_git.py
@@ -4,7 +4,7 @@ import os
 from pelican import signals, contents
 from pelican.utils import strftime, set_date_tzinfo
 from datetime import datetime
-from git_wrapper import git_wrapper
+from .git_wrapper import git_wrapper
 
 
 def datetime_from_timestamp(timestamp, content):


### PR DESCRIPTION
The filetime_from_git plugin needs to use relative imports; otherwise, it doesn't seem to work using Python 3.