### PR TITLE
[tag_cloud] Better tags repartition when TAG_CLOUD_MAX_ITEMS is used

### DIFF
--- a/tag_cloud/tag_cloud.py
+++ b/tag_cloud/tag_cloud.py
@@ -43,15 +43,16 @@ def generate_tag_cloud(generator):
 
     tags = list(map(itemgetter(1), tag_cloud))
     if tags:
-        max_count = max(tags)
+        max_count = tags[0]
+        min_count = tags[-1]
     steps = generator.settings.get('TAG_CLOUD_STEPS')
 
     # calculate word sizes
     def generate_tag(tag, count):
         tag = (
             tag,
-            int(math.floor(steps - (steps - 1) * math.log(count)
-                / (math.log(max_count)or 1)))
+            int(math.floor(steps - (steps - 1) * math.log(count - min_count + 1)
+                / (math.log(max_count - min_count + 1) or 1)))
         )
         if generator.settings.get('TAG_CLOUD_BADGE'):
             tag += (count,)


### PR DESCRIPTION
TAG_CLOUD_MAX_ITEMS allows to limit the cloud size to the most used tags.

# Old behavior

The current calculation of the tags step does not take this feature into account, resulting in almost all represented tags to belong to a single, highest step.

Let's say I have 5 steps, nearly all tags will belong to the fifth step, a few to the fourth, steps below will not be represented at all. All tags in the cloud appearing with the same size, the result is ugly.

# New behavior

This patch actively checks the minimum count value to ensure that tags are more evenly spread among all available steps.

If I keep the 5 steps example above, now tags are evenly spread along the five steps, producing a better cloud effect.