### PR TITLE
Fix the processing of org files with SRC blocks. Fixes #1065

### DIFF
--- a/org_reader/org_reader.el
+++ b/org_reader/org_reader.el
@@ -1,6 +1,11 @@
 (require 'json)
 (require 'org)
 (require 'ox)
+(require 'package)
+
+;; htmlize is needed for SRC blocks
+(setq package-load-list '((htmlize t)))
+(package-initialize)
 
 (defun org->pelican (filename backend)
   (progn
@@ -14,8 +19,7 @@
             ; convert MODIFIED prop to string
             (modifiedstr (cdr (assoc-string "MODIFIED" org-file-properties t)))
             ; prepare date property
-            (dateobj (car (plist-get (org-export-get-environment) ':date)))
-            )
+            (dateobj (car (plist-get (org-export-get-environment) ':date))))
 
         ; check if #+TITLE: is given and give sensible error message if not
         (if (symbolp (car (plist-get org-export-env :title)))
@@ -51,11 +55,4 @@
                  :modified (if (stringp modifiedstr)
                                (org-read-date nil nil modifiedstr nil)
                              "")
-                 :post (org-export-as backend nil nil t)
-                 )
-                )
-               )
-        )
-      )
-    )
-  )
+                 :post (org-export-as backend nil nil t))))))))


### PR DESCRIPTION
This should fix the error indicated in Issue #1065. The `htmlize` package is needed for Emacs to process SRC blocks in org files, but it is not included in the default installation of Emacs.

It sets up the `htmlize` package for Emacs to use. I also tested this code after deleting the package -- if `htmlize` is not installed, the same error occurs as described in #1065.

I also cleaned up some of the lisp formatting, hope that is OK.