### PR TITLE
filetime_from_git: Sanitise git environment when using `git_wrapper`

### DIFF
--- a/filetime_from_git/git_wrapper.py
+++ b/filetime_from_git/git_wrapper.py
@@ -31,6 +31,11 @@ class _GitWrapperCommon(object):
     '''
     def __init__(self, repo_path):
         self.git = Git()
+        self.git.update_environment(
+            GIT_CONFIG_NOSYSTEM='true',
+            HOME=os.getcwd(),
+            XDG_CONFIG_HOME=os.getcwd()
+        )
         self.repo = Repo(os.path.abspath('.'))
 
     def is_file_managed_by_git(self, path):


### PR DESCRIPTION
Otherwise peoples `~/.gitconfig` could cause commands in the wrapper to
fail.