### PR TITLE
Improve tag_cloud README

### DIFF
--- a/tag_cloud/README.rst
+++ b/tag_cloud/README.rst
@@ -88,9 +88,9 @@ For example::
         font-size: 120%;
     }
 
-    ...
+    /* ... add li.tag-3 etc, as much as needed */
 
-    ul.tagcloud .list-group-item <span>.badge {
+    ul.tagcloud .list-group-item span.badge {
         background-color: grey;
         color: white;
     }


### PR DESCRIPTION
Typo in `<span>.badge` in CSS selector in the example css configuration.