### PR TITLE
gzip_cache: Exclude internally-compressed woff2

### DIFF
--- a/gzip_cache/gzip_cache.py
+++ b/gzip_cache/gzip_cache.py
@@ -42,6 +42,7 @@ EXCLUDE_TYPES = [
     # Internally-compressed fonts. gzip can often shave ~50 more bytes off,
     # but it's not worth it.
     '.woff',
+    '.woff2',
 ]
 
 COMPRESSION_LEVEL = 9 # Best Compression


### PR DESCRIPTION
As per [this gist](https://gist.github.com/sergejmueller/cf6b4f2133bcb3e2f64a#good-to-know), woff2 is compressed also, so it should be excluded from the gzip cache as well.