### PR TITLE
filetime_from_git: better py2 and py3 compatibility

### DIFF
--- a/filetime_from_git/git_wrapper.py
+++ b/filetime_from_git/git_wrapper.py
@@ -2,7 +2,10 @@
 """
 Wrap python git interface for compatibility with older/newer version
 """
-import itertools
+try:
+    from itertools import zip_longest
+except ImportError:
+    from six.moves import zip_longest
 import logging
 import os
 from time import mktime
@@ -19,7 +22,7 @@ def grouper(iterable, n, fillvalue=None):
     '''
     # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx
     args = [iter(iterable)] * n
-    return itertools.izip_longest(fillvalue=fillvalue, *args)
+    return zip_longest(fillvalue=fillvalue, *args)
 
 
 class _GitWrapperCommon(object):


### PR DESCRIPTION
Python 3 doesn't have izip_longest introduced in commit f5d897632977abd0ef9ea591347331e60063ffac -- apparently it's called zip_longest. For compatilibity with py2 and py3 this commit just implements the cookbook idiom (alternative 1) from 
http://python-future.org/compatible_idioms.html#itertools-filterfalse-zip-longest

Downside is that this requires the future package to be installed i.e. `pip install future`.