### PR TITLE
Update jinja2content plugin

### DIFF
--- a/jinja2content/README.md
+++ b/jinja2content/README.md
@@ -1,23 +1,31 @@
 # Jinja2 Content
 
-This plugin allows the use of Jinja2 directives inside your pelican
-articles and pages.  This template rendering is done before the final html
-is generated, i.e. before your theme's `article.html` is applied.  This
-means the context and jinja variables usually visible to your article
-template **ARE NOT** available at this time.
+This plugin allows the use of Jinja2 directives inside your pelican articles and pages.
 
-All code that needs those variables (`article`, `category`, etc) should be
-put inside the theme's template logic.  As such, the main use of this
-plugin is to automatically generate parts of your articles.
+In this approach, your content is *first* rendered by the Jinja template engine. The result
+is then passed to the normal pelican reader as usual. There are two consequences for usage.
+First, this means the Pelican context and jinja variables [usually
+visible](http://docs.getpelican.com/en/stable/themes.html#templates-and-variables) to your
+article or page template are _not_ available at rendering time. Second, it means that if any
+of your input content could be parsed as Jinja directives, they will be rendered as such.
+This is unlikely to happen accidentally, but it's good to be aware of.
+
+All input that needs Pelican variables such as `article`, `category`, etc., should be put
+inside your *theme's* templating.  As such, the main use of this plugin is to automatically
+generate parts of your articles or pages.
+
+Markdown, reStructured Text, and HTML input are all supported. Note that by enabling this
+plugin, all input files of these file types will be preprocessed with the Jinja renderer.
+It is not currently supported to selectively enable or disable `jinja2content` for only some of
+these input sources.
 
 
 ## Example
 
-One usage is to embed repetitive html code into Markdown articles.  Since
-Markdown doesn't care for layout, if anything more sophisticated than just
-displaying an image is necessary, one is forced to embed html in Markdown
-articles (at the very least, hardcode `<div>` tags and then select them
-from the theme's CSS).  However, with `jinja2content`, one can do the
+One usage is to embed repetitive HTML in Markdown articles. Since Markdown doesn't allow
+customization of layout, if anything more sophisticated than just displaying an image is
+necessary, one is forced to embed HTML in Markdown articles (i.e. hardcode `<div>` tags and
+then select them from the theme's CSS).  However, with `jinja2content`, one can do the
 following.
 
 File `my-cool-article.md`
@@ -56,32 +64,51 @@ My cool content.
 </div>
 ```
 
-After this, the Markdown will be rendered into html and only then the
+After this, the Markdown will be rendered into HTML and only then the
 theme's templates will be applied.
 
 In this way, Markdown articles have more control over the content that is
 passed to the theme's `article.html` template, without the need to pollute
-the Markdown with html.  Another added benefit is that now `img_desc` is
+the Markdown with HTML.  Another added benefit is that now `img_desc` is
 reusable across articles.
 
 Note that templates rendered with `jinja2content` can contain Markdown as
-well as html, since they are added before the Markdown content is converted
+well as HTML, since they are added before the Markdown content is converted
 to html.
+
+
+## Usage
+
+Enable the `jinja2content` plugin in your project in [the usual
+manner](http://docs.getpelican.com/en/stable/plugins.html#how-to-use-plugins).
+
+```
+PLUGINS = [
+    # ...
+    "jinja2content",
+]
+```
 
 
 ## Configuration
 
-This plugin accepts the setting "JINJA2CONTENT_TEMPLATES" which should be
-set to a list of paths relative to 'PATH' (the main content directory).
-`jinja2content` will look for templates inside these directories, in order.
-If they are not found in any, the theme's templates folder is used.
+This plugin accepts the setting `JINJA2CONTENT_TEMPLATES` which should be set to a list of
+paths relative to `PATH` (the main content directory, usually `"content"`).  `jinja2content`
+will look for templates inside these directories, in order.  If they are not found in any,
+the theme's templates folder is used.
 
 
-## Notes
+## Extension
 
-+ Only Markdown supported at this moment.  Adding .rst support shouldn't be
-  too hard, and you can ask for it by opening an issue.
-+ This plugin is intended to replace
-  [pelican-jinj2content](https://github.com/joachimneu/pelican-jinja2content/tree/f73ef9b1ef1ee1f56c80757b4190b53f8cd607d1)
-  which hasn't been developed in a while and generated empty `<p>` tags in
-  the final html output.
+This plugin is structured such that it should be quite easy to extend readers for other file
+types to also render Jinja template logic. It should be sufficient to create a new reader
+class that inherents from the `JinjaContentMixin` and then your desired reader class. See
+class definitions in the source for examples.
+
+
+## Acknowledgements
+
+- Created by @Leonardo.
+- Updated to support rst and HTML input by @micahjsmith.
+- Replaces [pelican-jinj2content](https://github.com/joachimneu/pelican-jinja2content/tree/f73ef9b1ef1ee1f56c80757b4190b53f8cd607d1),
+which had become unmaintained.

--- a/jinja2content/jinja2content.py
+++ b/jinja2content/jinja2content.py
@@ -6,26 +6,23 @@ Pelican plugin that processes Markdown files as jinja templates.
 
 """
 
-from os import path
-from pelican import signals
-from pelican.readers import Markdown, MarkdownReader
-from pelican.utils import pelican_open
 from jinja2 import Environment, FileSystemLoader, ChoiceLoader
+import os
+from pelican import signals
+from pelican.readers import MarkdownReader, HTMLReader, RstReader
+from pelican.utils import pelican_open
+from tempfile import NamedTemporaryFile
 
-
-class JinjaMarkdownReader(MarkdownReader):
-
+class JinjaContentMixin:
     def __init__(self, *args, **kwargs):
-        super(JinjaMarkdownReader, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # will look first in 'JINJA2CONTENT_TEMPLATES', by default the
         # content root path, then in the theme's templates
-        # local_templates_dirs = self.settings.get('JINJA2CONTENT_TEMPLATES', ['.'])
-        # local_templates_dirs = path.join(self.settings['PATH'], local_templates_dirs)
         local_dirs = self.settings.get('JINJA2CONTENT_TEMPLATES', ['.'])
-        local_dirs = [path.join(self.settings['PATH'], folder)
+        local_dirs = [os.path.join(self.settings['PATH'], folder)
                       for folder in local_dirs]
-        theme_dir = path.join(self.settings['THEME'], 'templates')
+        theme_dir = os.path.join(self.settings['THEME'], 'templates')
 
         loaders = [FileSystemLoader(_dir) for _dir
                    in local_dirs + [theme_dir]]
@@ -41,28 +38,32 @@ class JinjaMarkdownReader(MarkdownReader):
             loader=ChoiceLoader(loaders),
             **jinja_environment)
 
+
     def read(self, source_path):
-        """Parse content and metadata of markdown files.
-
-        Rendering them as jinja templates first.
-
-        """
-
-        self._source_path = source_path
-        self._md = Markdown(extensions=self.settings['MARKDOWN']['extensions'])
-
         with pelican_open(source_path) as text:
             text = self.env.from_string(text).render()
-            content = self._md.convert(text)
 
-        metadata = self._parse_metadata(self._md.Meta)
-        return content, metadata
+        with NamedTemporaryFile(delete=False) as f:
+            f.write(text.encode())
+            f.close()
+            content, metadata = super().read(f.name)
+            os.unlink(f.name)
+            return content, metadata
 
+
+class JinjaMarkdownReader(JinjaContentMixin, MarkdownReader):
+    pass
+
+class JinjaRstReader(JinjaContentMixin, RstReader):
+    pass
+
+class JinjaHTMLReader(JinjaContentMixin, HTMLReader):
+    pass
 
 def add_reader(readers):
-    for ext in MarkdownReader.file_extensions:
-        readers.reader_classes[ext] = JinjaMarkdownReader
-
+    for Reader in [JinjaMarkdownReader, JinjaRstReader, JinjaHTMLReader]:
+        for ext in Reader.file_extensions:
+            readers.reader_classes[ext] = Reader
 
 def register():
     signals.readers_init.connect(add_reader)


### PR DESCRIPTION
This is a thorough refactor of the jinja2content plugin that also adds some additional functionality.

- restructure Jinja reader as a mixin
- remove re-implementation of MarkdownReader.read
- add support for RST and HTML input through JinjaRstReader and JinjaHTMLReader
- update README to clarify functionalities

The plugin now works as follows. The mixin reads Jinja-specific settings during initialization. Then, when the reader's `read` method is called, the mixin reads the source file and renders it using the configured Jinja environment. Then, it writes the results to a temporary file and passes it on to the base reader classes. This is nice because the plugin doesn't have to make any assumptions about what the base reader class is doing, as long as it can pass a file name to the content.

This also closes #809 and closes #922.