### PR TITLE
Allow headerid plugin to work with Python 3.5.3

### DIFF
--- a/headerid/__init__.py
+++ b/headerid/__init__.py
@@ -1,1 +1,1 @@
-from headerid import *
+from .headerid import *


### PR DESCRIPTION
Fixes #887

