### PR TITLE
Add plugin right_quoter to fix some curly quotes

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -218,6 +218,8 @@ Replacer                  Replace a text of a generated HTML
 
 Representative image      Extracts a representative image (i.e, featured image) from the article's summary or content
 
+Right Quoter              When used with typogrify/smartypants, this plugin attempts to fix the direction of assorted curly single quotes, e.g. for '90s, 'tis
+
 RMD Reader                Create posts via knitr RMarkdown files
 
 Section number            Adds section numbers for article headers, in the form of ``2.3.3``

--- a/right_quoter/ReadMe.rst
+++ b/right_quoter/ReadMe.rst
@@ -1,0 +1,41 @@
+Right Quoter
+------------
+
+When used with the ``TYPOGRIFY`` setting, this plugin attempts to fix
+the direction of the curly single quote for contractions with leading
+apostrophes, e.g. two-digit decade or year references like '90s or '78.
+
+Examples:
+
+::
+
+    &#8216;00s               --> &#8217;00s
+    &#8216;87                --> &#8217;87
+    Get &#8216;em!           --> Get &#8217;em!
+    &#8216;Tis but a scratch --> &#8217;Tis but a scratch
+
+| ‘00s → ’00s
+| ‘87 → ’87
+| Get ‘em! → Get ’em!
+| ‘Tis but a scratch. → ’Tis but a scratch.
+
+By piggybacking on the expected behavior of ``typogrify`` (which uses
+``smartypants`` for the curlying), it should respect the same ignored
+tags as ``typogrify``. (And only have an effect if ``typogrify`` is
+enabled.)
+
+It also handles wrapping spans that may be applied during processing
+before the plugin is able to act on the content, e.g.:
+
+::
+
+    <span class="quo">&#8217;</span>Tis
+    &#8217;<span class="caps">TWAS</span>
+    <span class="quo">&#8217;</span><span class="caps">TIS</span>
+
+Unfortunately it will also "fix" situations like this:
+
+| ‘98’ → ’98’
+| ‘98 things’ → ’98 things’
+
+Which is a challenge for another day.

--- a/right_quoter/__init__.py
+++ b/right_quoter/__init__.py
@@ -1,0 +1,1 @@
+from .right_quoter import *

--- a/right_quoter/right_quoter.py
+++ b/right_quoter/right_quoter.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+""" Right Quoter: Fix direction of assorted curly apostrophes
+
+When used with typogrify/smartypants, this plugin attempts to fix the
+direction of the curly single quote for contractions with leading
+apostrophes, e.g. two-digit decade or year references like '90s or '78.
+"""
+
+from __future__ import unicode_literals
+
+import re
+
+from pelican import contents
+from pelican import signals
+
+
+__author__ = 'Scott Carpenter'
+__email__ = 'scottc@movingtofreedom.org'
+
+
+regex_pattern = re.compile(
+    r'''(?xi)                # verbose mode, ignore case
+        &\#8216;             # left apos from typogrify/smartypants
+        (?=                  # positive lookahead
+          (</span>)?         # possible quote wrapper
+          (<span[^>]*>)?     # possible CAPS wrapper
+          (                  # exceptions
+            \d\d |           # two-digit years
+            \d0s |           # decades
+            em |             #
+            tis |            #
+            twas             #
+          )                  #
+          \b                 # word boundary
+        )                    # end of lookahead
+    '''
+)
+
+
+def rightify(text):
+    return re.sub(regex_pattern, '&#8217;', text)
+
+
+def right_quoter(content):
+    if isinstance(content, contents.Static):
+        return
+
+    content._content = rightify(content._content)
+    content.title = rightify(content.title)
+    if hasattr(content, '_summary'):  # summary metadata is set
+        content._summary = rightify(content._summary)
+
+
+def register():
+    signals.content_object_init.connect(right_quoter)

--- a/right_quoter/test_right_quoter.py
+++ b/right_quoter/test_right_quoter.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import unittest
+
+from pelican import contents
+
+from right_quoter import right_quoter
+
+
+class PseudoContent(contents.Content):
+
+    def __init__(self, content='content', title='title', summary=None):
+        self._content = content
+        self.title = title
+        if summary:
+            self._summary = summary
+
+
+class TestRightQuoter(unittest.TestCase):
+
+    def test_title(self):
+        expected = 'The &#8217;80s'
+        content = PseudoContent(title='The &#8216;80s')
+        right_quoter(content)
+        self.assertEqual(content.title, expected)
+
+    def test_summary(self):
+        expected = '&#8217;Twas the night...'
+        content = PseudoContent(summary='&#8216;Twas the night...')
+        right_quoter(content)
+        self.assertEqual(content._summary, expected)
+
+    def test_two_digit_year(self):
+        expected = '&#8216;7 &#8217;78 &#8216;789'
+        content = PseudoContent(content='&#8216;7 &#8216;78 &#8216;789')
+        right_quoter(content)
+        self.assertEqual(content._content, expected)
+
+    def test_decade(self):
+        expected = '&#8217;90s &#8216;90ss &#8216;95s'
+        content = PseudoContent(
+            content='&#8216;90s &#8216;90ss &#8216;95s'
+        )
+        right_quoter(content)
+        self.assertEqual(content._content, expected)
+
+    def test_quote_span(self):
+        expected = '<span class="quo">&#8217;</span>Tis but a test.'
+        content = PseudoContent(
+            content='<span class="quo">&#8216;</span>Tis but a test.'
+        )
+        right_quoter(content)
+        self.assertEqual(content._content, expected)
+
+    def test_caps_span(self):
+        expected = '&#8217;<span class="caps">EM</span>'
+        content = PseudoContent(
+            content='&#8216;<span class="caps">EM</span>'
+        )
+        right_quoter(content)
+        self.assertEqual(content._content, expected)
+
+    def test_quote_and_caps_spans(self):
+        expected = ('<span class="quo">&#8217;</span>'
+                    '<span class="caps">TIS</span>')
+        content = PseudoContent(
+            content=('<span class="quo">&#8216;</span>'
+                     '<span class="caps">TIS</span>')
+        )
+        right_quoter(content)
+        self.assertEqual(content._content, expected)
+
+    def test_word_boundary(self):
+        expected = '&#8217;em &#8216;emphasis&#8217;'
+        content = PseudoContent(
+            content='&#8216;em &#8216;emphasis&#8217;'
+        )
+        right_quoter(content)
+        self.assertEqual(content._content, expected)
+
+    def test_misc_non_matching(self):
+        expected = (
+            '<span class="quo">&#8216;</span>Blah blah blah'
+            '&#8216;<span class="caps">HELLO</span>Spam spam spam'
+            '<span class="quo">&#8216;</span>'
+            '<span class="caps">HONK</span> &#8216;tissue&#8217;'
+        )
+        content = PseudoContent(
+            content='<span class="quo">&#8216;</span>Blah blah blah'
+            '&#8216;<span class="caps">HELLO</span>Spam spam spam'
+            '<span class="quo">&#8216;</span>'
+            '<span class="caps">HONK</span> &#8216;tissue&#8217;'
+        )
+        right_quoter(content)
+        self.assertEqual(content._content, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When used with typogrify/smartypants, this plugin attempts to fix the
direction of the curly single quote for contractions with leading
apostrophes, e.g. two-digit decade or year references like '90s or '78.

(It won't hurt my feelings if this is judged trivial or too edge-casey to accept. Just wanted to share in case others might enjoy its benefits. Also of course happy to make any changes.)
