### PR TITLE
rmd_reader: Use relpath sans ext of markdown source as prefix for figures to avoid overwriting figures with same chunk name

### DIFF
--- a/rmd_reader/Readme.md
+++ b/rmd_reader/Readme.md
@@ -44,7 +44,7 @@ This plugin calls R to process these files and generates markdown files that are
 `rmd_reader` has these variables that can be set in `pelicanconf`.
 
 - `RMD_READER_CLEANUP` (`True`): The RMarkdown file is converted into a Markdown file with the extension `.aux` (to avoid conflicts while pelican is processing). This file is processed by pelican's MarkdownReader and is removed after that (the cleanup step). So if you want to check this file set `RMD_READER_CLEANUP=True`.
-- `RMD_READER_RENAME_PLOT` (`True`): the figures generated for plots are named with a default prefix (usually `unnamed-chunk`) followed by a sequential number. That sequence starts on 1 for every processed file, which causes naming conflicts among files. In order to avoid these conflicts `RMD_READER_RENAME_PLOT` can be set `True` and that prefix is replaced with the same name of the post file, without extension. Another way to avoid conflicts is naming the chuncks and in that case this variable can be set `False`.
+- `RMD_READER_RENAME_PLOT` (`chunklabel`): the figures generated for plots are named with a default prefix (usually `unnamed-chunk`) followed by a sequential number. That sequence starts on 1 for every processed file, which causes naming conflicts among files. In order to avoid these conflicts `RMD_READER_RENAME_PLOT` can be set `chunklabel` and that prefix is replaced with the name of the markdown source, without extension. Alternatively, `RMD_READER_RENAME_PLOT` can be set `directory` in which case the `fig.path` (defaults to `figure/`) is augmented with the path to markdown source including the name of the source file without extension.  Another way to avoid conflicts is naming the chuncks and in that case this variable can be set to any other string.
 - `RMD_READER_KNITR_QUIET` (`True`): sets `knitr`'s quiet argument.
 - `RMD_READER_KNITR_ENCODING` (`UTF-8`): sets `knitr`'s encoding argument.
 - `RMD_READER_KNITR_OPTS_CHUNK` (`None`): sets `knitr`'s `opts_chunk`.
@@ -53,14 +53,16 @@ This plugin calls R to process these files and generates markdown files that are
 
 ### Plotting
 
-I strongly suggest using the variable `RMD_READER_RENAME_PLOT=True`.
+I strongly suggest using the variable `RMD_READER_RENAME_PLOT='chunklabel'`.
 That helps with avoiding naming conflits among different posts.
 `rmd_reader` sets knitr's `unnamed.chunk.label` option to the Rmd file name (without extension) in runtime.
 
 Alternatively, Rebecca Weiss (@rjweiss) suggested using `opts_chunk` to set knitr's `fig.path` ([link](http://rjweiss.github.io/articles/2014_08_25/testing-rmarkdown-integration/)).
-Now that can be done directly in `pelicanconf` thougth `RMD_READER_KNITR_OPTS_CHUNK`, that variable receives a `dict` with options to be passed to knitr's `opts_chunk`.
+Now that can be done directly in `pelicanconf` thougth `RMD_READER_KNITR_OPTS_CHUNK`, that variable receives a `dict` with options to be passed to knitr's `opts_chunk`. With this scheme you can set `RMD_READER_RENAME_PLOT='directory'` and add the generated figures directory to `STATIC_PATHS`.
 
 ```
-RMD_READER_KNITR_OPTS_CHUNK = {'fig.path': '../../../figure/'}
+RMD_READER_RENAME_PLOT = 'directory'
+RMD_READER_KNITR_OPTS_CHUNK = {'fig.path': 'figure/'}
+STATIC_PATHS = ['figure']
 ```
 

--- a/rmd_reader/rmd_reader.py
+++ b/rmd_reader/rmd_reader.py
@@ -53,6 +53,14 @@ class RmdReader(readers.BaseReader):
         ENCODING = self.settings.get('RMD_READER_KNITR_ENCODING', 'UTF-8')
         CLEANUP = self.settings.get('RMD_READER_CLEANUP', True)
         RENAME_PLOT = self.settings.get('RMD_READER_RENAME_PLOT', 'chunklabel')
