### PR TITLE
tipue_search: adhere to RELATIVE_URLS setting for URL generation

### DIFF
--- a/tipue_search/tipue_search.py
+++ b/tipue_search/tipue_search.py
@@ -30,6 +30,7 @@ class Tipue_Search_JSON_Generator(object):
         self.output_path = output_path
         self.context = context
         self.siteurl = settings.get('SITEURL')
+        self.relative_urls = settings.get('RELATIVE_URLS')
         self.tpages = settings.get('TEMPLATE_PAGES')
         self.output_path = output_path
         self.json_nodes = []
@@ -49,7 +50,9 @@ class Tipue_Search_JSON_Generator(object):
 
         page_category = page.category.name if getattr(page, 'category', 'None') != 'None' else ''
 
-        page_url = page.url if page.url else '.'
+        page_url = '.'
+        if page.url:
+            page_url = page.url if self.relative_urls else (self.siteurl + '/' + page.url)
 
         node = {'title': page_title,
                 'text': page_text,


### PR DESCRIPTION
This solves an issue stemming from the changes in #591 where the generated URLs are always relative, even when using RELATIVE_URLS as False in publishing settings.  This caused URLs showing up in the Tipue Search JSON file (and thus a frontend UI) to appear like `blog/about.html` when it should be `https://example.com/blog/about.html`; in short, whilst it works, it looks strange as there is no context.

This fixes the issue by adhering to RELATIVE_URLS; if set as `True` (eg dev/testing), the existing behaviour is applied.  If set as `False` (eg for production use), then the full site URL is created using pre-#591 behaviour.