### PR TITLE
Photos plugin enhancement

### DIFF
--- a/photos/photos.py
+++ b/photos/photos.py
@@ -132,38 +132,51 @@ def detect_content(content):
 def process_gallery_photo(generator, article, gallery):
     if gallery.startswith('/'):
         gallery = gallery[1:]
-    dir_gallery = os.path.join(
-                    os.path.expanduser(generator.settings['PHOTO_LIBRARY']),
-                    gallery)
-    if os.path.isdir(dir_gallery):
-        logger.info('photos: Gallery detected: %s', gallery)
-        dir_photo = os.path.join('photos', gallery.lower())
-        dir_thumb = os.path.join('photos', gallery.lower())
-        exifs = read_notes(os.path.join(dir_gallery, 'exif.txt'),
-                           msg='photos: No EXIF for gallery %s')
-        captions = read_notes(os.path.join(dir_gallery, 'captions.txt'))
-        article.photo_gallery = []
-        for pic in sorted(os.listdir(dir_gallery)):
-            if pic.startswith('.'): continue
-            if pic.endswith('.txt'): continue
-            photo = os.path.splitext(pic)[0].lower() + '.jpg'
-            thumb = os.path.splitext(pic)[0].lower() + 't.jpg'
-            article.photo_gallery.append((
-                pic,
-                os.path.join(dir_photo, photo),
-                os.path.join(dir_thumb, thumb),
-                exifs.get(pic, ''),
-                captions.get(pic, '')))
-            enqueue_resize(
-                os.path.join(dir_gallery, pic),
-                os.path.join(dir_photo, photo),
-                generator.settings['PHOTO_GALLERY'])
-            enqueue_resize(
-                os.path.join(dir_gallery, pic),
-                os.path.join(dir_thumb, thumb),
-                generator.settings['PHOTO_THUMB'])
-    else:
-        logger.error('photos: Gallery does not exist: %s at %s', gallery, dir_gallery)
+
+    galleries = gallery.split('{photo}')
+    article.photo_gallery = []
+
+    for gallery in galleries:
+        # strip whitespaces
+        gallery = gallery.strip()
+
+        dir_gallery = os.path.join(
+                        os.path.expanduser(generator.settings['PHOTO_LIBRARY']),
+                        gallery)
+
+        if os.path.isdir(dir_gallery):
+            logger.info('photos: Gallery detected: %s', gallery)
+            dir_photo = os.path.join('photos', gallery.lower())
+            dir_thumb = os.path.join('photos', gallery.lower())
+            exifs = read_notes(os.path.join(dir_gallery, 'exif.txt'),
+                               msg='photos: No EXIF for gallery %s')
+            captions = read_notes(os.path.join(dir_gallery, 'captions.txt'))
+            articleGallery = []
+
+            for pic in sorted(os.listdir(dir_gallery)):
+                if pic.startswith('.'): continue
+                if pic.endswith('.txt'): continue
+                photo = os.path.splitext(pic)[0].lower() + '.jpg'
+                thumb = os.path.splitext(pic)[0].lower() + 't.jpg'
+                articleGallery.append((
+                    pic,
+                    os.path.join(dir_photo, photo),
+                    os.path.join(dir_thumb, thumb),
+                    exifs.get(pic, ''),
+                    captions.get(pic, '')))
+
+                enqueue_resize(
+                    os.path.join(dir_gallery, pic),
+                    os.path.join(dir_photo, photo),
+                    generator.settings['PHOTO_GALLERY'])
+                enqueue_resize(
+                    os.path.join(dir_gallery, pic),
+                    os.path.join(dir_thumb, thumb),
+                    generator.settings['PHOTO_THUMB'])
+
+            article.photo_gallery.append((gallery, articleGallery))
+        else:
+            logger.error('photos: Gallery does not exist: %s at %s', gallery, dir_gallery)
 
 
 def process_gallery_filename(generator, article, gallery):

--- a/photos/photos.py
+++ b/photos/photos.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 queue_resize = dict()
 hrefs = None
 
+created_galleries = {}
 
 def initialized(pelican):
     p = os.path.expanduser('~/Pictures')
@@ -140,6 +141,10 @@ def process_gallery_photo(generator, article, gallery):
         # strip whitespaces
         gallery = gallery.strip()
 
+        if gallery in created_galleries:
+            article.photo_gallery.append((gallery, created_galleries[gallery]))
+            continue
+
         dir_gallery = os.path.join(
                         os.path.expanduser(generator.settings['PHOTO_LIBRARY']),
                         gallery)
@@ -175,6 +180,7 @@ def process_gallery_photo(generator, article, gallery):
                     generator.settings['PHOTO_THUMB'])
 
             article.photo_gallery.append((gallery, articleGallery))
+            created_galleries[gallery] = articleGallery
         else:
             logger.error('photos: Gallery does not exist: %s at %s', gallery, dir_gallery)
 


### PR DESCRIPTION
The photos plugin works nicely for monolingual homepages. Together with i18n_subsites the galleries are processed once for each language, and an additional time for the initial page generation. This is of course not what should happen. The pictures are the same for a certain gallery independant of the language of the post which uses the gallery.

With this pull request I add some memoization to the photos plugin such that the galleries are only processed once and not multiple times.

Additionally I added the possibility of specifying multiple galleries for one post. This is as easy as putting them in the same :gallery: tag e.g. ```:gallery: {photo}folder1 {photo}folder2```
Please note that this feature does only work with the ```{photo}``` syntax and not with ```{filename}```