### PR TITLE
[render_math] Fix NameError in Python 3

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -45,6 +45,12 @@ try:
 except ImportError as e:
     PelicanMathJaxExtension = None
 
+try:
+    string_type = basestring
+except NameError:
+    string_type = str
+
+
 def process_settings(pelicanobj):
     """Sets user specified MathJax settings (see README for more details)"""
 
@@ -90,10 +96,7 @@ def process_settings(pelicanobj):
         # and 3 of python
 
         if key == 'align':
-            try:
-                typeVal = isinstance(value, basestring)
-            except NameError:
-                typeVal = isinstance(value, str)
+            typeVal = isinstance(value, string_type)
 
             if not typeVal:
                 continue
@@ -122,10 +125,7 @@ def process_settings(pelicanobj):
             mathjax_settings[key] = 'true' if value else 'false'
 
         if key == 'latex_preview':
-            try:
-                typeVal = isinstance(value, basestring)
-            except NameError:
-                typeVal = isinstance(value, str)
+            typeVal = isinstance(value, string_type)
 
             if not typeVal:
                 continue
@@ -133,10 +133,7 @@ def process_settings(pelicanobj):
             mathjax_settings[key] = value
 
         if key == 'color':
-            try:
-                typeVal = isinstance(value, basestring)
-            except NameError:
-                typeVal = isinstance(value, str)
+            typeVal = isinstance(value, string_type)
 
             if not typeVal:
                 continue
@@ -161,19 +158,12 @@ def process_settings(pelicanobj):
 
         if key == 'tex_extensions' and isinstance(value, list):
             # filter string values, then add '' to them
-            try:
-                value = filter(lambda string: isinstance(string, basestring), value)
-            except NameError:
-                value = filter(lambda string: isinstance(string, str), value)
-
+            value = filter(lambda string: isinstance(string, string_type), value)
             value = map(lambda string: "'%s'" % string, value)
             mathjax_settings[key] = ',' + ','.join(value)
 
         if key == 'mathjax_font':
-            try:
-                typeVal = isinstance(value, basestring)
-            except NameError:
-                typeVal = isinstance(value, str)
+            typeVal = isinstance(value, string_type)
 
             if not typeVal:
                 continue


### PR DESCRIPTION
This PR is to fix the `NameError` I get when using MathJax extensions. The error comes from the line

    filter(lambda string: isinstance(string, basestring))

Because `filter()` is a generator in Python 3, the lambda function doesn't actually called at the point of the `filter()` statement, it gets called later, outside the enclosing `try` block. I've changed this to identify the relevant string type in advance, at module level, so the new call to `filter()` doesn't raise this error.

I haven't created an issue in advance because this seemed like a very straightforward and simple fix.