### PR TITLE
render_math: Handle math markup in drafts

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -341,7 +341,10 @@ def process_rst_and_summaries(content_generators):
 
     for generator in content_generators:
         if isinstance(generator, generators.ArticlesGenerator):
-            for article in generator.articles + generator.translations:
+            for article in (
+                    generator.articles +
+                    generator.translations +
+                    generator.drafts):
                 rst_add_mathjax(article)
                 #optionally fix truncated formulae in summaries.
                 if process_summary.mathjax_script is not None:


### PR DESCRIPTION
 to fix the lack of math markup in drafts mentioned in #805. (CC @MarkCWirt)
