### PR TITLE
PlantUML: Update plugin for Pelican 3.7+

### DIFF
--- a/plantuml/plantuml_md.py
+++ b/plantuml/plantuml_md.py
@@ -70,7 +70,7 @@ class PlantUMLBlockProcessor(markdown.blockprocessors.BlockProcessor):
         # Generate image from PlantUML script
         imageurl = self.config['siteurl']+'/'+generate_uml_image(path, text, format)
         # Create image tag and append to the document
-        etree.SubElement(parent, "img", src=imageurl, alt=alt, classes=classes)
+        etree.SubElement(parent, "img", src=imageurl, alt=alt, attrib={'class':classes})
 
 
 # For details see https://pythonhosted.org/Markdown/extensions/api.html#extendmarkdown

--- a/plantuml/plantuml_rst.py
+++ b/plantuml/plantuml_rst.py
@@ -68,7 +68,7 @@ def pelican_init(pelicanobj):
     """ Prepare configurations for the MD plugin """
     try:
         import markdown
-        from plantuml_md import PlantUMLMarkdownExtension
+        from .plantuml_md import PlantUMLMarkdownExtension
     except:
         # Markdown not available
         logger.debug("[plantuml] Markdown support not available")
@@ -78,7 +78,11 @@ def pelican_init(pelicanobj):
     config = { 'siteurl': pelicanobj.settings['SITEURL'] }
 
     try:
-        pelicanobj.settings['MD_EXTENSIONS'].append(PlantUMLMarkdownExtension(config))
+        if 'MD_EXTENSIONS' in pelicanobj.settings.keys(): # pre pelican 3.7.0
+            pelicanobj.settings['MD_EXTENSIONS'].append(PlantUMLMarkdownExtension(config))
+        elif 'MARKDOWN' in pelicanobj.settings.keys() and \
+             not ('extension_configs' in pelicanobj.settings['MARKDOWN']['extension_configs']):  # from pelican 3.7.0
+            pelicanobj.settings['MARKDOWN']['extension_configs']['plantuml.plantuml_md'] = {}
     except:
         logger.error("[plantuml] Unable to configure plantuml markdown extension")
 


### PR DESCRIPTION
Fixed plugin plantuml for pelican 3.7 (tested with pelican 3.7.0); fixed #833.
Fixed class attribute if markdown syntax (fixes #838)