### PR TITLE
asciidoc_reader: Don't add empty metadata values

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -51,6 +51,8 @@ class AsciiDocReader(BaseReader):
 
         metadata = {}
         for name, value in ad.asciidoc.document.attributes.items():
+            if value is None:
+                continue
             name = name.lower()
             metadata[name] = self.process_metadata(name, six.text_type(value))
         if 'doctitle' in metadata:


### PR DESCRIPTION
The asciidoc api will return unset document attributes as empty strings. When set as metadata this will cause errors. This workarounds by pruning empty values before setting them as metadata.
