### PR TITLE
Adding ipynb2pelican plugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -136,3 +136,6 @@
 [submodule "deadlinks"]
 	path = deadlinks
 	url = https://github.com/silentlamb/pelican-deadlinks.git
+[submodule "ipynb2pelican"]
+	path = ipynb2pelican
+	url = git@github.com:peijunz/ipynb2pelican.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -128,6 +128,8 @@ Image Process             Automates the processing of images based on their clas
 
 Interlinks                Lets you add frequently used URLs to your markup using short keywords
 
+ipynb2pelican             Jupyter Notebooks reader using first Cell to store metadata
+
 Jinja2 Content            Allows the use of Jinja2 template code in articles, including ``include`` and ``import`` statements. Replacement for pelican-jinja2content.
 
 Just table                Easily create tables in articles


### PR DESCRIPTION
Adding a Jupyter Notebook reader plugin.

The page of the new plugin is [https://github.com/peijunz/ipynb2pelican](https://github.com/peijunz/ipynb2pelican)

Thank you!