### PR TITLE
filetime_from_git: Handle non-ASCII paths

### DIFF
--- a/filetime_from_git/git_wrapper.py
+++ b/filetime_from_git/git_wrapper.py
@@ -39,7 +39,7 @@ class _GitWrapperCommon(object):
         :returns: True if path is managed by git
         '''
         status, _stdout, _stderr = self.git.execute(
-            ['git', 'ls-files', path, '--error-unmatch'],
+            ['git', 'ls-files', path.encode('utf-8'), '--error-unmatch'],
             with_extended_output=True,
             with_exceptions=False)
         return status == 0
@@ -51,7 +51,7 @@ class _GitWrapperCommon(object):
         :returns: True if file has local changes
         '''
         status, _stdout, _stderr = self.git.execute(
-            ['git', 'diff', '--quiet', 'HEAD', path],
+            ['git', 'diff', '--quiet', 'HEAD', path.encode('utf-8')],
             with_extended_output=True,
             with_exceptions=False)
         return status != 0
@@ -77,7 +77,7 @@ class _GitWrapperCommon(object):
             '--follow',
             '--name-only',
             '--',
-            path).splitlines()
+            path.encode('utf-8')).splitlines()
 
         for commit_sha, _, filename in grouper(log_result, 3):
             yield self.repo.commit(commit_sha), filename
@@ -106,7 +106,7 @@ class _GitWrapperLegacy(_GitWrapperCommon):
 
         :returns: Sequence of commit objects. Newest to oldest
         '''
-        return self.repo.commits(path=path)
+        return self.repo.commits(path=path.encode('utf-8'))
 
     @staticmethod
     def get_commit_date(commit, tz_name):
@@ -133,7 +133,7 @@ class _GitWrapper(_GitWrapperCommon):
 
             Alternatively enabling GIT_FILETIME_FOLLOW may also make your problem go away.
         '''
-        return list(self.repo.iter_commits(paths=path))
+        return list(self.repo.iter_commits(paths=path.encode('utf-8')))
 
     @staticmethod
     def get_commit_date(commit, tz_name):


### PR DESCRIPTION
Paths with non-ascii characters would give encoding errors.

Fixes #328