### PR TITLE
adding indexing option to representative_image

### DIFF
--- a/representative_image/representative_image.py
+++ b/representative_image/representative_image.py
@@ -9,8 +9,12 @@ def images_extraction(instance):
     representativeImage = None
     if type(instance) in (Article, Draft, Page):
         if 'image' in instance.metadata:
-            representativeImage = instance.metadata['image']
-
+            try:
+                ix = int(instance.metadata['image'])
+            except ValueError:
+                representativeImage = instance.metadata['image']
+        else:
+            ix = 0
         # Process Summary:
         # If summary contains images, extract one to be the representativeImage and remove images from summary
         soup = BeautifulSoup(instance.summary, 'html.parser')
@@ -26,9 +30,11 @@ def images_extraction(instance):
         # If there are no image in summary, look for it in the content body
         if not representativeImage:
             soup = BeautifulSoup(instance._content, 'html.parser')
-            imageTag = soup.find('img')
+            imageTag = soup.find_all('img')
             if imageTag:
-                representativeImage = imageTag['src']
+                if len(imageTag) < (ix + 1):
+                    raise ValueError('Image index exceeds number of images in document')
+                representativeImage = imageTag[ix]['src']
 
         # Set the attribute to content instance
         instance.featured_image = representativeImage

--- a/representative_image/test_representative_image.py
+++ b/representative_image/test_representative_image.py
@@ -57,6 +57,18 @@ class TestRepresentativeImage(unittest.TestCase):
         self.assertEqual(article.featured_image, TEST_CUSTOM_IMAGE_URL)
         self.assertEqual(article.summary, TEST_SUMMARY_WITHOUTIMAGE)
 
+    def test_extract_image_with_indexing(self):
+        args = {
+            'content': TEST_CONTENT,
+            'metadata': {
+                'summary': TEST_SUMMARY_WITHOUTIMAGE,
+                'image': '0'
+            },
+        }
+
+        article = Article(**args)
+        self.assertEqual(article.featured_image, TEST_CONTENT_IMAGE_URL
+
 if __name__ == '__main__':
     unittest.main()
         


### PR DESCRIPTION
This is a quick addition to add the ability to specify an image index to representative image. Instead of just supplying a URL to the article `Image` metadata, you can optionally give an integer. It will assume this integer corresponds to an image in the article. In this way you can include:

```
Image: 3
```
in the metadata, and it would look for the 4th image in the article instead of the 1st. It'll raise a valueerror if you give an index that exceeds the number of images in the article.

Tests were a bit wonky to get working, so somebody should make sure this looks correct.