### PR TITLE
sitemap: Add ability to mark individual pages as private

### DIFF
--- a/sitemap/Readme.rst
+++ b/sitemap/Readme.rst
@@ -44,6 +44,9 @@ use the following ``SITEMAP`` setting.
 If a key is missing or a value is incorrect, it will be replaced with the
 default value.
 
+You can also exclude an individual URL by adding metadata to it setting ``private``
+to ``True``.
+
 The sitemap is saved in ``<output_path>/sitemap.<format>``.
 
 .. note::

--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -137,6 +137,9 @@ class SitemapGenerator(object):
 
         if getattr(page, 'status', 'published') != 'published':
             return
+           
+        if getattr(page, 'private', 'False') == 'True':
+            return
 
         # We can disable categories/authors/etc by using False instead of ''
         if not page.save_as:


### PR DESCRIPTION
The plugin currently supports using regexes to make a case private. This adds the ability for a page author to mark a page as private, without mucking around in the settings for the entire site.