### PR TITLE
Adding Extended Meta Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -121,3 +121,6 @@
 [submodule "mboxreader"]
 	path = pelican-mboxreader
 	url = https://github.com/TC01/pelican-mboxreader
+[submodule "extended_meta"]
+	path = extended_meta
+	url = git@github.com:kplaube/extended_meta.git


### PR DESCRIPTION
Extended Meta is a plugin that gives some extra metadata to a specific article. With this module, it's possible to write specific data for `og:title`, `og:description`, `og:url` and `og:image`.

For example:

```
Title: How to use Extended Meta Pelican's plugin
Date: 2014-04-22 13:00
Category: development
Tags: development, pelican, extended-meta, blog
Slug: how-to-use-extended-meta-pelican-plugin
meta_description: A brief description long enough to fit in search results
meta_keywords: Some keywords that describes your article
meta_robots: index,follow is the word
meta_og_title: A cool Open Graph's title
meta_og_description: A cool Open Graph's description
meta_og_url: A different way to view your article through Open Graph?
meta_og_image: The full address to an image
```

I hope you find it useful.
