### PR TITLE
better_figures_and_images: Fix "local variable 'src' referenced before assignment"

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -52,6 +52,7 @@ def content_object_init(instance):
 
             # Pelican 3.5+ supports {attach} macro for auto copy, in this use case the content does not exist in output
             # due to the fact it has not been copied, hence we take it from the source (same as current document)
+            src = None
             if img_filename.startswith('{attach}'):
                 img_path = os.path.dirname(instance.source_path)
                 img_filename = img_filename[8:]


### PR DESCRIPTION
```
  |   File "~/git/plugins/better_figures_and_images/better_figures_and_images.py", line 77, in content_object_init
  |     if src is None:
  | UnboundLocalError: local variable 'src' referenced before assignment
```