### PR TITLE
[pelican_comment_system] Logs a warning if the parent of a comment can not be found.

### DIFF
--- a/pelican_comment_system/pelican_comment_system.py
+++ b/pelican_comment_system/pelican_comment_system.py
@@ -187,9 +187,16 @@ def add_static_comments(gen, content):
 
     # TODO: Fix this O(n²) loop
     for reply in replies:
+        found_parent = False
         for comment in chain(comments, replies):
             if comment.slug == reply.replyto:
                 comment.addReply(reply)
+                found_parent = True
+                break
+        if not found_parent:
+            logger.warning('Comment "%s/%s" is a reply to non-existent comment "%s". '
+                'Make sure the replyto attribute is set correctly.',
+                content.slug, reply.slug, reply.replyto)
 
     count = 0
     for comment in comments:


### PR DESCRIPTION
https://github.com/getpelican/pelican-plugins/issues/714#issuecomment-219302129 :
> I'll add a warning if we processes a comment with an invalid parent.
> So in the future such errors are easy to detect.