### PR TITLE
Subcategory: Add support for folder-based subcategories.

### DIFF
--- a/subcategory/README.md
+++ b/subcategory/README.md
@@ -9,6 +9,8 @@ Feeds can be generated for each subcategory, just like categories and tags.
 
 ##Usage##
 
+###Metadata###
+
 Subcategories are an extension to categories. Add subcategories to an article's
 category metadata using a `/` like this:
 
@@ -33,6 +35,21 @@ breadcrumb-style navigation you might try something like this:
     {% endfor %}
     </ol>
     </nav>
+
+###Subcategory folders###
+
+To specify subcategories using folders you can configure `PATH_METADATA`  
+to extract the article path (containing all category and subcategory folders) 
+into the `subcategory_path` metadata. The following settings would use all available 
+subcategories for the hierarchy:
+
+    PATH_METADATA= '(?P<subcategory_path>.*)/.*'
+
+You can limit the depth of generated subcategories by adjusting the regular expression
+to only include a specific number of path separators (`/`). For example, the following 
+would generate only a single level of subcategories regardless of the folder tree depth:
+
+    PATH_METADATA= '(?P<subcategory_path>[^/]*/[^/]*)/.*'
 
 ##Subcategory Names##
 

--- a/subcategory/subcategory.py
+++ b/subcategory/subcategory.py
@@ -49,8 +49,12 @@ def get_subcategories(generator, metadata):
                 'subcategory', '{savepath}.html')
     if 'SUBCATEGORY_URL' not in generator.settings:
         generator.settings['SUBCATEGORY_URL'] = 'subcategory/{fullurl}.html'
-    
-    category_list = text_type(metadata.get('category')).split('/')
+
+    if 'subcategory_path' in metadata:
+        category_list = text_type(metadata.get('subcategory_path')).split('/')
+    else:
+        category_list = text_type(metadata.get('category')).split('/')
+
     category = (category_list.pop(0)).strip()
     category = Category(category, generator.settings)
     metadata['category'] = category


### PR DESCRIPTION
This PR adds support for folder-based subcategories, to remove the requirement to edit article files to edit/reorganise categories.

It is implemented based on providing an `PATH_METADATA` parameter to extract `subcategory_path` variable. Setting/unsetting this is sufficient to activate/deactivate folder-based subcategories. Using the regex allows for customisation of folder-subcategory hierarchy — e.g. to exclude specific subfolders, or adjust the hierarchy depth.

I've updated the `README.md` with an example of usage.