### PR TITLE
i18n_subsites: Accommodate filename renaming to static_content in generator context

### DIFF
--- a/i18n_subsites/i18n_subsites.py
+++ b/i18n_subsites/i18n_subsites.py
@@ -12,7 +12,10 @@ import posixpath
 from copy import copy
 from itertools import chain
 from operator import attrgetter
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 from contextlib import contextmanager
 from six.moves.urllib.parse import urlparse
 
@@ -356,13 +359,19 @@ def interlink_static_files(generator):
     '''Add links to static files in the main site if necessary'''
     if generator.settings['STATIC_PATHS'] != []:
         return                               # customized STATIC_PATHS
-    filenames = generator.context['filenames'] # minimize attr lookup
+    try: # minimize attr lookup
+        static_content = generator.context['static_content']
+    except KeyError:
+        static_content = generator.context['filenames']
     relpath = relpath_to_site(generator.settings['DEFAULT_LANG'], _MAIN_LANG)
     for staticfile in _MAIN_STATIC_FILES:
-        if staticfile.get_relative_source_path() not in filenames:
+        if staticfile.get_relative_source_path() not in static_content:
             staticfile = copy(staticfile) # prevent override in main site
             staticfile.override_url = posixpath.join(relpath, staticfile.url)
-            generator.add_source_path(staticfile)
+            try:
+                generator.add_source_path(staticfile, static=True)
+            except TypeError:
+                generator.add_source_path(staticfile)
 
 
 def save_main_static_files(static_generator):


### PR DESCRIPTION
Fixes https://github.com/getpelican/pelican-plugins/issues/1087 (hopefully)

The `i18n_subsites` tests are broken in multiple ways, so I've found it impossible to test whether this is backwards compatible, but it should be.