### PR TITLE
Add jinja2content plugin, allowing the use of Jinja2 directives inside articles

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -124,6 +124,8 @@ Image Process             Automates the processing of images based on their clas
 
 Interlinks                Lets you add frequently used URLs to your markup using short keywords
 
+Jinja2 Content            Allows the use of Jinja2 template code in articles, including ``include`` and ``import`` statements. Replacement for pelican-jinja2content.
+
 Just table                Easily create tables in articles
 
 Libravatar                Allows inclusion of user profile pictures from libravatar.org

--- a/jinja2content/README.md
+++ b/jinja2content/README.md
@@ -1,0 +1,65 @@
+# Jinja2 Content
+
+This plugin allows the use of Jinja2 directives inside your pelican
+articles and pages. This template rendering is done before the final html
+is generated, i.e. before your theme's `article.html` is applied. This
+means the context and jinja variables usually visible to your article
+template **ARE NOT** available at this time.
+
+All code that needs those variables (`article`, `category`, etc) should be
+put inside the theme's template logic. As such, the main use of this plugin
+is to automatically generate parts of your articles.
+
+
+## Example
+
+One usage is to embed repetitive html code into Markdown articles. Since
+Markdown doesn't care for layout, if anything more sophisticated than just
+displaying an image is necessary, one is forced to embed html in Markdown
+articles (at the very least, hardcode `<div>` tags and then fix it with the
+theme's CSS). However, with `jinja2content`, one can do the following.
+
+File `my-cool-article.md`
+```
+# My cool title
+
+My cool content.
+
+{% from 'img_desc.html' import img_desc %}
+{{ img_desc("/images/my-cool-image.png",
+    "This is a cool tooltip",
+    "This is a very cool image.") }}
+```
+
+Where file `img_desc.html` contains:
+```
+{% macro img_desc(src, title='', desc='') -%}
+<div class="img-desc">
+  <p><img src="{{ src }}" title="{{ title }}"></p>
+  {% if desc %}
+  <p><em>{{ desc }}</em></p>
+  {% endif %}
+</div>
+{%- endmacro %}
+```
+
+In this way, Markdown articles have more control over the content that is
+passed to the theme's `article.html`, without the need to pollute the
+Markdown with html. Another added benefit is that now `img_desc` is
+reusable across articles.
+
+Note that templates rendered with `jinja2content` can contain Markdown as
+well as html, since they are added before the Markdown content is converted
+to html.
+
+
+## Notes
+
++ Only Markdown supported at this moment. Adding .rst support shouldn't be
+  too hard, and you can ask for it here.
++ All templates `include`d in this way must be placed in your theme's
+  `templates` directory.
++ This plugin is intended to replace
+  [pelican-jinj2content](https://github.com/joachimneu/pelican-jinja2content/tree/f73ef9b1ef1ee1f56c80757b4190b53f8cd607d1)
+  which hasn't been developed in a while and generated empty `<p>` tags in
+  the final html output.

--- a/jinja2content/__init__.py
+++ b/jinja2content/__init__.py
@@ -1,0 +1,1 @@
+from .jinja2content import *

--- a/jinja2content/jinja2content.py
+++ b/jinja2content/jinja2content.py
@@ -1,0 +1,43 @@
+import os
+
+from pelican import signals
+from pelican.readers import Markdown, MarkdownReader
+from pelican.utils import pelican_open
+from jinja2 import Environment, FileSystemLoader
+
+
+class JinjaMarkdownReader(MarkdownReader):
+
+    def __init__(self, *args, **kwargs):
+        super(JinjaMarkdownReader, self).__init__(*args, **kwargs)
+
+        templates_dir = os.path.join(self.settings['THEME'], 'templates')
+        self._env = Environment(
+            trim_blocks=True, lstrip_blocks=True,
+            loader=FileSystemLoader(templates_dir),
+            extensions=self.settings['JINJA_EXTENSIONS'])
+
+    def read(self, source_path):
+        """Parse content and metadata of markdown files.
+
+        Rendering them as jinja templates first.
+
+        """
+
+        self._source_path = source_path
+        self._md = Markdown(extensions=self.extensions)
+        with pelican_open(source_path) as text:
+            text = self._env.from_string(text).render()
+            content = self._md.convert(text)
+
+        metadata = self._parse_metadata(self._md.Meta)
+        return content, metadata
+
+
+def add_reader(readers):
+    for ext in MarkdownReader.file_extensions:
+        readers.reader_classes[ext] = JinjaMarkdownReader
+
+
+def register():
+    signals.readers_init.connect(add_reader)


### PR DESCRIPTION
This plugin is intended to replace [pelican-jinja2content](https://github.com/joachimneu/pelican-jinja2content/tree/f73ef9b1ef1ee1f56c80757b4190b53f8cd607d1) which hasn't been developed in a while and generated empty `<p>` tags in final html output.