### PR TITLE
[photos] Expand photo size when rotated

### DIFF
--- a/photos/photos.py
+++ b/photos/photos.py
@@ -201,7 +201,7 @@ def rotate_image(img, exif_dict):
         elif orientation == 5:
             img = img.rotate(-90).transpose(Image.FLIP_LEFT_RIGHT)
         elif orientation == 6:
-            img = img.rotate(-90)
+            img = img.rotate(-90, expand=True)
         elif orientation == 7:
             img = img.rotate(90).transpose(Image.FLIP_LEFT_RIGHT)
         elif orientation == 8:


### PR DESCRIPTION
otherwise the image was being cut. See http://pillow.readthedocs.io/en/3.1.x/reference/Image.html#PIL.Image.Image.rotate for expand setting - this resizes the image when rotating.

It may be applicable to other orientations in this section of code, but I have no photos to test with.

See also https://stackoverflow.com/questions/31303938/how-do-i-stop-pil-from-swapping-height-width-when-rotating-an-image-90