### PR TITLE
i18n_subsites: Use new draft status for articles

### DIFF
--- a/i18n_subsites/i18n_subsites.py
+++ b/i18n_subsites/i18n_subsites.py
@@ -22,7 +22,10 @@ import locale
 from pelican import signals
 from pelican.generators import ArticlesGenerator, PagesGenerator
 from pelican.settings import configure_settings
-from pelican.contents import Draft
+try:
+    from pelican.contents import Draft
+except ImportError:
+    from pelican.contents import Article as Draft
 
 
 # Global vars


### PR DESCRIPTION
pelican 4 introduces `draft` as allowed status for articles and removes `Draft` from `pelican.contents`.

i18n_subsites does not work any more with version 4.x. This MR fixes this