### PR TITLE
Fix filetime_from_git not working in python3

### DIFF
--- a/filetime_from_git/git_wrapper.py
+++ b/filetime_from_git/git_wrapper.py
@@ -53,7 +53,7 @@ class _GitWrapperCommon(object):
         '''
         commit_shas = self.git.log(
             '--pretty=%H', '--follow', '--', path).splitlines()
-        return map(self.repo.commit, commit_shas)
+        return [self.repo.commit(shas) for shas in commit_shas]
 
     def get_commits(self, path, follow=False):
         '''


### PR DESCRIPTION
Fix filetime_from_git not working in python3 when `GIT_FILETIME_FOLLOW = True`. This fix uses list comprehension instead of map which works in both python2 and python3.