### PR TITLE
asccidoc_reader: Do not encode into latin1 on python3

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -26,10 +26,7 @@ def default():
 
 def fix_unicode(val):
     if sys.version_info < (3,0):
-        val = unicode(val.decode("utf-8"))
-    else:
-        # This fixes an issue with character substitutions, e.g. 'ñ' to 'Ã±'.
-        val = str.encode(val, "latin-1").decode("utf-8")
+        return unicode(val.decode("utf-8"))
     return val
 
 ALLOWED_CMDS = ["asciidoc", "asciidoctor"]


### PR DESCRIPTION
It causes UnicodeDecodeError when using non-ascii characters in titles such as 'à'.
The commented example (`ñ`) doesn't work in python3.7 with the encode/decode hack, but works fine without. I don't really understand why it was introduced.

I haven't run the test suite, I can't manage to get a working testing environment with pelican and pelican-plugins.