### PR TITLE
Adding ctags_generator plugin

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -72,6 +72,8 @@ Creole reader             Allows you to write your posts using the wikicreole sy
 
 Custom article URLs       Adds support for defining different default URLs for different categories
 
+CTags generator           Generates a "tags" file following the CTags in the "content/" directory, to provide autocompletion for code editors that support it.
+
 Dateish                   Treat arbitrary metadata fields as datetime objects
 
 Dead Links                Manage dead links (website not available, errors such as 403, 404)

--- a/ctags_generator/README.md
+++ b/ctags_generator/README.md
@@ -1,0 +1,15 @@
+# Summary
+
+This plugin generates a `tags` file following the [CTags format](http://ctags.sourceforge.net/FORMAT) in the `content/` directory,
+to provide autocompletion for code editors that support it.
+
+
+Installation
+------------
+
+To enable, add the following to your settings.py:
+
+    PLUGIN_PATH = 'path/to/pelican-plugins'
+    PLUGINS = ['ctags_generator']
+
+`PLUGIN_PATH` can be a path relative to your settings file or an absolute path.

--- a/ctags_generator/__init__.py
+++ b/ctags_generator/__init__.py
@@ -1,0 +1,1 @@
+from .ctags_generator import *

--- a/ctags_generator/ctags_generator.py
+++ b/ctags_generator/ctags_generator.py
@@ -1,0 +1,26 @@
+import os
+
+from pelican import signals
+
+
+CTAGS_TEMPLATE = '''{% for tag, articles in tags_articles %}
+{% for article in articles %}
+{{tag}}\t{{article}}\t0;"\ttag
+{% endfor %}
+{% endfor %}
+'''
+
+
+def generate_ctags(article_generator, writer):
+    tags_file_path = os.path.join(article_generator.path, 'tags')
+    article_generator.settings.setdefault('WRITE_SELECTED', []).append(tags_file_path)
+    writer.output_path = article_generator.path
+    try:
+        writer.write_file('tags', article_generator.env.from_string(CTAGS_TEMPLATE), article_generator.context,
+                          tags_articles=sorted(article_generator.tags.items()))
+    finally:
+        writer.output_path = article_generator.output_path
+
+
+def register():
+    signals.article_writer_finalized.connect(generate_ctags)

--- a/ctags_generator/test_content/article_with_duplicate_tags_authors.md
+++ b/ctags_generator/test_content/article_with_duplicate_tags_authors.md
@@ -1,0 +1,15 @@
+Title: Test metadata duplicates
+Category: test
+Tags: foo, bar, foobar, foo, bar
+Authors: Author, First; Author, Second; Author, First
+Date: 2010-12-02 10:14
+Modified: 2010-12-02 10:20
+Summary: I have a lot to test
+
+Test Markdown File Header
+=========================
+
+Used for pelican test
+---------------------
+
+The quick brown fox jumped over the lazy dog's back.

--- a/ctags_generator/test_content/article_with_markdown_and_nonascii_summary.md
+++ b/ctags_generator/test_content/article_with_markdown_and_nonascii_summary.md
@@ -1,0 +1,19 @@
+Title: マックOS X 10.8でパイソンとVirtualenvをインストールと設定
+Slug: python-virtualenv-on-mac-osx-mountain-lion-10.8
+Date: 2012-12-20
+Modified: 2012-12-22
+Tags: パイソン, マック
+Category: 指導書
+Summary: パイソンとVirtualenvをまっくでインストールする方法について明確に説明します。
+
+Writing unicode is certainly fun.
+
+パイソンとVirtualenvをまっくでインストールする方法について明確に説明します。
+
+And let's mix languages.
+
+первый пост
+
+Now another.
+
+İlk yazı çok özel değil.

--- a/ctags_generator/test_content/article_with_md_extension.md
+++ b/ctags_generator/test_content/article_with_md_extension.md
@@ -1,0 +1,14 @@
+Title: Test md File
+Category: test
+Tags: foo, bar, foobar
+Date: 2010-12-02 10:14
+Modified: 2010-12-02 10:20
+Summary: I have a lot to test
+
+Test Markdown File Header
+=========================
+
+Used for pelican test
+---------------------
+
+The quick brown fox jumped over the lazy dog's back.

--- a/ctags_generator/test_ctags_generator.py
+++ b/ctags_generator/test_ctags_generator.py
@@ -1,0 +1,42 @@
+#!/bin/sh
+import os, shutil
+from tempfile import mkdtemp
+
+from pelican.generators import ArticlesGenerator
+from pelican.tests.support import get_settings, unittest
+from pelican.writers import Writer
+
+from ctags_generator import generate_ctags
+
+
+TEST_CONTENT_DIR = './test_content/'
+
+
+class TestCtagsGenerator(unittest.TestCase):
+
+    def test_generate_ctags(self):
+        settings = get_settings(filenames={})
+        settings['GENERATE_CTAGS'] = True
+
+        generator = ArticlesGenerator(
+            context=settings.copy(), settings=settings,
+            path=TEST_CONTENT_DIR, theme=settings['THEME'], output_path=None)
+        generator.generate_context()
+
+        writer = Writer(None, settings=settings)
+        generate_ctags(generator, writer)
+
+        output_path = os.path.join(TEST_CONTENT_DIR, 'tags')
+        self.assertTrue(os.path.exists(output_path))
+
+        try:
+            # output content is correct
+            with open(output_path, 'r') as output_file:
+                ctags = [l.split('\t')[0] for l in output_file.readlines()]
+                self.assertEqual(['bar', 'bar', 'foo', 'foo', 'foobar', 'foobar', 'マック', 'パイソン'], ctags)
+        finally:
+            os.remove(output_path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The goal is to provide tags autocompletion in all editors that support ctags (e.g. `vim` natively).

Here is an example of simple integration of such tags completion in Notepad++ using the "Python Script" plugin:
```
import os
ctags_filepath = os.path.join(os.path.dirname(notepad.getCurrentFilename()), 'tags')
if os.path.exists(ctags_filepath):
    with open(ctags_filepath) as ctags_file:
        ctags = set(line.split('\t')[0] for line in ctags_file.readlines() if not line.startswith('!'))
editor.autoCShow(0, ' '.join(sorted(ctags)))
```

When bound to a shortcut, this will provide autocompletion of existing articles tags.