### PR TITLE
Add support for python3 in liquid_tags/b64img.py

### DIFF
--- a/liquid_tags/b64img.py
+++ b/liquid_tags/b64img.py
@@ -24,7 +24,10 @@ Output
 """
 import re
 import base64
-import urllib2
+try:
+    import urllib.request as urllib2
+except ImportError:
+    import urllib2
 from .mdx_liquid_tags import LiquidTags
 import six
 


### PR DESCRIPTION
The following error occured when used with python3

ImportError: No module named 'urllib2'