### PR TITLE
Fix syntax highlighting collapsible code

### DIFF
--- a/liquid_tags/notebook.py
+++ b/liquid_tags/notebook.py
@@ -6,7 +6,7 @@ notebook in a blog post.
 
 Syntax
 ------
-{% notebook filename.ipynb [ cells[start:end] ]%}
+{% notebook filename.ipynb [ cells[start:end] language[language] ]%}
 
 The file should be specified relative to the ``notebooks`` subdirectory of the
 content directory.  Optionally, this subdirectory can be specified in the
@@ -16,6 +16,9 @@ config file:
 
 The cells[start:end] statement is optional, and can be used to specify which
 block of cells from the notebook to include.
+
+The language statement is obvious and can be used to specify whether ipython2
+or ipython3 syntax highlighting should be used.
 
 Requirements
 ------------

--- a/liquid_tags/pelicanhtml_3.tpl
+++ b/liquid_tags/pelicanhtml_3.tpl
@@ -36,13 +36,13 @@
 {% if "# <!-- collapse=True -->" in cell.source %}
 <div class="collapseheader inner_cell"><span style="font-weight: bold;">Expand Code</span>
 <div class="input_area" style="display:none">
-{{ cell.source.replace("# <!-- collapse=True -->\n", "") | highlight2html(metadata=cell.metadata) }}
+{{ cell.source.replace("# <!-- collapse=True -->\n", "") | highlight_code(metadata=cell.metadata) }}
 </div>
 </div>
 {% elif "# <!-- collapse=False -->" in cell.source %}
 <div class="collapseheader inner_cell"><span style="font-weight: bold;">Collapse Code</span>
 <div class="input_area">
-{{ cell.source.replace("# <!-- collapse=False -->\n", "") | highlight2html(metadata=cell.metadata) }}
+{{ cell.source.replace("# <!-- collapse=False -->\n", "") | highlight_code(metadata=cell.metadata) }}
 </div>
 </div>
 {% else %}


### PR DESCRIPTION
Syntax highlighting in collapsible notebook input cells was broken for IPython >=3 as it called highlight2html instead of highlight_code.

Document the language switch for notebooks.