### PR TITLE
Jinja2htmlcontent

### DIFF
--- a/jinja2htmlcontent/README.md
+++ b/jinja2htmlcontent/README.md
@@ -1,0 +1,67 @@
+# Jinja2 in HTML articles and pages
+
+This plugin enables the use of Jinja2 directives inside Pelican 
+**HTML** articles and pages. 
+
+This plugin is a shameless rip-off the `jinja2content` plugin.
+It was adapted in order to work with `.html` content files.
+This enables creating complex static sites with Pelican using html
+instead of Markdown, and having components split into macros and fragments.
+
+The jinja rendering inside the content files is done before the rendering of 
+the theme template files.
+This means the context and jinja variables are not visible inside articles and pages.
+
+All code that needs those variables (`article`, `category`, etc) should be
+put inside the theme's template logic.  As such, the main use of this
+plugin is to automatically generate parts of your articles.
+
+## Example
+
+We can use this plugin to create macros and fragments which are 
+reusable across pages.
+Let's take the following example using the excellent Semantic-UI framework:
+
+File `mypage.md`
+```
+<h1 class="ui header">Join us</h1>
+<div class="ui link cards">
+    {% from 'card.html' import card %}
+    {{ card(
+        "illustration.png", 
+        "Lorem ipsum",
+        "Lorem ipsum dolor sit amet"  
+    ) }}
+...
+```
+
+Where file `card.html` contains:
+```
+{% macro card(img_src, title, desc) -%}
+<div class="ui card">
+    <div class="image">
+        <img src="/theme/images/{{img_src}}">
+    </div>
+    <div class="content">
+        <h2 class="header">
+            {{title}}
+        </h2>
+        <p class="description">
+            {{desc}}
+        </p>
+        <div class="extra content">
+            <div class="buttons">
+                <a href="/" class="ui button">Find out more</a>
+            </div>
+        </div>
+    </div>
+</div>
+{%- endmacro %}
+```
+
+## Configuration
+
+This plugin accepts the setting "JINJA2CONTENT_TEMPLATES" which should be
+set to a list of paths relative to 'PATH' (the main content directory).
+`jinja2htmlcontent` will look for templates inside these directories, in order.
+If they are not found in any, the theme's templates folder is used.

--- a/jinja2htmlcontent/__init__.py
+++ b/jinja2htmlcontent/__init__.py
@@ -1,0 +1,1 @@
+from .jinja2htmlcontent import *

--- a/jinja2htmlcontent/jinja2htmlcontent.py
+++ b/jinja2htmlcontent/jinja2htmlcontent.py
@@ -1,0 +1,66 @@
+"""
+jinja2htmlcontent.py
+----------------
+
+Pelican plugin that processes HTML files as Jinja templates.
+
+"""
+
+from os import path
+from pelican import signals
+from pelican.readers import HTMLReader
+from pelican.utils import pelican_open
+from jinja2 import Environment, FileSystemLoader, ChoiceLoader
+
+
+class JinjaHTMLReader(HTMLReader):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # will look first in 'JINJA2CONTENT_TEMPLATES', by default the
+        # content root path, then in the theme's templates
+        # local_templates_dirs = self.settings.get('JINJA2CONTENT_TEMPLATES', ['.'])
+        # local_templates_dirs = path.join(self.settings['PATH'], local_templates_dirs)
+        local_dirs = self.settings.get('JINJA2CONTENT_TEMPLATES', ['.'])
+        local_dirs = [path.join(self.settings['PATH'], folder)
+                      for folder in local_dirs]
+        theme_dir = path.join(self.settings['THEME'], 'templates')
+
+        loaders = [FileSystemLoader(_dir) for _dir
+                   in local_dirs + [theme_dir]]
+        if 'JINJA_ENVIRONMENT' in self.settings: # pelican 3.7
+            jinja_environment = self.settings['JINJA_ENVIRONMENT']
+        else:
+            jinja_environment = {
+                'trim_blocks': True,
+                'lstrip_blocks': True,
+                'extensions': self.settings['JINJA_EXTENSIONS']
+            }
+        self.env = Environment(
+            loader=ChoiceLoader(loaders),
+            **jinja_environment)
+
+    def read(self, filename):
+        """
+        Parse HTML content files with Jinja templates inside
+        """
+        with pelican_open(filename) as content:
+            jinjad_content = self.env.from_string(content).render()
+            parser = self._HTMLParser(self.settings, filename)
+            parser.feed(jinjad_content)
+            parser.close()
+
+        metadata = {}
+        for k in parser.metadata:
+            metadata[k] = self.process_metadata(k, parser.metadata[k])
+        return parser.body, metadata
+
+
+def add_reader(readers):
+    for ext in HTMLReader.file_extensions:
+        readers.reader_classes[ext] = JinjaHTMLReader
+
+
+def register():
+    signals.readers_init.connect(add_reader)

--- a/jinja2htmlcontent/jinja2htmlcontent.py
+++ b/jinja2htmlcontent/jinja2htmlcontent.py
@@ -40,6 +40,9 @@ class JinjaHTMLReader(HTMLReader):
         self.env = Environment(
             loader=ChoiceLoader(loaders),
             **jinja_environment)
+        if 'JINJA_FILTERS' in self.settings:
+            custom_filters = self.settings['JINJA_FILTERS']
+            self.env.filters.update(custom_filters)
 
     def read(self, filename):
         """


### PR DESCRIPTION
This plugin enables the use of Jinja2 directives inside Pelican 
**HTML** articles and pages. 

This plugin is a shameless rip-off the `jinja2content` plugin.
It was adapted in order to work with `.html` content files.
This enables creating complex static sites with Pelican using html
instead of Markdown, and having components split into macros and fragments.
