### PR TITLE
liquid_tags: Python 3 requires from errno import EINVAL, EPIPE

### DIFF
--- a/liquid_tags/graphviz.py
+++ b/liquid_tags/graphviz.py
@@ -51,6 +51,7 @@ Output
 
 import base64
 import re
+from errno import EINVAL, EPIPE
 from .mdx_liquid_tags import LiquidTags
 
 SYNTAX = '{% dot graphviz [program] [dot code] %}'


### PR DESCRIPTION
Python 2 did not require these import but Python 3 does.