### PR TITLE
Add bootstrap-rat plugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,3 +124,6 @@
 [submodule "pelican-yuicompressor"]
 	path = pelican-yuicompressor
 	url = https://github.com/auroredea/pelican-yuicompressor
+[submodule "bootstrap-rst"]
+	path = bootstrap-rst
+	url = https://github.com/Alexqw/bootstrap-rst

--- a/Readme.rst
+++ b/Readme.rst
@@ -52,6 +52,8 @@ Better code samples       Wraps ``table`` blocks with ``div > .hilitewrapper > .
 
 Better figures/samples    Adds a ``style="width: ???px; height: auto;"`` attribute to any ``<img>`` tags in the content
 
+bootstrap-rst             Provides most (though not all) of Bootstrap's features as rst directives
+
 bootstrapify              Automatically add bootstraps default classes to your content
 
 Category Order            Order categories (and tags) by the number of articles in that category (or tag).


### PR DESCRIPTION
Nicolas P. Rougier[1] has done some great work making Bootstrap's features available as rst directives. This is merely packaging his work into a Pelican plugin.

Overall, it is much more featureful than the 'twitter_bootstrap_rst_directives' plugin and makes using Bootstrap's rows and columns actually possible in the content without descending into `.. raw:: html` spaghetti hell.

A nice outline[2] shows which features are supported so far.

There are some superfluous files, but I've kept the changes minimal in order to simplify the merging of future upstream development.

---Alex

[1] https://github.com/rougier/bootstrap-rst
[2] https://rougier.github.io/bootstrap-rst/