+        if type(RENAME_PLOT) is bool:
+            logger.error("RMD_READER_RENAME_PLOT takes a string value (either chunklabel or directory), please see the readme.")
+            if RENAME_PLOT:
+                RENAME_PLOT = 'chunklabel'
+                logger.error("Defaulting to chunklabel")
+            else:
+                RENAME_PLOT = 'disabled'
+                logger.error("Disabling plot renaming")
         logger.debug("RMD_READER_KNITR_QUIET = %s", QUIET)
         logger.debug("RMD_READER_KNITR_ENCODING = %s", ENCODING)
         logger.debug("RMD_READER_CLEANUP = %s", CLEANUP)
@@ -66,11 +74,11 @@ class RmdReader(readers.BaseReader):
                 chunk_label = os.path.splitext(os.path.basename(filename))[0]
                 logger.debug('Chunk label: %s', chunk_label)
             elif RENAME_PLOT == 'directory':
-                chunk_label = 'unnamed_chunk'
+                chunk_label = 'unnamed-chunk'
                 PATH = self.settings.get('PATH','%s/content' % settings.DEFAULT_CONFIG.get('PATH'))
                 src_name = os.path.splitext(os.path.relpath(filename, PATH))[0]
                 idx = knitr.opts_chunk.names.index('set')
-                knitroptschunk = { 'fig.path': os.path.join(fig_path, src_name) }
+                knitroptschunk = { 'fig.path': '%s-' % os.path.join(fig_path, src_name) }
                 knitr.opts_chunk[idx](**{str(k): v for k,v in knitroptschunk.items()})
                 logger.debug('Figures path: %s, chunk label: %s', knitroptschunk['fig.path'], chunk_label)
             robjects.r('''

--- a/rmd_reader/rmd_reader.py
+++ b/rmd_reader/rmd_reader.py
@@ -12,9 +12,10 @@ from pelican import settings
 
 knitr = None
 rmd = False
+fig_path = None
 
 def initsignal(pelicanobj):
-    global knitr, rmd, robjects
+    global knitr, rmd, fig_path, robjects
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -31,6 +32,7 @@ def initsignal(pelicanobj):
         idx = knitr.opts_chunk.names.index('set')
         knitroptschunk = pelicanobj.settings.get('RMD_READER_KNITR_OPTS_CHUNK', None)
         if knitroptschunk:
+            fig_path = knitroptschunk['fig.path'] if knitroptschunk.has_key('fig.path') else 'figure/'
             knitr.opts_chunk[idx](**{str(k): v for k,v in knitroptschunk.items()})
         rmd = True
     except ImportError as ex:
@@ -50,7 +52,7 @@ class RmdReader(readers.BaseReader):
         QUIET = self.settings.get('RMD_READER_KNITR_QUIET', True)
         ENCODING = self.settings.get('RMD_READER_KNITR_ENCODING', 'UTF-8')
         CLEANUP = self.settings.get('RMD_READER_CLEANUP', True)
-        RENAME_PLOT = self.settings.get('RMD_READER_RENAME_PLOT', True)
+        RENAME_PLOT = self.settings.get('RMD_READER_RENAME_PLOT', 'chunklabel')
         logger.debug("RMD_READER_KNITR_QUIET = %s", QUIET)
         logger.debug("RMD_READER_KNITR_ENCODING = %s", ENCODING)
         logger.debug("RMD_READER_CLEANUP = %s", CLEANUP)
@@ -59,9 +61,18 @@ class RmdReader(readers.BaseReader):
         filename = filename.replace('\\', '\\\\')
         # parse Rmd file - generate md file
         md_filename = filename.replace('.Rmd', '.aux').replace('.rmd', '.aux')
-        if RENAME_PLOT:
-            chunk_label = os.path.splitext(os.path.basename(filename))[0]
-            logger.debug('Chunk label: %s', chunk_label)
+        if RENAME_PLOT == 'chunklabel' or RENAME_PLOT == 'directory':
+            if RENAME_PLOT == 'chunklabel':
+                chunk_label = os.path.splitext(os.path.basename(filename))[0]
+                logger.debug('Chunk label: %s', chunk_label)
+            elif RENAME_PLOT == 'directory':
+                chunk_label = 'unnamed_chunk'
+                PATH = self.settings.get('PATH','%s/content' % settings.DEFAULT_CONFIG.get('PATH'))
+                src_name = os.path.splitext(os.path.relpath(filename, PATH))[0]
+                idx = knitr.opts_chunk.names.index('set')
+                knitroptschunk = { 'fig.path': os.path.join(fig_path, src_name) }
+                knitr.opts_chunk[idx](**{str(k): v for k,v in knitroptschunk.items()})
+                logger.debug('Figures path: %s, chunk label: %s', knitroptschunk['fig.path'], chunk_label)
             robjects.r('''
 opts_knit$set(unnamed.chunk.label="{unnamed_chunk_label}")
 render_markdown()

--- a/rmd_reader/test_rmd_reader.py
+++ b/rmd_reader/test_rmd_reader.py
@@ -75,7 +75,7 @@ plot(cars)
             'OUTPUT_PATH': self.outputdir,
             'RMD_READER_KNITR_OPTS_CHUNK': {'fig.path' : '%s/' % self.figpath},
             'RMD_READER_KNITR_OPTS_KNIT': {'progress' : True, 'verbose': True},
-            'RMD_READER_RENAME_PLOT': False,
+            'RMD_READER_RENAME_PLOT': 'disable',
             'PLUGIN_PATHS': ['../'],
             'PLUGINS': ['rmd_reader'],
         })
