### PR TITLE
[liquid_tags] include_code tag Python3 compatibility. Fixes #602

### DIFF
--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -39,6 +39,7 @@ in the STATIC_PATHS setting, e.g.:
 """
 import re
 import os
+import sys
 from .mdx_liquid_tags import LiquidTags
 
 
@@ -124,11 +125,18 @@ def include_code(preprocessor, tag, markup):
     else:
         lang_include = ''
 
-    source = (open_tag
-              + '\n\n    '
-              + lang_include
-              + '\n    '.join(code.decode(codec).split('\n')) + '\n\n'
-              + close_tag + '\n')
+    if sys.version_info[0] < 3:
+        source = (open_tag
+                  + '\n\n    '
+                  + lang_include
+                  + '\n    '.join(code.decode(codec).split('\n')) + '\n\n'
+                  + close_tag + '\n')
+    else:
+        source = (open_tag
+                  + '\n\n    '
+                  + lang_include
+                  + '\n    '.join(code.split('\n')) + '\n\n'
+                  + close_tag + '\n')
 
     return source
 


### PR DESCRIPTION
When using Python3 calling .decode(codec) on a str is impossible.
We need to check against python's interpreter version to check
if we can decode or not the str.
