### PR TITLE
txt2tags_reader: Add --no-headers option

### DIFF
--- a/txt2tags_reader/txt2tags_reader.py
+++ b/txt2tags_reader/txt2tags_reader.py
@@ -21,7 +21,7 @@ class Txt2tagsReader(BaseReader):
                 content = "\n".join(text[i:])
                 break
 
-        t2t_cmd = [r"txt2tags", r"--encoding=utf-8", r"--target=html", r"--infile=-", r"--outfile=-"]
+        t2t_cmd = [r"txt2tags", r"--encoding=utf-8", r"--target=html", r"--infile=-", r"--outfile=-", r"--no-headers"]
 
         proc = subprocess.Popen(t2t_cmd,
                                 stdin = subprocess.PIPE,


### PR DESCRIPTION
Important improvement of the txt2tags html output (remove not needed header and footer).