### PR TITLE
Add pelican-resume plugin.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -121,3 +121,6 @@
 [submodule "mboxreader"]
 	path = pelican-mboxreader
 	url = https://github.com/TC01/pelican-mboxreader
+[submodule "pelican-resume"]
+	path = pelican-resume
+	url = https://github.com/cmenguy/pelican-resume.git


### PR DESCRIPTION
Pelican module to generate customizable PDF resumes based on Markdown pages.
Currently only supports moderncv resume style, based on the CSS from http://resume.chmd.fr/style.css but other resume styles can be added by writing a custom CSS and the style can be controlled by the `RESUME_STYLE` setting.