### PR TITLE
liquid_tags: Open notebooks with utf-8 encoding

### DIFF
--- a/liquid_tags/liquid_tags.py
+++ b/liquid_tags/liquid_tags.py
@@ -3,18 +3,22 @@ from .mdx_liquid_tags import LiquidTags, LT_CONFIG
 
 
 def addLiquidTags(gen):
-    if not gen.settings.get('MD_EXTENSIONS'):
+    if not gen.settings.get('MARKDOWN'):
         from pelican.settings import DEFAULT_CONFIG
-        gen.settings['MD_EXTENSIONS'] = DEFAULT_CONFIG['MD_EXTENSIONS']
+        gen.settings['MARKDOWN'] = DEFAULT_CONFIG['MARKDOWN']
 
-    if LiquidTags not in gen.settings['MD_EXTENSIONS']:
+    if LiquidTags not in gen.settings['MARKDOWN']:
         configs = dict()
         for key,value in LT_CONFIG.items():
             configs[key]=value
         for key,value in gen.settings.items():
             if key in LT_CONFIG:
                 configs[key]=value
-        gen.settings['MD_EXTENSIONS'].append(LiquidTags(configs))
+        gen.settings['MARKDOWN'].setdefault(
+            'extensions', []
+        ).append(
+            LiquidTags(configs)
+        )
 
 
 def register():

--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -51,6 +51,7 @@ import warnings
 import re
 import os
 from functools import partial
+from io import open
 
 from .mdx_liquid_tags import LiquidTags
 
@@ -324,7 +325,7 @@ def notebook(preprocessor, tag, markup):
                             **subcell_kwarg)
 
     # read and parse the notebook
-    with open(nb_path) as f:
+    with open(nb_path, encoding='utf-8') as f:
         nb_text = f.read()
         if IPYTHON_VERSION < 3:
             nb_json = IPython.nbformat.current.reads_json(nb_text)


### PR DESCRIPTION
I discovered a problem with UTF-8 encoded notebooks. It throws a
DecodeError. We now use io.open() so we can define a encoding to open a
file. Works with ASCII and Unicode encoded notebooks.

Jupyter saves the notebook usually as ASCII (i think) and if there is some special characters in it (like umlauts in my case) its unicode and the plugin has problems with it.

Or does anyone has a better idea? 
