### PR TITLE
Fix author images encoding

### DIFF
--- a/author_images/author_images.py
+++ b/author_images/author_images.py
@@ -16,7 +16,7 @@ EXTENSIONS = ['jpg', 'png', 'svg']
 
 
 def add_author_image(author, generator):
-    hashsum = sha256(author.name).hexdigest()
+    hashsum = sha256(author.name.encode("utf-8")).hexdigest()
     static = generator.settings['THEME'] + '/static/'
     if 'AUTHOR_AVATARS' in generator.settings.keys():
         avatar = generator.settings['AUTHOR_AVATARS'] + '/' + hashsum

--- a/author_images/generate_hashsum.py
+++ b/author_images/generate_hashsum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 import hashlib

--- a/author_images/generate_hashsum.py
+++ b/author_images/generate_hashsum.py
@@ -4,4 +4,4 @@ from __future__ import print_function
 import hashlib
 import sys
 
-print(hashlib.sha256(sys.argv[1]).hexdigest())
+print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())


### PR DESCRIPTION
In this pull request:

in author_images line 19:
```hashsum = sha256(author.name.encode("utf-8")).hexdigest()```
in generate_hashsum line 7
```print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())```

#964 