### PR TITLE
Update rmd_reader to work in Pelican 4.0

### DIFF
--- a/rmd_reader/rmd_reader.py
+++ b/rmd_reader/rmd_reader.py
@@ -61,7 +61,7 @@ class RmdReader(readers.BaseReader):
     file_extensions = ['Rmd', 'rmd']
 
     @property
-    def enabled():
+    def enabled(self):
         return RMD
 
     # You need to have a read method, which takes a filename and returns


### PR DESCRIPTION
Upon upgrading to Pelican 4.0, I was presented with this error:

```
CRITICAL: TypeError: enabled() takes 0 positional arguments but 1 was given
```

pdb revealed this was when Pelican tried to access the `enabled` property of an `RmdReader` instance; since `enabled` was not declared to take `self`, the method doesn't work on instances. Adding the `self` argument now works perfectly.