### PR TITLE
[autopages] Misleading variable descriptions in README

### DIFF
--- a/autopages/README.md
+++ b/autopages/README.md
@@ -14,8 +14,8 @@ an ordinary Pelican page, so it can be Markdown, reStructuredText, etc.
 
 ## Template Variables
 
-| Variable        | Notes                                      |
-|-----------------|--------------------------------------------|
-| `author.page`   | The rendered content of the author page.   |
-| `category.page` | The rendered content of the category page. |
-| `tag.page`      | The rendered content of the tag page.      |
+| Variable        | Notes                                |
+|-----------------|--------------------------------------|
+| `author.page`   | `Page` object for the author page.   |
+| `category.page` | `Page` object for the category page. |
+| `tag.page`      | `Page` object for the tag page.      |


### PR DESCRIPTION
Related to #1083: explicitly state `author.page`, `category.page` and `tag.page` variables are `Page` objects and not "rendered content" in the `autopages` README. Rendered content could be intepreted as rendered HTML, not as page objects.