### PR TITLE
Fix the yuicompressor plugin

### DIFF
--- a/yuicompressor/README.md
+++ b/yuicompressor/README.md
@@ -1,18 +1,36 @@
 # YUI Compressor Plugin
 
-A pelican plugin which minify through yui compressor CSS/JS file on building step.
+A pelican plugin that minifies CSS/JS files using YUI Compressor during the
+building step.
 
 # Installation
 
-In order to work, JRE should be already installed.
-Please add `pip install yuicompressor`
+YUI Compressor needs to be present on your system. One way to obtain it is by
+installing it using pip:
 
-More info : (https://github.com/yui/yuicompressor)
+Important: This method assumes that JRE is already installed.
+
+```bash
+pip install yuicompressor
+```
+
+More information about YUI Compressor: https://github.com/yui/yuicompressor
 
 # Instructions
 
-Add `yuicompressor` to `pelicanconf.py` after install :
-`PLUGINS = ['yuicompressor']`
+Add `yuicompressor` to `pelicanconf.py` after installing YUI Compressor:
+
+```python
+PLUGINS = ['yuicompressor']
+```
+
+By default, this plugin expects the YUI Compressor executable to be named
+`yuicompressor`. This can be changed by defining `YUICOMPRESSOR_EXECUTABLE` in
+`pelicanconf.py`:
+
+```python
+YUICOMPRESSOR_EXECUTABLE = 'yui-compressor'
+```
 
 # Licence
 

--- a/yuicompressor/yuicompressor.py
+++ b/yuicompressor/yuicompressor.py
@@ -18,12 +18,13 @@ def minify(pelican):
       Minify CSS and JS with YUI Compressor
       :param pelican: The Pelican instance
     """
+    executable = pelican.settings.get('YUICOMPRESSOR_EXECUTABLE', 'yuicompressor')
     for dirpath, _, filenames in os.walk(pelican.settings['OUTPUT_PATH']):
         for name in filenames:
             if os.path.splitext(name)[1] in ('.css','.js'):
                 filepath = os.path.join(dirpath, name)
                 logger.info('minify %s', filepath)
-                check_call(['yuicompressor', '--charset', 'utf-8', filepath, '-o', filepath])
+                check_call([executable, '--charset', 'utf-8', filepath, '-o', filepath])
 
 def register():
     signals.finalized.connect(minify)

--- a/yuicompressor/yuicompressor.py
+++ b/yuicompressor/yuicompressor.py
@@ -8,8 +8,7 @@ import os
 logger = logging.getLogger(__name__)
 
 """
-Minify CSS and JS files in output path
-with YUI Compressor from Yahoo.
+Minify CSS and JS files in output path with YUI Compressor from Yahoo.
 Required: an existing installation of YUI Compressor.
 """
 

--- a/yuicompressor/yuicompressor.py
+++ b/yuicompressor/yuicompressor.py
@@ -23,8 +23,7 @@ def minify(pelican):
             if os.path.splitext(name)[1] in ('.css','.js'):
                 filepath = os.path.join(dirpath, name)
                 logger.info('minify %s', filepath)
-                check_call("yuicompressor --charset utf-8 {} -o {}".format(
-                    filepath, filepath), shell=True)
+                check_call(['yuicompressor', '--charset', 'utf-8', filepath, '-o', filepath])
 
 def register():
     signals.finalized.connect(minify)

--- a/yuicompressor/yuicompressor.py
+++ b/yuicompressor/yuicompressor.py
@@ -9,8 +9,8 @@ logger = logging.getLogger(__name__)
 
 """
 Minify CSS and JS files in output path
-with Yuicompressor from Yahoo
-Required : pip install yuicompressor
+with YUI Compressor from Yahoo.
+Required: an existing installation of YUI Compressor.
 """
 
 def minify(pelican):

--- a/yuicompressor/yuicompressor.py
+++ b/yuicompressor/yuicompressor.py
@@ -7,9 +7,6 @@ import os
 
 logger = logging.getLogger(__name__)
 
-# Display command output on DEBUG and TRACE
-SHOW_OUTPUT = logger.getEffectiveLevel() <= logging.DEBUG
-
 """
 Minify CSS and JS files in output path
 with Yuicompressor from Yahoo
@@ -26,9 +23,8 @@ def minify(pelican):
             if os.path.splitext(name)[1] in ('.css','.js'):
                 filepath = os.path.join(dirpath, name)
                 logger.info('minify %s', filepath)
-                verbose = '-v' if SHOW_OUTPUT else ''
-                check_call("yuicompressor {} --charset utf-8 {} -o {}".format(
-                    verbose, filepath, filepath), shell=True)
+                check_call("yuicompressor --charset utf-8 {} -o {}".format(
+                    filepath, filepath), shell=True)
 
 def register():
     signals.finalized.connect(minify)

--- a/yuicompressor/yuicompressor.py
+++ b/yuicompressor/yuicompressor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pelican import signals
-from subprocess import call
+from subprocess import check_call
 import logging
 import os
 
@@ -27,7 +27,7 @@ def minify(pelican):
                 filepath = os.path.join(dirpath, name)
                 logger.info('minify %s', filepath)
                 verbose = '-v' if SHOW_OUTPUT else ''
-                call("yuicompressor {} --charset utf-8 {} -o {}".format(
+                check_call("yuicompressor {} --charset utf-8 {} -o {}".format(
                     verbose, filepath, filepath), shell=True)
 
 def register():


### PR DESCRIPTION
Changes:

1. Exit with error if the YUI Compressor command fails. No more silent errors.
2. Add a new setting - `YUICOMPRESSOR_EXECUTABLE` - to customize the expected name of the YUI Compressor executable.
3. Prevent problems with file names that have whitespace and shell metacharacters.
4. Remove useless verbosity option.
6. Edit README.md

Rationale for (2):

In the original readme, the suggested way of obtaining YUI Compressor is through pip. For YUI Compressor to work if it is installed using pip, the system must already have JRE installed (because YUI Compressor depends on JRE, and pip does not install JRE). For some people, this is not the best way to obtain YUI Compressor. Some people may already have YUI Compressor installed at a different path, or some may have already obtained YUI Compressor from their distribution's repositories (e.g. `sudo apt-get install yui-compressor`, which installs an executable named `yui-compressor`). Currently, the plugin expects the executable to be named `yuicompressor`, making it impossible to use copies of YUI Compressor whose executables are not named `yuicompressor`. The new `YUICOMPRESSOR_EXECUTABLE` setting allows customization of the expected executable name.