### PR TITLE
Add `deadlinks` plugin as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -133,3 +133,6 @@
 [submodule "pelican-ipynb"]
 	path = pelican-ipynb
 	url = https://github.com/danielfrg/pelican-ipynb
+[submodule "deadlinks"]
+	path = deadlinks
+	url = https://github.com/silentlamb/pelican-deadlinks.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -74,6 +74,8 @@ Custom article URLs       Adds support for defining different default URLs for d
 
 Dateish                   Treat arbitrary metadata fields as datetime objects
 
+Dead Links                Manage dead links (website not available, errors such as 403, 404)
+
 Disqus static comments    Adds a disqus_comments property to all articles. Comments are fetched at generation time using disqus API
 
 Encrypt content           Password protect pages and articles


### PR DESCRIPTION
This change adds a `deadlink` plugin to manage links to pages that are not available anymore. It allows to replace original link with a link to proper archive.org query. It also allows to modify anchor tags of dead links by adding custom classes or appending bootstrap labels to them.

I hope you find it useful.