### PR TITLE
liquid_tags.youtube: change regex to support width & height in percents

### DIFF
--- a/liquid_tags/youtube.py
+++ b/liquid_tags/youtube.py
@@ -26,7 +26,7 @@ from .mdx_liquid_tags import LiquidTags
 
 SYNTAX = "{% youtube id [width height] %}"
 
-YOUTUBE = re.compile(r'([\S]+)(\s+(\d+)\s(\d+))?')
+YOUTUBE = re.compile(r'([\S]+)(\s+([\d%]+)\s([\d%]+))?')
 
 
 @LiquidTags.register('youtube')


### PR DESCRIPTION
The liquid_tags youtube module will support both absolute and percent size of video player.

Now it's only possible to do: {% youtube VIDEO_ID 640 390 %}
Will be possible to do so as well: {% youtube VIDEO_ID 640% 390% %}