### PR TITLE
render_math: clarify scope of macro support

### DIFF
--- a/render_math/Readme.md
+++ b/render_math/Readme.md
@@ -129,17 +129,20 @@ must *not* be any whitespace before the ending `$`. So for example:
  * **Will not render as inline math**: `$40 vs $50`
 
 ###Displayed Math
-Math between `$$`..`$$`, for example, `$$`x^2`$$`, will be rendered centered in a
+Math between `$$`..`$$` will be rendered "block style", for example, `$$`x^2`$$`, will be rendered centered in a
 new paragraph.
 
-###Latex Macros
-Latex macros are supported, and are automatically treated like displayed math 
-(i.e. it is wrapped in `div` tag). For example, `begin{equation}` x^2 `\end{equation}`,
+####Other Latex  Display Math commands
+The other LaTeX commands which usually invoke display math mode from text mode
+are supported,
+and are automatically treated like `$$`-style displayed math 
+in that they are rendered "block" style on their own lines.
+For example, `begin{equation}` x^2 `\end{equation}`,
 will be rendered in its own block with a right justified equation number
 at the top of the block. This equation number can be referenced in the document.
 To do this, use a `label` inside of the equation format and then refer to that label
-using `ref`. For example: `begin{equation}` `\label{eq}` X^2 `\end{equation}`. Now
-refer to that equation number by `$`\ref{eq}`$`.
+using `ref`. For example: `begin{equation}` `\label{eq}` X^2 `\end{equation}`. 
+Now refer to that equation number by `$`\ref{eq}`$`.
 
 reStructuredText
 ----------------


### PR DESCRIPTION
I would like to introduce LaTeX macros support (e.g. for `\renewcommand` and the limited macro definitions that MathJaX allows)

However, I need to update the documentation first because otherwise when discussing math display environments it seems to imply that some kind of user macro support already exists.

This patch clarifies that we are discussing supporting display math environment macros in particular, rather than arbitrary macros (which in the broad sense are not in any case supported by all our rendering backends)