### PR TITLE
plantuml: Fix reST format option

### DIFF
--- a/plantuml/plantuml_rst.py
+++ b/plantuml/plantuml_rst.py
@@ -42,7 +42,8 @@ class PlantUML_rst(Directive):
         body = '\n'.join(self.content)
 
         try:
-            url = global_siteurl+'/'+generate_uml_image(path, body, "png")
+            uml_format = self.options.get('format', 'png')
+            url = global_siteurl+'/'+generate_uml_image(path, body, uml_format)
         except Exception as exc:
             error = self.state_machine.reporter.error(
                 'Failed to run plantuml: %s' % exc,


### PR DESCRIPTION
The plantuml Rst pluging was ignoring the `format` option in the `uml`
blocks, hardcoded to `png` all the time.  This did not allow for
generating `svg` images, as described in the Readme.rst.

Corrected the issue.

@mikitex70 and @mandaris and @justinmayer,
Please review.