### PR TITLE
simple_footnotes: Fix html5lib module problem

### DIFF
--- a/simple_footnotes/simple_footnotes.py
+++ b/simple_footnotes/simple_footnotes.py
@@ -75,7 +75,7 @@ def parse_for_footnotes(article_or_page_generator):
                     ol.appendChild(li)
                     e.parentNode.removeChild(e)
                 dom.getElementsByTagName("body")[0].appendChild(ol)
-                s = html5lib.serializer.htmlserializer.HTMLSerializer(omit_optional_tags=False, quote_attr_values=True)
+                s = html5lib.serializer.HTMLSerializer(omit_optional_tags=False, quote_attr_values='legacy')
                 output_generator = s.serialize(html5lib.treewalkers.getTreeWalker("dom")(dom.getElementsByTagName("body")[0]))
                 article._content =  "".join(list(output_generator)).replace(
                     "<x-simple-footnote>", "[ref]").replace("</x-simple-footnote>", "[/ref]").replace(


### PR DESCRIPTION
Looks like html5lib module has been updated, and the plugin is broken. Here
is the way to fix that.

### Problems

`'Attribute error: html5lib.serializer' has no attribute 'htmlserializer'`