### PR TITLE
Add read time feature

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -206,6 +206,8 @@ Random article            Generates a html file which redirect to a random artic
 
 Read More link            Inserts an inline "read more" or "continue" link into the last html element of the object summary
 
+Read Time                 Calculates the read time based on the number of words and a words per minute count
+
 Related posts             Adds the ``related_posts`` variable to the article's context
 
 Render Math               Render mathematics in content via the MathJax Javascript engine

--- a/read_time/README.md
+++ b/read_time/README.md
@@ -1,0 +1,64 @@
+Read Time
+===================================
+
+This plugin calculates the read time for each article based on the number of words and a words per minute count. There are two ways to set up the plugin: using words per minute only or using the more advanced language option.
+
+## Setting Up
+
+#### 1. Words Per Minute Only
+
+In your settings you would use assign the `READ_TIME` variable to an integer like so:
+
+***pelicanconf.py***
+```
+READ_TIME = 180
+```
+
+Every article's read time would  be calculated using this average words per minute count. (See the Usage section for how to use the calculated read times in templates). This is the simplest read time method.
+
+#### 2. Words Per Minute per language
+
+This is the preferred method if you are dealing with multiple languages. Take a look at the following settings
+
+
+***pelicanconf.py***
+```
+READ_TIME = {
+    'default': {
+        'wpm': 180,
+        'plurals': ['minute', 'minutes']
+    },
+    'es': {
+        'wpm': 200,
+        'plurals': ['minuto', 'minutos']
+    },
+    'it': {
+    	'plurals': ['minuto', 'minuti']
+	}
+}
+```
+
+
+In this example the default reading time for all articles is 180 words per minute. Any articles in spanish will be calculated at 200 wpm. This is useful for information dense languages where the read time varies rapidly.
+
+Also notice the Italian language, the read time for all italian articles will be 180wpm (the default value). However, the article will also be able to take advantage of the plurality option. An italian article that takes four minutes to read will have access to a variable that prints "4 minuti". (See the Usage section for how to use the calculated read times in templates)
+
+Chances are the average reading time will not vary rapidly from language to language, however using this method also allows you to set plurals which make templating easier in the long run.
+
+## Usage
+
+Two variables are accessible through the read time plugin, **read_time** and **read_time_string**
+
+```
+This article takes {{article.read_time}} minute(s) to read.
+// This article takes 4 minute(s) to read
+```
+
+```
+This article takes {{article.read_time_string}} to read.
+// This article takes 4 minutes to read
+```
+
+## Contact
+
+Deepak Bhalla https://deepakrb.com 2016

--- a/read_time/__init__.py
+++ b/read_time/__init__.py
@@ -1,0 +1,1 @@
+from read_time import *

--- a/read_time/read_time.py
+++ b/read_time/read_time.py
@@ -1,0 +1,91 @@
+from pelican import signals
+from itertools import chain
+
+
+def init(generator):
+    data = {
+        'default': {
+            'wpm': 200,
+            'plurals': [
+                'minute',
+                'minutes'
+            ]
+        }
+    }
+
+    settings_wpm = generator.settings.get('READ_TIME', data)
+
+    # Allows a wpm entry
+    if isinstance(settings_wpm, int):
+        data['default']['wpm'] = settings_wpm
+
+    # Default checker
+    if isinstance(settings_wpm, dict):
+        if 'default' not in settings_wpm:
+            return None
+        if 'wpm' not in settings_wpm['default']:
+            return None
+        if 'plurals' not in settings_wpm['default']:
+            return None
+        if not isinstance(settings_wpm['default']['wpm'], int):
+            return None
+        if not isinstance(settings_wpm['default']['plurals'], list):
+            return None
+        if len(settings_wpm['default']['plurals']) != 2:
+            return None
+        data = settings_wpm
+
+    for article in chain(generator.articles, generator.drafts, generator.translations, generator.drafts_translations):
+        language = 'default'
+        if article.lang in data:
+            language = article.lang
+        # Exit if read time is set by article
+        if hasattr(article, 'read_time'):
+            return None
+
+        article.read_time = calculate_wpm(article.content, data, language)
+        article.read_time_string = generate_string(
+            article.read_time, data, language)
+
+def calculate_wpm(text, data, language):
+    '''
+    Calculates read length of article
+    '''
+
+    try:
+        wpm = data[language]['wpm']
+    except LookupError:
+        wpm = data['default']['wpm']
+
+    read_time = len(text.split(' ')) / wpm
+
+    # Articles cannot take 0 minutes to read
+    if read_time == 0:
+        return 1
+
+    return read_time
+
+
+def generate_string(read_time, data, language):
+    '''
+    Generates read length as string with appropriate plurality i.e 1 minute, 4 minutes
+    '''
+
+    try:
+        non_plural = data[language]['plurals'][0]
+    except LookupError:
+        non_plural = data['default']['plurals'][0]
+
+    try:
+        plural = data[language]['plurals'][1]
+    except LookupError:
+        plural = data['default']['plurals'][1]
+
+    if read_time != 1:
+        return '{0} {1}'.format(read_time, plural)
+
+    return '{0} {1}'.format(read_time, non_plural)
+
+
+def register():
+    signals.article_generator_finalized.connect(init)


### PR DESCRIPTION
This plugin calculates the read time for each article based on the number of words and a words per minute count. This is quite commonly seen on medium articles. (See [here](https://www.deepakrb.com/blog/) for how it looks in pelican). There are two ways to set up the plugin: using words per minute only or using the more advanced language option.
