### PR TITLE
Add the Similar Posts plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -139,3 +139,6 @@
 [submodule "pelican_meetup_info"]
 	path = pelican_meetup_info
 	url = https://github.com/tylerdave/pelican-meetup-info.git
+[submodule "similar_posts"]
+	path = similar_posts
+	url = https://github.com/davidlesieur/similar_posts.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -246,6 +246,8 @@ Share post                Creates share URLs of article
 
 Show Source               Place a link to the source text of your posts.
 
+Similar Posts             Adds a list of similar posts to every article's context.
+
 Simple footnotes          Adds footnotes to blog posts
 
 Sitemap                   Generates plain-text or XML sitemaps


### PR DESCRIPTION
The [Similar Posts](https://github.com/davidlesieur/similar_posts) plugin adds a list of similar articles to each article's context.