@@ -104,7 +104,7 @@ plot(cars)
             'OUTPUT_PATH': self.outputdir,
             'RMD_READER_KNITR_OPTS_CHUNK': {'fig.path' : '%s/' % self.figpath},
             'RMD_READER_KNITR_OPTS_KNIT': {'progress' : True, 'verbose': True},
-            'RMD_READER_RENAME_PLOT': True,
+            'RMD_READER_RENAME_PLOT': 'chunklabel',
             'PLUGIN_PATHS': ['../'],
             'PLUGINS': ['rmd_reader'],
         })
@@ -125,6 +125,33 @@ plot(cars)
         logging.debug(images)
         self.assertTrue(len(images) == 1,'Contents of images dir is not correct: %s' % ','.join(images))
 
+    def testKnitrSettings3(self):
+        settings = read_settings(path=None, override={
+            'LOAD_CONTENT_CACHE': False,
+            'PATH': self.contentdir,
+            'OUTPUT_PATH': self.outputdir,
+            'RMD_READER_KNITR_OPTS_CHUNK': {'fig.path' : '%s/' % self.figpath},
+            'RMD_READER_KNITR_OPTS_KNIT': {'progress' : True, 'verbose': True},
+            'RMD_READER_RENAME_PLOT': 'directory',
+            'PLUGIN_PATHS': ['../'],
+            'PLUGINS': ['rmd_reader'],
+        })
+        pelican = Pelican(settings=settings)
+        pelican.run()
+
+        outputfilename = os.path.join(self.outputdir,'%s.html' % self.testtitle)
+        self.assertTrue(os.path.exists(outputfilename),'File %s was not created.' % outputfilename)
+
+        imagesdir = os.path.join(self.outputdir, self.figpath)
+        self.assertTrue(os.path.exists(imagesdir), 'figpath not created.')
+
+        imagefile = os.path.join(imagesdir, os.path.splitext(os.path.split(self.contentfile)[1])[0]) + '-unnamed-chunk-1-1.png'
+        logging.debug(imagefile)
+        self.assertTrue(os.path.exists(imagefile), 'image correctly named.')
+
+        images = glob.glob('%s/*' % imagesdir)
+        logging.debug(images)
+        self.assertTrue(len(images) == 1,'Contents of images dir is not correct: %s' % ','.join(images))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit changes the behaviour of RMD_READER_RENAME_PLOT variable such that it can be set to chunklabel to enable the default unnamed chunk renaming, or to directory to rename figures according to the path of the markdown source. The latter is intended to be used in conjuction with setting fig.path in knitr options. Alternatively the variable can be set to anything else to disable automatic renaming, in which case the chunks in markdown files must have unique names.