### PR TITLE
Hotfix/#602 liquid tags decode str error

### DIFF
--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -124,8 +124,8 @@ def include_code(preprocessor, tag, markup):
         lang_include = ':::' + lang + '\n    '
     else:
         lang_include = ''
-    
-    if sys.version_info[0] < 3
+
+    if sys.version_info[0] < 3:
         source = (open_tag
                   + '\n\n    '
                   + lang_include
@@ -136,7 +136,7 @@ def include_code(preprocessor, tag, markup):
                   + '\n\n    '
                   + lang_include
                   + '\n    '.join(code.split('\n')) + '\n\n'
-                  + close_tags + '\n')
+                  + close_tag + '\n')
 
     return source
 


### PR DESCRIPTION
liquid_tags plugin: Fixes issue [#602 liquid tags decode str error](https://github.com/getpelican/pelican-plugins/issues/602) on Python 3.