### PR TITLE
SiteMap: Updated sample

### DIFF
--- a/sitemap/Readme.rst
+++ b/sitemap/Readme.rst
@@ -59,8 +59,9 @@ The sitemap is saved in ``<output_path>/sitemap.<format>``.
 Here is an example configuration (it's also the default settings):
 
 .. code-block:: python
-
-    PLUGINS=['pelican.plugins.sitemap',]
+    # Where your plug-ins reside
+    PLUGIN_PATHS = ['/where/you/cloned/it/pelican-plugins/', ]
+    PLUGINS=['sitemap',]
 
     SITEMAP = {
         'format': 'xml',


### PR DESCRIPTION
Thanks for the plugin; ping it forward with a doc update..
The sample as-is, 'pelican.plugins.sitemap ' would not load. What I have provided works. I also added the path statement as an extra helper.