### PR TITLE
Fix UnboundLocalError build error

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -50,6 +50,7 @@ def content_object_init(instance):
                 if len(sheet.width) > 0 or len(sheet.height) > 0:
                     continue
 
+            src = None
             # Pelican 3.5+ supports {attach} macro for auto copy, in this use case the content does not exist in output
             # due to the fact it has not been copied, hence we take it from the source (same as current document)
             if img_filename.startswith('{attach}'):


### PR DESCRIPTION
In commit b39fe8231, a build error has been introduced. When plugin `better_figures_and_images` is used, and a `image ::` tag references an image file using `{filename}`, `|filename|` or `/static` prefix, the test `if src is None:` raises an exception:

```
ERROR: Could not process .\blog-post-file.rst
  | UnboundLocalError: local variable 'src' referenced before assignment
```

This PR simply fix this error, by defining `src` variable to None by default. I assume this was the original intention of the author