### PR TITLE
Tipue search add static mode.

### DIFF
--- a/tipue_search/README.md
+++ b/tipue_search/README.md
@@ -33,7 +33,8 @@ pip install beautifulsoup4
 
 How Tipue Search works
 =========================
-
+JSON mode
+---------
 Tipue Search serializes the generated HTML into JSON. Format of JSON is as follows
 
 ```python
@@ -57,10 +58,48 @@ Tipue Search serializes the generated HTML into JSON. Format of JSON is as follo
 
 JSON is written to file `tipuesearch_content.json` which is created in the root of `output` directory.
 
+Static mode
+-----------
+>Static mode is the default mode for Tipue Search, and also the fastest. We recommend using Static mode wherever possible.
+
+Tipue Search serializes the generated HTML into 'tipuesearch_content.js'.
+
+>Static mode uses site content stored in the tipuesearch_content.js file. It contains the search data as a JavaScript object.
+
+__JS__
+
+```javascript
+var tipuesearch = {
+  "pages": [
+    {
+      "title": "Tipue",
+      "text": "",
+      "tags": "jQuery HTML5 CSS",
+      "url": "http://www.tipue.com"
+    },
+    {
+      "title": "Tipue Search, a site search engine jQuery plugin",
+      "text": "Tipue Search is a site search engine jQuery plugin. It's free, open source, responsive and fast. Tipue Search only needs a browser that supports jQuery. It doesn't need MySQL or similar. In Static mode it doesn't even need a web server.",
+      "tags": "JavaScript",
+      "url": "http://www.tipue.com/search"
+    },
+    {
+      "title": "Tipue Search Documentation",
+      "text": "Tipue Search is a site search engine jQuery plugin. It's free, open source, responsive and fast. Tipue Search uses various modes for loading content. Static mode uses a JavaScript object, while JSON mode uses JSON. Live mode grabs content from a list of pages dynamically.",
+      "tags": "docs",
+      "url": "http://www.tipue.com/search/docs"
+    }
+  ]
+};
+```
+File `tipuesearch_content.js` is created in the root of `output` directory.
+
 How to use
 ==========
 
 To utilize JSON Search mode, your theme needs to have Tipue Search properly configured in it. [Official documentation](http://www.tipue.com/search/docs/#json) has the required details.
+
+To utilize Static Serch mode. [Official documentation](http://www.tipue.com/search/docs/?d=1) has the required details.
 
 Pelican [Elegant Theme](https://github.com/talha131/pelican-elegant) and [Plumage
 theme](https://github.com/kdeldycke/plumage) have Tipue Search configured. You can view their

--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -90,6 +90,8 @@ class Tipue_Search_JSON_Generator(object):
     def generate_output(self, writer):
         path = os.path.join(self.output_path, 'tipuesearch_content.json')
 
+        js_path = os.path.join(self.output_path, 'tipuesearch_content.js')
+
         pages = self.context['pages'] + self.context['articles']
 
         for article in self.context['articles']:
@@ -102,8 +104,10 @@ class Tipue_Search_JSON_Generator(object):
             self.create_json_node(page)
         root_node = {'pages': self.json_nodes}
 
-        with open(path, 'w', encoding='utf-8') as fd:
+        with open(path, 'w', encoding='utf-8') as fd, open(js_path, 'w', encoding='utf-8') as js_fd:
             json.dump(root_node, fd, separators=(',', ':'), ensure_ascii=False)
+            js_fd.write('var tipuesearch = {};'.format(json.dumps(root_node,
+                        separators=(',', ':'), ensure_ascii=False)))
 
 
 def get_generators(generators):


### PR DESCRIPTION
'Tipue_search.py' output add 'tipuesearch_content.js'.
 By 'tipuesearch_content.js' can use tipue_search's static mode.