### PR TITLE
Added `extensions` to babel.cfg

### DIFF
--- a/i18n_subsites/localizing_using_jinja2.rst
+++ b/i18n_subsites/localizing_using_jinja2.rst
@@ -105,6 +105,11 @@ create a mapping file ``babel.cfg`` with the following line
 .. code-block:: cfg
 
     [jinja2: templates/**.html]
+    extensions=jinja2.ext.autoescape,jinja2.ext.with_,...
+    
+Make sure to mention all the extensions you are using. Failing to do 
+so will result in incomplete catalog. You can add `silent=false` if
+you need to debug.
 
 
 2. Extract translatable strings from templates


### PR DESCRIPTION
Being new to babel and i18n I spent a long time troubleshooting an incomplete catalog. The solution was quite easy: babel was missing an extension I was using: `jinja2.ext.do`. I hope adding these few lines would save time to other people who might use extensions.