### PR TITLE
[render_math] fix python3 error with basestring where statement in try block wasn't evaluated until later

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -45,6 +45,11 @@ try:
 except ImportError as e:
     PelicanMathJaxExtension = None
 
+try:
+    STRING_CLASS = basestring
+except NameError:
+    STRING_CLASS = str
+
 def process_settings(pelicanobj):
     """Sets user specified MathJax settings (see README for more details)"""
 
@@ -90,12 +95,7 @@ def process_settings(pelicanobj):
         # and 3 of python
 
         if key == 'align':
-            try:
-                typeVal = isinstance(value, basestring)
-            except NameError:
-                typeVal = isinstance(value, str)
-
-            if not typeVal:
+            if not isinstance(value, STRING_CLASS):
                 continue
 
             if value == 'left' or value == 'right' or value == 'center':
@@ -122,23 +122,13 @@ def process_settings(pelicanobj):
             mathjax_settings[key] = 'true' if value else 'false'
 
         if key == 'latex_preview':
-            try:
-                typeVal = isinstance(value, basestring)
-            except NameError:
-                typeVal = isinstance(value, str)
-
-            if not typeVal:
+            if not isinstance(value, STRING_CLASS):
                 continue
 
             mathjax_settings[key] = value
 
         if key == 'color':
-            try:
-                typeVal = isinstance(value, basestring)
-            except NameError:
-                typeVal = isinstance(value, str)
-
-            if not typeVal:
+            if not isinstance(value, STRING_CLASS):
                 continue
 
             mathjax_settings[key] = value
@@ -161,21 +151,12 @@ def process_settings(pelicanobj):
 
         if key == 'tex_extensions' and isinstance(value, list):
             # filter string values, then add '' to them
-            try:
-                value = filter(lambda string: isinstance(string, basestring), value)
-            except NameError:
-                value = filter(lambda string: isinstance(string, str), value)
-
+            value = filter(lambda string: isinstance(string, STRING_CLASS), value)
             value = map(lambda string: "'%s'" % string, value)
             mathjax_settings[key] = ',' + ','.join(value)
 
         if key == 'mathjax_font':
-            try:
-                typeVal = isinstance(value, basestring)
-            except NameError:
-                typeVal = isinstance(value, str)
-
-            if not typeVal:
+            if not isinstance(value, STRING_CLASS):
                 continue
 
             value = value.lower()


### PR DESCRIPTION
This fixes a bug in lines 164--167 where in Python 3, `isinstance(string, basestring)` doesn't trigger the exception because the statement isn't evaluated until later.