### PR TITLE
Update render_math plugin to use cdnjs

### DIFF
--- a/render_math/Readme.md
+++ b/render_math/Readme.md
@@ -95,8 +95,6 @@ is less than `responsive_break` (see below) and if so, sets `align` to `left`, `
 when setting `responsive_align` to `True`. **Default Value**: 768
  * `process_summary`: [boolean] ensures math will render in summaries and fixes math in that were cut off.
 Requires [BeautifulSoup4](http://www.crummy.com/software/BeautifulSoup/bs4/doc/) be installed. **Default Value**: `True`
- * `force_tls`: [boolean] forces mathjax script to load from cdn using https. If set to false, will use document.location.protocol
-**Default Value**: `False`
  * `message_style`: [string] This value controls the verbosity of the messages in the lower left-hand corner. Set it to `None` to eliminate all messages.
 **Default Value**: normal
 

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -69,11 +69,10 @@ def process_settings(pelicanobj):
     mathjax_settings['responsive_break'] = '768'  # The break point at which it math is responsively aligned (in pixels)
     mathjax_settings['mathjax_font'] = 'default'  # forces mathjax to use the specified font.
     mathjax_settings['process_summary'] = BeautifulSoup is not None  # will fix up summaries if math is cut off. Requires beautiful soup
-    mathjax_settings['force_tls'] = 'false'  # will force mathjax to be served by https - if set as False, it will only use https if site is served using https
     mathjax_settings['message_style'] = 'normal'  # This value controls the verbosity of the messages in the lower left-hand corner. Set it to "none" to eliminate all messages
 
     # Source for MathJax
-    mathjax_settings['source'] = "'//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
+    mathjax_settings['source'] = "'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
 
     # Get the user specified settings
     try:
@@ -155,9 +154,6 @@ def process_settings(pelicanobj):
             mathjax_settings[key] = value
 
         if key == 'responsive' and isinstance(value, bool):
-            mathjax_settings[key] = 'true' if value else 'false'
-
-        if key == 'force_tls' and isinstance(value, bool):
             mathjax_settings[key] = 'true' if value else 'false'
 
         if key == 'responsive_break' and isinstance(value, int):

--- a/render_math/math.py
+++ b/render_math/math.py
@@ -73,7 +73,7 @@ def process_settings(pelicanobj):
     mathjax_settings['message_style'] = 'normal'  # This value controls the verbosity of the messages in the lower left-hand corner. Set it to "none" to eliminate all messages
 
     # Source for MathJax
-    mathjax_settings['source'] = "'//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
+    mathjax_settings['source'] = "'//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'"
 
     # Get the user specified settings
     try:

--- a/render_math/mathjax_script_template
+++ b/render_math/mathjax_script_template
@@ -10,11 +10,9 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
     }}
 
     var mathjaxscript = document.createElement('script');
-    var location_protocol = ({force_tls}) ? 'https' : document.location.protocol;
-    if (location_protocol !== 'http' && location_protocol !== 'https') location_protocol = 'https:';
     mathjaxscript.id = 'mathjaxscript_pelican_#%@#$@#';
     mathjaxscript.type = 'text/javascript';
-    mathjaxscript.src = location_protocol + {source};
+    mathjaxscript.src = {source};
     mathjaxscript[(window.opera ? "innerHTML" : "text")] =
         "MathJax.Hub.Config({{" +
         "    config: ['MMLorHTML.js']," +


### PR DESCRIPTION
As MathJax is closing its CDN, users are advised to use local version or another CDN, with cdnjs being preferred at the moment. Update link in plugin configuration and really close #881 