### PR TITLE
Glossary plugin: accept GLOSSARY_EXCLUDE as a setting to skip over some predefined definition lists

### DIFF
--- a/glossary/glossary.py
+++ b/glossary/glossary.py
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup
 
 class Definitions():
     definitions = []
-    exclude = ['Hint']
+    exclude = []
 
 
 def extract_definitions(content):
@@ -59,6 +59,11 @@ def set_definitions(generator, metadata):
     generator.context['definitions'] = Definitions.definitions
 
 
+def get_excludes(generator, metadata):
+    Definitions.exclude = generator.context.get('GLOSSARY_EXCLUDE', [])
+
+
 def register():
+    signals.article_generator_context.connect(get_excludes)
     signals.content_object_init.connect(parse_content)
     signals.page_generator_context.connect(set_definitions)

--- a/glossary/readme.md
+++ b/glossary/readme.md
@@ -3,6 +3,9 @@
 Builds a glossary page containing definition lists found in articles and
 pages.
 
+
+## Example
+
 If you have an article or page that generates the following:
 
 file `defns.html` titled "My definitions"
@@ -48,6 +51,9 @@ dict2.see_also = [dict1]
 
 Note the `link` attribute does not necessarily point to `source.url`.
 
+
+## Usage
+
 Next is an example usage of the `definitions` variable.
 
 ```
@@ -73,3 +79,11 @@ Next is an example usage of the `definitions` variable.
 </dl>
 {% endfor %}
 ```
+
+## Notes
+
++ The `glossary` plugin supports the use of a `GLOSSARY_EXCLUDE` setting,
+  which can be set to an arbitrary list in your `pelicanconf.py`. By
+  default, it's equal to the empty list. `glossary` will add to
+  `definitions` all definitions **EXCEPT** those whose title is found
+  inside `GLOSSARY_EXCLUDE`.


### PR DESCRIPTION
Also updated readme accordingly.