### PR TITLE
[better_figures_and_images] Default to 100% width if opening image with PIL fails (e.g. for SVG images)

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -77,8 +77,12 @@ def content_object_init(instance):
                 logger.debug('Better Fig. src: %s', src)
 
                 # Open the source image and query dimensions; build style string
-                im = Image.open(src)
-                extra_style = 'width: {}px; height: auto;'.format(im.size[0])
+                try:
+                    im = Image.open(src)
+                    extra_style = 'width: {}px; height: auto;'.format(im.size[0])
+                except IOError as e:
+                    logger.debug('Better Fig. Failed to open: %s', src)
+                    extra_style = 'width: 100%; height: auto;'
 
                 if 'RESPONSIVE_IMAGES' in instance.settings and instance.settings['RESPONSIVE_IMAGES']:
                     extra_style += ' max-width: 100%;'


### PR DESCRIPTION
The better_figures_and_images plugin stops with an error if it fails to open any image to parse its width. For example, this would happen with RMarkdown articles with SVG plots. Instead, according to [this article](http://tympanus.net/codrops/2014/08/19/making-svgs-responsive-with-css/) we could just set the width to 100%.