### PR TITLE
Video Privacy Enhancer: Add Python 3 support

### DIFF
--- a/video_privacy_enhancer/video_service_thumbnail_url_generating_functions.py
+++ b/video_privacy_enhancer/video_service_thumbnail_url_generating_functions.py
@@ -8,7 +8,8 @@ Each function should accept one argument (the video id from that service) and sh
 LIBRARIES
 """
 
-import urllib # For downloading the video thumbnails. Not as clean as, e.g., the requests module, but installed by default in many Python distributions.
+# from urllib.request import urlopen # For downloading the video thumbnails. Not as clean as, e.g., the requests module, but installed by default in many Python distributions.
+from six.moves.urllib.request import urlopen
 
 import json
 
@@ -26,7 +27,7 @@ def generate_thumbnail_download_link_vimeo(video_id_from_shortcode):
 	"""Thumbnail URL generator for Vimeo videos."""
 	
 	# Following the Vimeo API at https://developer.vimeo.com/api#video-request, we need to request the video's metadata and get the thumbnail from that. First, then, we'll get the metadata in JSON format, and then will parse it to find the thumbnail URL.
-	video_metadata = urllib.urlopen("https://vimeo.com/api/v2/video/" + video_id_from_shortcode + ".json") # Download the video's metadata in JSON format.
-	video_metadata_parsed = json.load(video_metadata) # Parse the JSON
+	video_metadata = urlopen("https://vimeo.com/api/v2/video/" + str(video_id_from_shortcode) + ".json").read() # Download the video's metadata in JSON format.
+	video_metadata_parsed = json.loads(video_metadata.decode('utf-8')) # Parse the JSON
 	video_thumbnail_large_location = video_metadata_parsed[0]['thumbnail_large'] # Go into the JSON and get the URL of the thumbnail.
 	return video_thumbnail_large_location	


### PR DESCRIPTION
I upgraded my Pelican virtualenv this weekend to Python 3 and Pelican 3.7.1, and realized that the Video Privacy Enhancer breaks with the upgrade. Thus, I added use of the `six` package to support both Python 2 and 3. I then tested re-generating my site with Python 2.7.12 (with Pelican 3.6.3) and Python 3.4.5 (with Pelican 3.7.1).