### PR TITLE
permalinks and filetime_from_git: Py3 compatibility fixes. Fixes #1011

### DIFF
--- a/filetime_from_git/actions.py
+++ b/filetime_from_git/actions.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 import base64
 import hashlib
-import os
 import logging
+import os
+
 from pelican.utils import strftime
-from .utils import string_to_bool
-from .utils import datetime_from_timestamp
+
 from .registration import content_git_object_init
+from .utils import datetime_from_timestamp
+from .utils import string_to_bool
 
 
 logger = logging.getLogger(__name__)
@@ -112,6 +114,7 @@ def git_permalink(content, git_content):
     if permalink_id_metadata_key in content.metadata:
         content.metadata[permalink_id_metadata_key] = (
             ','.join((
-                content.metadata[permalink_id_metadata_key], git_permalink_id)))
+                content.metadata[permalink_id_metadata_key], git_permalink_id))
+        )
     else:
         content.metadata[permalink_id_metadata_key] = git_permalink_id

--- a/filetime_from_git/actions.py
+++ b/filetime_from_git/actions.py
@@ -79,6 +79,14 @@ def git_sha_metadata(content, git_content):
     content.metadata['gitsha_oldest'] = str(git_content.get_oldest_commit())
 
 
+def update_hash_from_str(hsh, str_input):
+    """
+    Convert a str to object supporting buffer API and update a hash with it.
+    """
+    byte_input = str(str_input).encode("UTF-8")
+    hsh.update(byte_input)
+
+
 @content_git_object_init.connect
 def git_permalink(content, git_content):
     '''
@@ -95,9 +103,10 @@ def git_permalink(content, git_content):
         return
 
     permalink_hash = hashlib.sha1()
-    permalink_hash.update(str(git_content.get_oldest_commit()))
-    permalink_hash.update(str(git_content.get_oldest_filename()))
-    git_permalink_id = base64.urlsafe_b64encode(permalink_hash.digest())
+    update_hash_from_str(permalink_hash, git_content.get_oldest_commit())
+    update_hash_from_str(permalink_hash, git_content.get_oldest_filename())
+    git_permalink_id_raw = base64.urlsafe_b64encode(permalink_hash.digest())
+    git_permalink_id = git_permalink_id_raw.decode("UTF-8")
     permalink_id_metadata_key = content.settings['PERMALINK_ID_METADATA_KEY']
 
     if permalink_id_metadata_key in content.metadata:

--- a/filetime_from_git/content_adapter.py
+++ b/filetime_from_git/content_adapter.py
@@ -75,7 +75,7 @@ class GitContentAdapter(object):
         '''
         commit_and_name_iter = self.git.get_commits_and_names_iter(
             self.content.source_path)
-        _commit, name = commit_and_name_iter.next()
+        _commit, name = next(commit_and_name_iter)
         return name
 
     @memoized

--- a/filetime_from_git/git_wrapper.py
+++ b/filetime_from_git/git_wrapper.py
@@ -128,10 +128,12 @@ class _GitWrapper(_GitWrapperCommon):
         :returns: Sequence of commit objects. Newest to oldest
 
         .. NOTE ::
-            If this fails it could be that your gitpython version is out of sync with the git
-            binary on your distro. Make sure you use the correct gitpython version.
+            If this fails it could be that your gitpython version is out of
+            sync with the git binary on your distro.
+            Make sure you use the correct gitpython version.
 
-            Alternatively enabling GIT_FILETIME_FOLLOW may also make your problem go away.
+            Alternatively enabling GIT_FILETIME_FOLLOW may also make your
+            problem go away.
         '''
         return list(self.repo.iter_commits(paths=path))
 

--- a/permalinks/permalinks.py
+++ b/permalinks/permalinks.py
@@ -3,14 +3,15 @@
 This plugin enables a kind of permalink which can be used to refer to a piece
 of content which is resistant to the file being moved or renamed.
 """
-import logging
 import itertools
+import logging
 import os
 import os.path
+
 from pelican import signals
 from pelican.generators import Generator
-from pelican.utils import mkdir_p
 from pelican.utils import clean_output_dir
+from pelican.utils import mkdir_p
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,8 @@ class PermalinkGenerator(Generator):
         '''
         self.permalink_output_path = os.path.join(
             self.output_path, self.settings['PERMALINK_PATH'])
-        self.permalink_id_metadata_key = self.settings['PERMALINK_ID_METADATA_KEY']
+        self.permalink_id_metadata_key = (
+            self.settings['PERMALINK_ID_METADATA_KEY'])
 
     def generate_output(self, writer=None):
         '''
@@ -79,7 +81,8 @@ class PermalinkGenerator(Generator):
 
 def get_permalink_ids_iter(self):
     '''
-    Method to get permalink ids from content. To be bound to the class last thing
+    Method to get permalink ids from content. To be bound to the class last
+    thing.
     '''
     permalink_id_key = self.settings['PERMALINK_ID_METADATA_KEY']
     permalink_ids = self.metadata.get(permalink_id_key, '')
@@ -91,9 +94,11 @@ def get_permalink_ids_iter(self):
 
 def get_permalink_ids(self):
     '''
-    Method to get permalink ids from content. To be bound to the class last thing
+    Method to get permalink ids from content. To be bound to the class last
+    thing.
     '''
     return list(self.get_permalink_ids_iter())
+
 
 def get_permalink_path(self):
     """Get just path component of permalink."""
@@ -131,12 +136,14 @@ def add_permalink_methods(content_inst):
             permalink_method.__name__,
             permalink_method.__get__(content_inst, content_inst.__class__))
 
+
 def add_permalink_option_defaults(pelicon_inst):
     '''
     Add perlican defaults
     '''
     pelicon_inst.settings.setdefault('PERMALINK_PATH', 'permalinks')
-    pelicon_inst.settings.setdefault('PERMALINK_ID_METADATA_KEY', 'permalink_id')
+    pelicon_inst.settings.setdefault(
+        'PERMALINK_ID_METADATA_KEY', 'permalink_id')
 
 
 def get_generators(_pelican_object):

--- a/permalinks/permalinks.py
+++ b/permalinks/permalinks.py
@@ -82,9 +82,9 @@ def get_permalink_ids_iter(self):
     Method to get permalink ids from content. To be bound to the class last thing
     '''
     permalink_id_key = self.settings['PERMALINK_ID_METADATA_KEY']
-    permalink_ids_raw = self.metadata.get(permalink_id_key, '')
+    permalink_ids = self.metadata.get(permalink_id_key, '')
 
-    for permalink_id in permalink_ids_raw.split(','):
+    for permalink_id in permalink_ids.split(','):
         if permalink_id:
             yield permalink_id.strip()
 
@@ -98,7 +98,7 @@ def get_permalink_ids(self):
 def get_permalink_path(self):
     """Get just path component of permalink."""
     try:
-        first_permalink_id = self.get_permalink_ids_iter().next()
+        first_permalink_id = next(self.get_permalink_ids_iter())
     except StopIteration:
         return None
 


### PR DESCRIPTION
The interface for hashlib.update changed to require input supporting [the buffer API](https://docs.python.org/3/c-api/buffer.html).    Also `.next` no longer exists in python 3.

Should fix issue #1011 