### PR TITLE
Allow user to change mathjax urls in render_math

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -107,6 +107,9 @@ def process_settings(pelicanobj):
         if key == 'indent':
             mathjax_settings[key] = value
 
+        if key == 'source':
+            mathjax_settings[key] = value
+
         if key == 'show_menu' and isinstance(value, bool):
             mathjax_settings[key] = 'true' if value else 'false'
 
@@ -155,7 +158,7 @@ def process_settings(pelicanobj):
             mathjax_settings[key] = 'true' if value else 'false'
 
         if key == 'force_tls' and isinstance(value, bool):
-            mathjax_settings[key] = 'true' if value else 'false'       
+            mathjax_settings[key] = 'true' if value else 'false'
 
         if key == 'responsive_break' and isinstance(value, int):
             mathjax_settings[key] = str(value)


### PR DESCRIPTION
Here in China our network condition is poor, sometimes connection to mathjax cdns may stuck and prevent the equations from loading.

Thus I enabled changing of `source` settings in `render_math` plugin, allowing user to change urls to their preferred CDNs or mirrors in case of bad network condition.