### PR TITLE
Thumbnailer: add optional input file name regex setting

### DIFF
--- a/thumbnailer/Readme.md
+++ b/thumbnailer/Readme.md
@@ -23,6 +23,7 @@ Configuration
   The generated filename will be `originalname_thumbnailname.ext` unless `THUMBNAIL_KEEP_NAME` is set.
 * `THUMBNAIL_KEEP_NAME` is a Boolean that, if set, puts the file with the original name in a thumbnailname folder, named like the key in `THUMBNAIL_SIZES`.
 * `THUMBNAIL_KEEP_TREE` is a Boolean that, if set, saves the image directory tree.
+* `THUMBNAIL_INCLUDE_REGEX` is an optional string that is used as regular expression to restrict thumbnailing to matching files. By default all files not starting with a dot are respected.
 
 Sizes can be specified using any of the following formats:
 

--- a/thumbnailer/thumbnailer.py
+++ b/thumbnailer/thumbnailer.py
@@ -132,12 +132,19 @@ def resize_thumbnails(pelican):
 
     in_path = _image_path(pelican)
 
+    include_regex = pelican.settings.get('THUMBNAIL_INCLUDE_REGEX')
+    if include_regex:
+        pattern = re.compile(include_regex)
+        is_included = lambda name: pattern.match(name)
+    else:
+        is_included = lambda name: not name.startswith('.')
+
     sizes = pelican.settings.get('THUMBNAIL_SIZES', DEFAULT_THUMBNAIL_SIZES)
     resizers = dict((k, _resizer(k, v, in_path)) for k,v in sizes.items())
     logger.debug("Thumbnailer Started")
     for dirpath, _, filenames in os.walk(in_path):
         for filename in filenames:
-            if not filename.startswith('.'):
+            if is_included(filename):
                 for name, resizer in resizers.items():
                     in_filename = path.join(dirpath, filename)
                     out_path = get_out_path(pelican, in_path, in_filename, name)


### PR DESCRIPTION
With the help of the THUMBNAIL_INCLUDE_REGEX setting it is now possible to restrict thumbnailing to a files matching this regular expression. The setting is expected to be a string. If available, a regular expression is created. The default behavior is still that all files not starting with a dot are respected.

For instance, this can be set to only match files ending in "jpg", "jpeg" or "png" one can use:

THUMBNAIL_INCLUDE_REGEX = r'(jp[e]g|png)$'

This is useful to exclude other files that sometimes go along with images, e.g. titles.