### PR TITLE
[i18n_subsites] Object Draft now doesn't exist

### DIFF
--- a/i18n_subsites/i18n_subsites.py
+++ b/i18n_subsites/i18n_subsites.py
@@ -22,7 +22,7 @@ import locale
 from pelican import signals
 from pelican.generators import ArticlesGenerator, PagesGenerator
 from pelican.settings import configure_settings
-from pelican.contents import Draft
+from pelican.contents import Article
 
 
 # Global vars
@@ -151,9 +151,9 @@ def save_generator(generator):
 
 
 def article2draft(article):
-    '''Transform an Article to Draft'''
-    draft = Draft(article._content, article.metadata, article.settings,
-                  article.source_path, article._context)
+    '''Set to draft the status of an article'''
+    draft = Article(article._content, article.metadata, article.settings,
+                    article.source_path, article._context)
     draft.status = 'draft'
     return draft
 


### PR DESCRIPTION
It was removed from Pelican, so we have to use the object Article with the
value of status set to 'draft'.

This aims to fix issue #937 

I'm not able to run the tests, as I get an error I don't know how to solve. Any help is really appreciated. Ping @smartass101 and @ingwinlu

<pre><samp>
✔ ~/Código/Repositorios/pelican-plugins/i18n_subsites [fix-i18n_subsites L|✔]$ python3 test_i18n_subsites.py 
Traceback (most recent call last):
  File "test_i18n_subsites.py", line 10, in <module>
    from . import i18n_subsites as i18ns
SystemError: Parent module '' not loaded, cannot perform relative import
</samp></pre>