### PR TITLE
Prints the error we got from emacs if it fails

### DIFF
--- a/org_reader/org_reader.py
+++ b/org_reader/org_reader.py
@@ -84,9 +84,13 @@ class OrgReader(readers.BaseReader):
         cmd.append('--eval')
         cmd.append(self.ELISP_EXEC.format(filename, backend))
 
-        LOG.debug("OrgReader: running command `{0}`".format(cmd))
+        LOG.debug("OrgReader: running command `%s`" % (' '.join(cmd)))
 
-        json_result = subprocess.check_output(cmd, universal_newlines=True)
+        try:
+            json_result = subprocess.check_output(cmd, universal_newlines=True, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            print("Failed error: output %s" % e.output)
+            raise e
         json_output = json.loads(json_result)
 
         # get default slug from .org filename


### PR DESCRIPTION
Rather than an error code we now have the message of what's wrong with the org document.

Also makes the printed command more usable from command line (to debug easier).