### PR TITLE
render_math: fix for Pelican 3.7 MARKDOWN dict

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -269,7 +269,7 @@ def mathjax_for_markdown(pelicanobj, mathjax_script, mathjax_settings):
 
     # Instantiate markdown extension and append it to the current extensions
     try:
-        if isinstance(pelicanobj.settings['MD_EXTENSIONS'], list): # pelican 3.6.3 and earlier
+        if isinstance(pelicanobj.settings.get('MD_EXTENSIONS'), list): # pelican 3.6.3 and earlier
             pelicanobj.settings['MD_EXTENSIONS'].append(PelicanMathJaxExtension(config))
         else:
             pelicanobj.settings['MARKDOWN']['extension_configs'].update({PelicanMathJaxExtension(config):{}})

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -272,7 +272,7 @@ def mathjax_for_markdown(pelicanobj, mathjax_script, mathjax_settings):
         if isinstance(pelicanobj.settings['MD_EXTENSIONS'], list): # pelican 3.6.3 and earlier
             pelicanobj.settings['MD_EXTENSIONS'].append(PelicanMathJaxExtension(config))
         else:
-            pelicanobj.settings['MD_EXTENSIONS'].update({PelicanMathJaxExtension(config):{}})
+            pelicanobj.settings['MARKDOWN']['extension_configs'].update({PelicanMathJaxExtension(config):{}})
     except:
         sys.excepthook(*sys.exc_info())
         sys.stderr.write("\nError - the pelican mathjax markdown extension failed to configure. MathJax is non-functional.\n")

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -269,10 +269,17 @@ def mathjax_for_markdown(pelicanobj, mathjax_script, mathjax_settings):
 
     # Instantiate markdown extension and append it to the current extensions
     try:
-        if isinstance(pelicanobj.settings.get('MD_EXTENSIONS'), list): # pelican 3.6.3 and earlier
-            pelicanobj.settings['MD_EXTENSIONS'].append(PelicanMathJaxExtension(config))
+        # pelican 3.6.3 and earlier
+        if isinstance(pelicanobj.settings.get('MD_EXTENSIONS'), list):
+            pelicanobj.settings['MD_EXTENSIONS'].append(
+                PelicanMathJaxExtension(config)
+            )
         else:
-            pelicanobj.settings['MARKDOWN']['extension_configs'].update({PelicanMathJaxExtension(config):{}})
+            pelicanobj.settings['MARKDOWN'].setdefault(
+                'extensions', []
+            ).append(
+                PelicanMathJaxExtension(config)
+            )
     except:
         sys.excepthook(*sys.exc_info())
         sys.stderr.write("\nError - the pelican mathjax markdown extension failed to configure. MathJax is non-functional.\n")

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -269,7 +269,10 @@ def mathjax_for_markdown(pelicanobj, mathjax_script, mathjax_settings):
 
     # Instantiate markdown extension and append it to the current extensions
     try:
-        pelicanobj.settings['MD_EXTENSIONS'].append(PelicanMathJaxExtension(config))
+        if isinstance(pelicanobj.settings['MD_EXTENSIONS'], list): # pelican 3.6.3 and earlier
+            pelicanobj.settings['MD_EXTENSIONS'].append(PelicanMathJaxExtension(config))
+        else:
+            pelicanobj.settings['MD_EXTENSIONS'].update({PelicanMathJaxExtension(config):{}})
     except:
         sys.excepthook(*sys.exc_info())
         sys.stderr.write("\nError - the pelican mathjax markdown extension failed to configure. MathJax is non-functional.\n")


### PR DESCRIPTION
BEcause I am an idiot I can't persuade github to let me compare with the fork Krastanov:patch-1 as referenced in #787. However, here's my modified patch.