### PR TITLE
pelican_comment_system: Fix link to import comments

### DIFF
--- a/pelican_comment_system/Readme.md
+++ b/pelican_comment_system/Readme.md
@@ -24,7 +24,7 @@ Bernhard Scheirle  | <http://bernhard.scheirle.de> | <https://github.com/Scheirl
 
  - [Quickstart Guide](doc/quickstart.md)
  - [Installation and basic usage](doc/installation.md)
- - [Import existing comments](docs/import.md)
+ - [Import existing comments](doc/import.md)
  - [Avatars and identicons](doc/avatars.md)
  - [Comment Atom feed](doc/feed.md)
  


### PR DESCRIPTION
Overlooked typo from #835