### PR TITLE
filetime_from_git: _GitWrapperCommon.get_commits_following needs to return a list.

### DIFF
--- a/filetime_from_git/git_wrapper.py
+++ b/filetime_from_git/git_wrapper.py
@@ -53,7 +53,7 @@ class _GitWrapperCommon(object):
         '''
         commit_shas = self.git.log(
             '--pretty=%H', '--follow', '--', path).splitlines()
-        return map(self.repo.commit, commit_shas)
+        return list(map(self.repo.commit, commit_shas))
 
     def get_commits(self, path, follow=False):
         '''


### PR DESCRIPTION
Previously, the mentioned method returned a generator object. However, the calling
code wants to use list operations, which are not available for generator
objects, leading to an exception if `GIT_FILETIME_FOLLOW` was set to `True`.