### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/bootstrap-rst/make-glyphicons.py
+++ b/bootstrap-rst/make-glyphicons.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 glyphs = """<span class="glyphicon glyphicon-asterisk"></span>
 <span class="glyphicon glyphicon-plus"></span>
 <span class="glyphicon glyphicon-euro"></span>
@@ -210,14 +211,14 @@ glyphs = glyphs.split('\n')
 #    print ""
 
 
-print ".. row::"
+print(".. row::")
 for i, glyph in enumerate(glyphs):
     if i % 50 == 0:
-        print ""
-        print "   .. column::"
-        print "      :width: 3"
-        print ""
-        print "      .. list:: list-unstyled"
-        print ""
+        print("")
+        print("   .. column::")
+        print("      :width: 3")
+        print("")
+        print("      .. list:: list-unstyled")
+        print("")
     name = glyph[33:-9]
-    print "         * |%s| : %s" % (name,name)
+    print("         * |%s| : %s" % (name,name))

--- a/libravatar/test_libravatar.py
+++ b/libravatar/test_libravatar.py
@@ -1,4 +1,5 @@
 """Unit testing suite for the Libravatar Plugin"""
+from __future__ import print_function
 
 ## Copyright (C) 2015  Rafael Laboissiere <rafael@laboissiere.net>
 ##
@@ -66,7 +67,7 @@ class TestLibravatarURL (unittest.TestCase):
         fid = open (os.path.join (self.output_path, 'test.html'), 'r')
         found = False
         for line in fid.readlines ():
-            print line
+            print(line)
             if re.search (LIBRAVATAR_BASE_URL + MD5_HASH + options, line):
                 found = True
                 break


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.