### PR TITLE
Optimization for svg images with svgo (optimze_images)

### DIFF
--- a/optimize_images/Readme.md
+++ b/optimize_images/Readme.md
@@ -2,11 +2,12 @@ Optimize Images Plugin For Pelican
 ==================================
 
 This plugin applies lossless compression on JPEG and PNG images, with no
-effect on image quality. It uses [jpegtran][1] and [OptiPNG][2]. It assumes
-that both of these tools are installed on system path.
+effect on image quality. It uses [jpegtran][1], [OptiPNG][2] and [svgo][3]. 
+It assumes that all of these tools are installed on system path.
 
 [1]: http://jpegclub.org/jpegtran/              "jpegtran"
 [2]: http://optipng.sourceforge.net/            "OptiPNG"
+[3]: https://github.com/svg/svgo				"SVGO"
 
 
 Installation

--- a/optimize_images/optimize_images.py
+++ b/optimize_images/optimize_images.py
@@ -22,6 +22,7 @@ SHOW_OUTPUT = logger.getEffectiveLevel() <= logging.DEBUG
 # A list of file types with their respective commands
 COMMANDS = {
     # '.ext': ('command {flags} {filename', 'silent_flag', 'verbose_flag')
+    '.svg': ('svgo {flags} --input="{filename}" --output="{filename}"', '--quiet', ''),
     '.jpg': ('jpegtran {flags} -copy none -optimize -outfile "{filename}" "{filename}"', '', '-v'),
     '.png': ('optipng {flags} "{filename}"', '--quiet', ''),
 }


### PR DESCRIPTION
With default options it varies from ~30% reduction for plantuml
generated, all the way up to 80 to 90 precent for inkscape based
images.

I thought others may want this because this can result in drastic page load improvements.