### PR TITLE
Section Number: Dots after numbers in headers

### DIFF
--- a/section_number/section_number.py
+++ b/section_number/section_number.py
@@ -1,10 +1,11 @@
+# -*- coding: utf-8 -*-
 """
 Section number plugin for Pelican
 ================================
 Adds section numbers to section titles of the article
 """
 
-from pelican import signals, contents
+from pelican import signals
 
 
 def _extract_level(text, idx):
@@ -14,7 +15,7 @@ def _extract_level(text, idx):
         return (idx, -1)
 
     try:
-        level = int(text[idx : end])
+        level = int(text[idx: end])
         return (end, level)
 
     except:
@@ -30,11 +31,10 @@ def _level_str(level_nums, level_max):
     for n in level_nums:
         ret += str(n) + '.'
 
-    return ret[:-1] + ' '
+    return ret[:-1]
 
 
 def _insert_title_number(text, level_max):
-    ret = u''
     idx = 0
     levels = []
     level_nums = []
@@ -67,9 +67,10 @@ def _insert_title_number(text, level_max):
                 levels += [levels[-1] + 1]
                 level_nums += [1]
 
-        text = text[:idx+1] + _level_str(level_nums, level_max) + text[idx+1:]
+        text = text[:idx + 1] + \
+            _level_str(level_nums, level_max) + '. ' + text[idx + 1:]
 
-    #print text.encode('gb2312')
+    # print text.encode('gb2312')
     return text
 
 
@@ -78,7 +79,7 @@ def process_content(content):
         return
 
     level_max = content.settings.get('SECTION_NUMBER_MAX', 3)
-    
+
     if level_max <= 0:
         return
 


### PR DESCRIPTION
### 1. Steps to reproduce

I run any command for build site, for example, `pelican content`.

### 2. Behavior before pull request

Example of HTML page display:

```markdown
1 Sasha first header

1.1 Sasha first subheader

2 Sasha second header
```

### 3. Behavior after pull request

Dots after headers numbers:

```markdown
1. Sasha first header

1.1. Sasha first subheader

2. Sasha second header
```

### 4. Argumentation

I think, that in English typography is customary to put dots like [**ordered lists**](https://daringfireball.net/projects/markdown/syntax#list). [**Example**](http://foundation.zurb.com/sites/docs/typography-base.html#header).

### 5. Other changes

Also, I remove unused module and variable.

Thanks.