### PR TITLE
[pelican_comment_system] Fix comparison of offset-naive and offset-aware datetimes

### DIFF
--- a/pelican_comment_system/comment.py
+++ b/pelican_comment_system/comment.py
@@ -52,7 +52,7 @@ class Comment(Content):
         return None
 
     def __lt__(self, other):
-        return self.metadata['date'] < other.metadata['date']
+        return self.date < other.date
 
     def sortReplies(self):
         for r in self.replies:


### PR DESCRIPTION
The direct `date` attribute of a Content object has always a timezone. 

Fixes #721