### PR TITLE
Render_Math: Fixed broken config script + Added variables for font & numbering

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -76,6 +76,8 @@ def process_settings(pelicanobj):
     mathjax_settings['mathjax_font'] = 'default'  # forces mathjax to use the specified font.
     mathjax_settings['process_summary'] = BeautifulSoup is not None  # will fix up summaries if math is cut off. Requires beautiful soup
     mathjax_settings['message_style'] = 'normal'  # This value controls the verbosity of the messages in the lower left-hand corner. Set it to "none" to eliminate all messages
+    mathjax_settings['font_list'] = ['STIX', 'TeX'] # Include in order of preference among TeX, STIX-Web, Asana-Math, Neo-Euler, Gyre-Pagella, Gyre-Termes and Latin-Modern
+    mathjax_settings['equation_numbering'] = 'none' # AMS, auto, none
 
     # Source for MathJax
     mathjax_settings['source'] = "'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/latest.js?config=TeX-AMS-MML_HTMLorMML'"
@@ -180,6 +182,15 @@ def process_settings(pelicanobj):
                 value = 'default'
 
             mathjax_settings[key] = value
+
+        if key == 'font_list' and isinstance(value, list):
+            # make an array string from the list
+            value = filter(lambda string: isinstance(string, string_type), value)
+            value = map(lambda string: ",'%s'" % string, value)
+            mathjax_settings[key] = ''.join(value)[1:]
+
+        if key == 'equation_numbering':
+            mathjax_settings[key] = value if value is not None else 'none'
 
     return mathjax_settings
 

--- a/render_math/mathjax_script_template
+++ b/render_math/mathjax_script_template
@@ -13,10 +13,13 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
     mathjaxscript.id = 'mathjaxscript_pelican_#%@#$@#';
     mathjaxscript.type = 'text/javascript';
     mathjaxscript.src = {source};
-    mathjaxscript[(window.opera ? "innerHTML" : "text")] =
+
+    var configscript = document.createElement('script');
+    configscript.type = 'text/x-mathjax-config';
+    configscript[(window.opera ? "innerHTML" : "text")] =
         "MathJax.Hub.Config({{" +
         "    config: ['MMLorHTML.js']," +
-        "    TeX: {{ extensions: ['AMSmath.js','AMSsymbols.js','noErrors.js','noUndefined.js'{tex_extensions}], equationNumbers: {{ autoNumber: 'AMS' }} }}," +
+        "    TeX: {{ extensions: ['AMSmath.js','AMSsymbols.js','noErrors.js','noUndefined.js'{tex_extensions}], equationNumbers: {{ autoNumber: '{equation_numbering}' }} }}," +
         "    jax: ['input/TeX','input/MathML','output/HTML-CSS']," +
         "    extensions: ['tex2jax.js','mml2jax.js','MathMenu.js','MathZoom.js']," +
         "    displayAlign: '"+ align +"'," +
@@ -30,6 +33,7 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
         "        preview: '{latex_preview}'," +
         "    }}, " +
         "    'HTML-CSS': {{ " +
+        "        fonts: [{font_list}]," +
         "        styles: {{ '.MathJax_Display, .MathJax .mo, .MathJax .mi, .MathJax .mn': {{color: '{color} ! important'}} }}," +
         "        linebreaks: {{ automatic: "+ linebreak +", width: '90% container' }}," +
         "    }}, " +
@@ -50,5 +54,7 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
                 "VARIANT['-tex-mathit'].fonts.unshift('MathJax_{mathjax_font}-italic');" +
             "}});" +
         "}}";
+
+    (document.body || document.getElementsByTagName('head')[0]).appendChild(configscript);
     (document.body || document.getElementsByTagName('head')[0]).appendChild(mathjaxscript);
 }}


### PR DESCRIPTION
Changing `MATH_JAX[key] = value` was not affecting the final `MathJax.Config.Hub` output to the page, because the configuration script has to go _before_ the MathJax invocation, not after.

Also, it was not previously possible to force the use of TeX (or any of the other MathJax fonts) over STIX. I have fixed this, but it turned on equation numbering by default, so I have turned that off by default and made Pelican config variables for both things.

In `pelicanconf.py`, you can now specify

```python
MATH_JAX = {         'font_list': ['my_favorite_font', 'my_next_favorite'], 
            'equation_numbering': 'none/auto/AMS'}
```
where fonts can be any of `TeX, STIX-Web, Asana-Math, Neo-Euler, Gyre-Pagella, Gyre-Termes, Latin-Modern`.