### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/asciidoc_reader/asciidocapi.py
+++ b/asciidoc_reader/asciidocapi.py
@@ -243,7 +243,7 @@ class AsciiDocAPI(object):
                 self.asciidoc.execute(self.cmd, opts.values, args)
             finally:
                 self.messages = self.asciidoc.messages[:]
-        except SystemExit, e:
+        except SystemExit as e:
             if e.code:
                 raise AsciiDocError(self.messages[-1])
 

--- a/clean_summary/clean_summary.py
+++ b/clean_summary/clean_summary.py
@@ -20,7 +20,7 @@ def init(pelican):
 
 
 def clean_summary(instance):
-    if type(instance) == Article:
+    if isinstance(instance, Article):
         summary = instance.summary
         summary = BeautifulSoup(instance.summary, 'html.parser')
         images = summary.findAll('img')

--- a/dateish/dateish.py
+++ b/dateish/dateish.py
@@ -19,7 +19,7 @@ def dateish(generator):
         for field in generator.settings['DATEISH_PROPERTIES']:
             if hasattr(article, field):
                 value = getattr(article, field)
-                if type(value) == list:
+                if isinstance(value, list):
                     setattr(article, field, [get_date(d) for d in value])
                 else:
                     setattr(article, field, get_date(value))

--- a/events/events.py
+++ b/events/events.py
@@ -40,7 +40,7 @@ def parse_tstamp(ev, field_name):
     """
     try:
         return datetime.strptime(ev[field_name], '%Y-%m-%d %H:%M')
-    except Exception, e:
+    except Exception as e:
         log.error("Unable to parse the '%s' field in the event named '%s': %s" \
             % (field_name, ev['title'], e))
         raise

--- a/libravatar/test_libravatar.py
+++ b/libravatar/test_libravatar.py
@@ -1,4 +1,5 @@
 """Unit testing suite for the Libravatar Plugin"""
+from __future__ import print_function
 
 ## Copyright (C) 2015  Rafael Laboissiere <rafael@laboissiere.net>
 ##
@@ -66,7 +67,7 @@ class TestLibravatarURL (unittest.TestCase):
         fid = open (os.path.join (self.output_path, 'test.html'), 'r')
         found = False
         for line in fid.readlines ():
-            print line
+            print(line)
             if re.search (LIBRAVATAR_BASE_URL + MD5_HASH + options, line):
                 found = True
                 break

--- a/plantuml/plantuml_rst.py
+++ b/plantuml/plantuml_rst.py
@@ -71,7 +71,7 @@ class PlantUML(Directive):
         try:
             p = Popen(cmdline, stdout=PIPE, stderr=PIPE)
             out, err = p.communicate()
-        except Exception, exc:
+        except Exception as exc:
             error = self.state_machine.reporter.error(
                 'Failed to run plantuml: %s' % (exc, ),
                 literal_block(self.block_text, self.block_text),
@@ -86,7 +86,7 @@ class PlantUML(Directive):
 	        
 	        try: # for Windows
 		    os.remove(newname)  
-		except Exception, exc:
+		except Exception as exc:
 		    logger.debug('File '+newname+' does not exist, not deleted')
 		
 	        os.rename(name, newname)

--- a/read_more_link/read_more_link.py
+++ b/read_more_link/read_more_link.py
@@ -49,7 +49,7 @@ def insert_read_more_link(instance):
     """
 
     # only deals with Article type
-    if type(instance) != contents.Article: return
+    if not isinstance(instance, contents.Article): return
 
 
     SUMMARY_MAX_LENGTH = instance.settings.get('SUMMARY_MAX_LENGTH')


### PR DESCRIPTION
* Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.
* Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.