### PR TITLE
Add pelican_meetup_info as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -136,3 +136,6 @@
 [submodule "pelican-ert"]
 	path = pelican-ert
 	url = https://github.com/nogaems/pelican-ert.git
+[submodule "pelican_meetup_info"]
+	path = pelican_meetup_info
+	url = https://github.com/tylerdave/pelican-meetup-info.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -188,6 +188,8 @@ Pelican Jinja2Content     Allows the use of Jinja2 template code in articles, in
 
 Pelican Link Class        Set class attribute of ``<a>`` elements according to whether the link is external or internal
 
+Pelican Meetup Info       Include your Meetup.com group and event information on generated pages and articles
+
 Pelican Page Hierarchy    Creates a URL hierarchy for pages that matches the filesystem hierarchy of their sources
 
 Pelican Page Order        Adds a ``page_order`` attribute to all pages if one is not defined.


### PR DESCRIPTION
Add plugin that gets information about a Meetup.com group from the Meetup API and makes it available for use in pages/articles.