### PR TITLE
Asciidoc3 reader

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -40,6 +40,8 @@ Ace Editor                Replace default **<code>** by an Ace__ code editor wit
 
 Always modified           Copy created date metadata into modified date for easy "latest updates" indexes
 
+AsciiDoc3 reader          Use AsciiDoc3 (Python3) to write your posts.
+
 AsciiDoc reader           Use AsciiDoc to write your posts.
 
 Asset management          Use the Webassets module to manage assets such as CSS and JS files.

--- a/asciidoc3_reader/README.rst
+++ b/asciidoc3_reader/README.rst
@@ -1,0 +1,45 @@
+AsciiDoc3 Reader
+###############
+
+This plugin allows you to use `AsciiDoc3 <https://asciidoc3.org/>`_
+to write your posts. File extension should be ``.ad3``.
+
+Dependency
+----------
+
+At the moment there is only one command line utility used to render AsciiDoc3:
+``asciidoc3``. Be sure to have this installed and on the PATH.
+
+Settings
+--------
+
+========================================  =======================================================
+Setting name (followed by default value)  What does it do?
+========================================  =======================================================
+``ASCIIDOC3_CMD = asciidoc3``             Selects which utility to use for rendering (at the 
+                                          moment only asciidoc3).
+``ASCIIDOC3_OPTIONS = []``                A list of options to pass to AsciiDoc3. See `Appendix I
+                                          <https://asciidoc3.org/userguide.html>`_.
+========================================  =======================================================
+
+Example file header
+-------------------
+
+Following the `example <https://github.com/getpelican/pelican/blob/master/docs/content.rst#file-metadata>`_ in the main pelican documentation:
+
+.. code-block:: none
+
+  = My super title
+
+  :date: 2010-10-03 10:20
+  :modified: 2010-10-04 18:40
+  :tags: thats, awesome
+  :category: yeah
+  :slug: my-super-post
+  :authors: Alexis Metaireau, Conan Doyle
+  :summary: Short version for index and feeds
+
+  == title level 2
+
+  and so on...
+

--- a/asciidoc3_reader/__init__.py
+++ b/asciidoc3_reader/__init__.py
@@ -1,0 +1,1 @@
+from .asciidoc3_reader import *

--- a/asciidoc3_reader/asciidoc3_reader.py
+++ b/asciidoc3_reader/asciidoc3_reader.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""
+AsciiDoc3 Reader
+================
+
+This plugin allows you to use AsciiDoc3 to write your posts.
+File extension should be ``.ad3``.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pelican.readers import BaseReader
+from pelican import signals
+
+def call(cmd):
+    """Calls a CLI command and returns the stdout as string."""
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, \
+                            shell=True).communicate()[0].decode('utf-8')
+
+def default():
+    """Attempt to find the default AsciiDoc3 utility."""
+    for cmd in ALLOWED_CMDS:
+        if call(cmd + " --help"):
+            return cmd
+
+def fix_unicode(val):
+    if sys.version_info[0] < 3:
+        val = unicode(val.decode("utf-8"))
+    else:
+        # This fixes an issue with character substitutions, e.g. 'ñ' to 'Ã±'.
+        val = str.encode(val, "latin-1").decode("utf-8")
+    return val
+
+ALLOWED_CMDS = ["asciidoc3"]
+
+ENABLED = None != default()
+
+class AsciiDoc3Reader(BaseReader):
+    """Reader for AsciiDoc3 files."""
+
+    enabled = ENABLED
+    file_extensions = ['ad3']
+    default_options = ['--no-header-footer']
+
+    def read(self, source_path):
+        """Parse content and metadata of AsciiDoc3 files."""
+        cmd = self._get_cmd()
+        content = ""
+        if cmd:
+            optlist = self.settings.get('ASCIIDOC3_OPTIONS', []) + self.default_options
+            options = " ".join(optlist)
+            content = call("%s %s -o - %s" % (cmd, options, source_path))
+        metadata = self._read_metadata(source_path)
+        return content, metadata
+
+    def _get_cmd(self):
+        """Returns the AsciiDoc3 utility command to use for rendering or None if
+        one cannot be found."""
+        if self.settings.get('ASCIIDOC3_CMD') in ALLOWED_CMDS:
+            return self.settings.get('ASCIIDOC3_CMD')
+        return default()
+
+    def _read_metadata(self, source_path):
+        """Parses the AsciiDoc3 file at the given `source_path` and returns found
+        metadata."""
+        metadata = {}
+        with open(source_path) as fi:
+            prev = ""
+            for line in fi.readlines():
+                # Parse for doc title.
+                if 'title' not in metadata.keys():
+                    title = ""
+                    if line.startswith("= "):
+                        title = line[2:].strip()
+                    elif line.count("=") == len(prev.strip()):
+                        title = prev.strip()
+                    if title:
+                        metadata['title'] = self.process_metadata('title', fix_unicode(title))
+
+                # Parse for other metadata.
+                regexp = re.compile(r"^:[A-z]+:\s*[A-z0-9]")
+                if regexp.search(line):
+                    toks = line.split(":", 2)
+                    key = toks[1].strip().lower()
+                    val = toks[2].strip()
+                    metadata[key] = self.process_metadata(key, fix_unicode(val))
+                prev = line
+        return metadata
+
+def add_reader(readers):
+    for ext in AsciiDoc3Reader.file_extensions:
+        readers.reader_classes[ext] = AsciiDoc3Reader
+
+def register():
+    signals.readers_init.connect(add_reader)

--- a/ctags_generator/ctags_generator.py
+++ b/ctags_generator/ctags_generator.py
@@ -13,7 +13,8 @@ CTAGS_TEMPLATE = '''{% for tag, articles in tags_articles %}
 
 def generate_ctags(article_generator, writer):
     tags_file_path = os.path.join(article_generator.path, 'tags')
-    article_generator.settings.setdefault('WRITE_SELECTED', []).append(tags_file_path)
+    if article_generator.settings.get('WRITE_SELECTED'):
+        article_generator.settings['WRITE_SELECTED'].append(tags_file_path)
     writer.output_path = article_generator.path
     try:
         writer.write_file('tags', article_generator.env.from_string(CTAGS_TEMPLATE), article_generator.context,


### PR DESCRIPTION
Plugin for AsciiDoc3

This plugins enables the user to write his posts with AsciiDoc3 (https://asciidoc3.org Python3 implementation of the asciidoc-markup-language). Works fine for me, see https://asciidoc3.org/blog