### PR TITLE
sitemap: Remove duplicate entries from txt header

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -21,9 +21,6 @@ from pelican import signals, contents
 from pelican.utils import get_date
 
 TXT_HEADER = """{0}/index.html
-{0}/archives.html
-{0}/tags.html
-{0}/categories.html
 """
 
 XML_HEADER = """<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Removing entries for 'tags.html', 'categories.html' and 'archives.html' from `TXT_HEADER` prevents them from getting duplicated in sitemap.txt.