### PR TITLE
Add author_images plugin

### DIFF
--- a/author_images/README.md
+++ b/author_images/README.md
@@ -1,0 +1,55 @@
+# author_images
+
+This Pelican plugin adds support for author images and avatars. You may choose
+to display one or the other.
+
+## Configuration
+
+Add the directory to the base plugins directory to `PLUGIN_PATHS` in
+`pelicanconf.py`, and then add `author_images` to the `PLUGINS` list. For example,
+
+    PLUGIN_PATHS = ["../git/pelican-plugins"]
+    PLUGINS = ['author_images']
+
+You can also configure the directory for the author images and avatars. Note
+that both of these directories should exist in your theme, inside the static
+directory. This feels like the best way to approach this.
+
+    AUTHOR_AVATARS = 'images/author_avatars'
+    AUTHOR_IMAGES = 'images/author_images'
+
+### Adding images
+
+Now you can place images and avatars into the correct places. The location for
+these is `THEME / THEME_STATIC_DIR / AUTHOR_AVATARS`. For instance,
+`strudel/static/images/author_avatars` for my particular setup. Note that in
+this case, `strudel` is my theme.
+
+### Naming images
+
+Images have to named correctly for the plugin to find them. Currently, this
+means you need to take a `sha256` of the authors name. The extension of
+the file can be one of `svg`, `jpg`, `jpeg` or `png`. For instance, my name is
+William Pettersson, so I can run
+
+    python -c 'import hashlib; print hashlib.sha256("William Pettersson").hexdigest()'
+
+to get the hash sum of my name. Then I just rename my images or avatars to have
+that name, but with the appropriate extension. For simplicity, there is a
+`generate_hashsum.py` which can also be used as follows
+
+    python generate_hashsum.py "William Pettersson"
+
+which prints out
+`a40249517dfaf4e83264ced7d802c9fe9b811c8425b1ce1b3e8b9e236b52fa3e`. This means
+my files have to be named
+`a40249517dfaf4e83264ced7d802c9fe9b811c8425b1ce1b3e8b9e236b52fa3e.png`, or
+`a40249517dfaf4e83264ced7d802c9fe9b811c8425b1ce1b3e8b9e236b52fa3e.jpg` or
+similar.
+
+
+### Using in themes
+
+These images and avatars are made available to themes through the
+`author.avatar` and `author.image` variables.
+

--- a/author_images/__init__.py
+++ b/author_images/__init__.py
@@ -1,0 +1,1 @@
+from .author_images import *

--- a/author_images/author_images.py
+++ b/author_images/author_images.py
@@ -1,0 +1,47 @@
+"""
+Author images plugin for Pelican
+===========================
+
+This plugin assigns the ``author.avatar`` and ``author.image`` variables to the
+avatar and image of the author in question. Authors are identified by email
+address, and avatars are images are stored in directories configured by
+AUTHOR_AVATARS and AUTHOR_IMAGES.
+"""
+
+from pelican import signals
+from hashlib import sha256
+from os.path import exists
+
+EXTENSIONS = ['jpg', 'png', 'svg']
+
+
+def add_author_image(author, generator):
+    hashsum = sha256(author.name).hexdigest()
+    static = generator.settings['THEME'] + '/static/'
+    if 'AUTHOR_AVATARS' in generator.settings.keys():
+        avatar = generator.settings['AUTHOR_AVATARS'] + '/' + hashsum
+        for ext in EXTENSIONS:
+            if exists('%s%s.%s' % (static, avatar, ext)):
+                author.avatar = '%s/%s.%s' % \
+                    (generator.settings['THEME_STATIC_DIR'], avatar, ext)
+                break
+
+    if 'AUTHOR_IMAGES' in generator.settings.keys():
+        image = generator.settings['AUTHOR_IMAGES'] + '/' + hashsum
+        for ext in EXTENSIONS:
+            if exists('%s%s.%s' % (static, image, ext)):
+                author.image = '%s/%s.%s' % \
+                    (generator.settings['THEME_STATIC_DIR'], image, ext)
+                break
+
+
+def add_author_images(generator):
+    for article in generator.articles:
+        for author in article.authors:
+            add_author_image(author, generator)
+    for author, _ in generator.authors:
+        add_author_image(author, generator)
+
+
+def register():
+    signals.article_generator_finalized.connect(add_author_images)

--- a/author_images/generate_hashsum.py
+++ b/author_images/generate_hashsum.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python2
+
+from __future__ import print_function
+import hashlib
+import sys
+
+print(hashlib.sha256(sys.argv[1]).hexdigest())


### PR DESCRIPTION
This plugin adds support for author.image and author.avatar properties, based on files found with appropriate naming. It searches the AUTHOR_IMAGES (or _AVATARS) path for files named appropriately, and then adds the locations of these files (if found) to author.images (or author.avatars) for use when displaying articles.

I'm not convinced it's ready for merging, I have a few questions which I cannot answer myself.
I don't know if I'm calling my function with the right signal. I've dug through the Pelican code, and tested many options, and I just can't work out how it all glues together. Currently it uses article_generator_finalized, but this feels too late as I not only have to iterate over all authors in the generator, but also all authors in each article in the generator.

I'm also finding file names of images/avatars by running a sha256sum over the author name, and then appending various extensions. Any hash should do, even MD5 should be fine as the worst that should happen is the wrong image is displayed, but I didn't see any significant downside in using a more recent hashing algorithm. I'm happy to be told to use something else here. And I decided not to just use the author name directly as I imagine some webhosts might not allow full unicode filenames, and this also avoids any issues with spaces in filenames.