### PR TITLE
Render Math: Workaround for processing summaries

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -187,7 +187,7 @@ def process_summary(article):
     """Ensures summaries are not cut off. Also inserts
     mathjax script so that math will be rendered"""
 
-    summary = article._get_summary()
+    summary = article.summary
     summary_parsed = BeautifulSoup(summary, 'html.parser')
     math = summary_parsed.find_all(class_='math')
 
@@ -198,6 +198,12 @@ def process_summary(article):
             full_text = content_parsed.find_all(class_='math')[len(math)-1].get_text()
             math[-1].string = "%s ..." % full_text
             summary = summary_parsed.decode()
+
+        # clear memoization cache
+        import functools
+        if isinstance(article.get_summary, functools.partial):
+            memoize_instance = article.get_summary.func.__self__
+            memoize_instance.cache.clear()
 
         article._summary = "%s<script type='text/javascript'>%s</script>" % (summary, process_summary.mathjax_script)
 


### PR DESCRIPTION
Since Pelican 3.7, render_math no longer is able to process summaries.

Simply fixing the deprecation warning (#850, #858) does not solve this issue, as the `get_summary` function is memoized using `pelican.util.memoize`.
As a workaround, the memoize instance is acquired by inspecting the result of `memoize.__call__` and  its cache subsequently is cleared.

The following assumptions are made, which might not hold for future versions of pelican:

- `article.get_summary` is an instance of `functools.partial`
- the function bound by this instance is a bound method of an `pelican.util.memoize` instance
- `pelican.util.memoize` has a member `cache` that stores the memoization