### PR TITLE
filetime_from_git: Add GIT_FILETIME_ALWAYS_ADD_MODIFIED setting.

### DIFF
--- a/filetime_from_git/README.rst
+++ b/filetime_from_git/README.rst
@@ -30,6 +30,11 @@ You can also set GIT_FILETIME_FOLLOW to True in your pelican config to
 make the plugin follow file renames i.e. ensure the creation date matches
 the original file creation date, not the date is was renamed.
 
+By default, the plugin ensures that articles which use "git time" always have a
+"Modified" date set, even if this date matches the creation date. If you only want
+to add a "Modified" date if it actually differs from the creation date, then set
+``GIT_FILETIME_ALWAYS_ADD_MODIFIED`` to ``False`` in your Pelican config.
+
 FAQ
 ---
 

--- a/filetime_from_git/filetime_from_git.py
+++ b/filetime_from_git/filetime_from_git.py
@@ -65,7 +65,8 @@ def filetime_from_git(content):
         # file is not managed by git
         content.date = datetime_from_timestamp(os.stat(path).st_ctime, content)
 
-    if not hasattr(content, 'modified'):
+    # Make sure we always have a `modified' field unless this behaviour has been disabled:
+    if not hasattr(content, 'modified') and content.settings.get("GIT_FILETIME_ALWAYS_ADD_MODIFIED", True):
         content.modified = content.date
 
     if hasattr(content, 'date'):


### PR DESCRIPTION
The plugin usually always sets the "modified" field of a content piece,
even if it has not actually been modified, leading to the "Modified" date being the same as the "Created" date in some cases. This setting allows the user to disable that behaviour so that only content pieces which have been modified get a "Modified" date.

To ensure backward compatibility, this setting is set to "True" by default -- i. e. the old behaviour is kept by default.