### PR TITLE
interlinks: Fix images not rendering

### DIFF
--- a/interlinks/interlinks.py
+++ b/interlinks/interlinks.py
@@ -55,10 +55,15 @@ def parse_links(instance):
                 if name in interlinks:
                     hi = url.replace(name+">", interlinks[name])
                     img['src'] = hi
+
+                # generated output has no trailing slash; match for replacement
+                repaired_old_tag = old_tag.replace("/>", ">")
+
                 content = content.replace(
-                    old_tag.replace("&gt;", ">").replace("/>", ">"),
+                    repaired_old_tag,
                     img.decode()
                 )
+
 
         instance._content = content
 


### PR DESCRIPTION
This occurs because Pelican now generates &gt; for >, so the old string replacement no longer works.

I tried to rebuild my site, but it failed, and upon investigation, it was because this string replace was failing.  &gt; did not need to be replaced with '>'