### PR TITLE
liquid_tags > graphviz: Decode base64 output string to UTF-8

### DIFF
--- a/liquid_tags/graphviz.py
+++ b/liquid_tags/graphviz.py
@@ -116,7 +116,7 @@ def graphviz_parser(preprocessor, tag, markup):
         output = run_graphviz(program, code)
 
         # Return Base64 encoded image
-        return '<div class="graphviz" style="text-align: center;"><img src="data:image/png;base64,%s"></div>' % base64.b64encode(output)
+        return '<div class="graphviz" style="text-align: center;"><img src="data:image/png;base64,%s"></div>' % base64.b64encode(output).decode('utf-8')
 
     else:
         raise ValueError('Error processing input. '


### PR DESCRIPTION
Fix byte string in python 3

`base64.b64encode` will output byte string in Python 3, and it breaks inline base64 image in HTML.
`decode('utf-8')` will convert a byte string into a string and make  python 2 be happy, too.

```
>>> print(base64.b64encode(b'\01'))
b'AQ=='
>>> print(base64.b64encode(b'\01').decode('utf-8'))
AQ==
```

