### PR TITLE
fixed warning _get_summary() deprecated in render math

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -201,7 +201,7 @@ def process_summary(article):
     """Ensures summaries are not cut off. Also inserts
     mathjax script so that math will be rendered"""
 
-    summary = article._get_summary()
+    summary = article.get_summary(article.get_siteurl())
     summary_parsed = BeautifulSoup(summary, 'html.parser')
     math = summary_parsed.find_all(class_='math')
 


### PR DESCRIPTION
Render Math plugin produced the following warning : 
```shell
# WARNING: _get_summary() has been deprecated since 3.6.4. Use the summary decorat
# or instead
```

Fixed it by simply changing the function to get_summary() instead of deprecated function _get_summary().