### PR TITLE
interlinks: UnicodeDecodeError: 'ascii' codec can't decode byte... on python 2.7

### DIFF
--- a/interlinks/interlinks.py
+++ b/interlinks/interlinks.py
@@ -34,7 +34,7 @@ def parse_links(instance):
             text = BeautifulSoup(
                 content, "html.parser", parse_only=SoupStrainer("a"))
             for link in text.find_all("a", href=re.compile("(.+?)>")):
-                old_tag = str(link)
+                old_tag = link.decode()
                 url = link.get('href')
                 m = re.search(r"(.+?)>", url).groups()
                 name = m[0]
@@ -42,13 +42,13 @@ def parse_links(instance):
                     hi = url.replace(name + ">", interlinks[name])
                     link['href'] = hi
 
-                content = content.replace(old_tag, str(link))
+                content = content.replace(old_tag, link.decode())
 
         if '<img' in content:
             text = BeautifulSoup(
                 content, "html.parser", parse_only=SoupStrainer("img"))
             for img in text.find_all('img', src=re.compile("(.+?)>")):
-                old_tag = str(img)
+                old_tag = img.decode()
                 url = img.get('src')
                 m = re.search(r"(.+?)>", url).groups()
                 name = m[0]
@@ -56,7 +56,9 @@ def parse_links(instance):
                     hi = url.replace(name+">", interlinks[name])
                     img['src'] = hi
                 content = content.replace(
-                    old_tag.replace("&gt;", ">").replace("/>", ">"), str(img))
+                    old_tag.replace("&gt;", ">").replace("/>", ">"),
+                    img.decode()
+                )
 
         instance._content = content
 

--- a/interlinks/interlinks.py
+++ b/interlinks/interlinks.py
@@ -1,62 +1,66 @@
-﻿# -*- coding: utf-8 -*-
-
+# -*- coding: utf-8 -*-
 """
 Interlinks
 =========================
-
-This plugin allows you to include "interwiki" or shortcuts links into the blog, as keyword>rest_of_url
-
+This plugin allows you to include "interwiki" or shortcuts links into the blog,
+as keyword>rest_of_url
 """
+import re
+
+from pelican import signals
 
 from bs4 import BeautifulSoup
 from bs4 import SoupStrainer
-from pelican import signals
-import re
 
 interlinks = {}
 
-def getSettings (generator):
 
-	global interlinks
+def getSettings(generator):
 
-	interlinks = {'this': generator.settings['SITEURL']+"/"}
-	if 'INTERLINKS' in generator.settings:
-		for key, value in generator.settings['INTERLINKS'].items():
-			interlinks[key] = value
+    global interlinks
 
-			
+    interlinks = {'this': generator.settings['SITEURL']+"/"}
+    if 'INTERLINKS' in generator.settings:
+        for key, value in generator.settings['INTERLINKS'].items():
+            interlinks[key] = value
+
+
 def parse_links(instance):
 
-	if instance._content is not None:
-		content = instance._content
-		
-		if '<a' in content:
-			text = BeautifulSoup(content, "html.parser", parse_only=SoupStrainer("a"))
-			for link in text.find_all("a",href=re.compile("(.+?)>")):
-				old_tag = str(link)
-				url = link.get('href')
-				m = re.search(r"(.+?)>", url).groups()
-				name = m[0]
-				if name in interlinks:
-					hi = url.replace(name + ">", interlinks[name])
-					link['href'] = hi
-				
-				content = content.replace(old_tag, str(link))
+    if instance._content is not None:
+        content = instance._content
 
-		if '<img' in content:
-			text = BeautifulSoup(content, "html.parser", parse_only=SoupStrainer("img"))
-			for img in text.find_all('img', src=re.compile("(.+?)>")):
-				old_tag = str(img)
-				url = img.get('src')
-				m = re.search(r"(.+?)>", url).groups()
-				name = m[0]
-				if name in interlinks:
-					hi = url.replace(name+">",interlinks[name])
-					img['src'] = hi
-				content = content.replace(old_tag.replace("&gt;", ">").replace("/>",">"), str(img))
+        if '<a' in content:
+            text = BeautifulSoup(
+                content, "html.parser", parse_only=SoupStrainer("a"))
+            for link in text.find_all("a", href=re.compile("(.+?)>")):
+                old_tag = str(link)
+                url = link.get('href')
+                m = re.search(r"(.+?)>", url).groups()
+                name = m[0]
+                if name in interlinks:
+                    hi = url.replace(name + ">", interlinks[name])
+                    link['href'] = hi
 
-		instance._content = content
+                content = content.replace(old_tag, str(link))
+
+        if '<img' in content:
+            text = BeautifulSoup(
+                content, "html.parser", parse_only=SoupStrainer("img"))
+            for img in text.find_all('img', src=re.compile("(.+?)>")):
+                old_tag = str(img)
+                url = img.get('src')
+                m = re.search(r"(.+?)>", url).groups()
+                name = m[0]
+                if name in interlinks:
+                    hi = url.replace(name+">", interlinks[name])
+                    img['src'] = hi
+                content = content.replace(
+                    old_tag.replace("&gt;", ">").replace("/>", ">"), str(img))
+
+        instance._content = content
+
 
 def register():
-	signals.generator_init.connect(getSettings)
-	signals.content_object_init.connect(parse_links)
+    signals.generator_init.connect(getSettings)
+    signals.content_object_init.connect(parse_links)


### PR DESCRIPTION
I'm using Python 3 now but doing test builds against  2.7 to check for compatibility issues for anyone who's still on 2.7. I noticed the following error from the interlinks plugin;

```
  | UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 71: ordinal not in range(128)
  |___
  | Traceback (most recent call last):
  |   File "/mnt/sdd_store/cscutcher/myrepos/website/cscutcher.gitlab.io/.tox/py27/lib/python2.7/site-packages/pelican/generators.py", line 523, in generate_context
  |     context_sender=self)
  |   File "/mnt/sdd_store/cscutcher/myrepos/website/cscutcher.gitlab.io/.tox/py27/lib/python2.7/site-packages/pelican/readers.py", line 572, in read_file
  |     context=context)
  |   File "/mnt/sdd_store/cscutcher/myrepos/website/cscutcher.gitlab.io/.tox/py27/lib/python2.7/site-packages/pelican/contents.py", line 153, in __init__
  |     signals.content_object_init.send(self)
  |   File "/mnt/sdd_store/cscutcher/myrepos/website/cscutcher.gitlab.io/.tox/py27/lib/python2.7/site-packages/blinker/base.py", line 267, in send
  |     for receiver in self.receivers_for(sender)]
  |   File "/mnt/sdd_store/cscutcher/myrepos/website/pelican-plugins/interlinks/interlinks.py", line 44, in parse_links
  |     content = content.replace(old_tag, str(link))
  | UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 71: ordinal not in range(128)
```

`Python 2.7.14`

```
beautifulsoup4==4.6.0
blinker==1.4
docutils==0.14
feedgenerator==1.9
ghp-import==0.5.5
gitdb2==2.0.3
GitPython==2.1.9
Jinja2==2.10
Markdown==2.6.11
MarkupSafe==1.0
pelican==3.7.1
Pygments==2.2.0
python-dateutil==2.7.2
pytz==2018.4
six==1.11.0
smartypants==2.0.1
smmap2==2.0.3
typogrify==2.0.7
Unidecode==1.0.22
```
I can see the cause of the issue and have PR incoming to fix. 