### PR TITLE
category_meta: Add support for Pelican >= 3.7.0

### DIFF
--- a/category_meta/category_meta.py
+++ b/category_meta/category_meta.py
@@ -70,7 +70,10 @@ def make_category(article, slug):
 
     # Setting a category's name resets its slug, so do that first.
     category.name = article.title
-    category.slug = slug
+    try:
+        category.slug = slug
+    except AttributeError:
+        category._slug = slug
 
     # Description from article text.
     # XXX Relative URLs in the article content may not be handled correctly.


### PR DESCRIPTION
`category.slug` is not writeable since [648165b839fe9562822fa843cbdbfe224b12dfbd](https://github.com/getpelican/pelican/commit/648165b839fe9562822fa843cbdbfe224b12dfbd).