### PR TITLE
rmd_reader: Avoid warning about the use of {filename}

### DIFF
--- a/rmd_reader/rmd_reader.py
+++ b/rmd_reader/rmd_reader.py
@@ -104,7 +104,7 @@ class RmdReader(readers.BaseReader):
 opts_knit$set(unnamed.chunk.label="{unnamed_chunk_label}")
 render_markdown()
 hook_plot <- knit_hooks$get('plot')
-knit_hooks$set(plot=function(x, options) hook_plot(paste0("{{filename}}/", x), options))
+knit_hooks$set(plot=function(x, options) hook_plot(paste0("{{static}}/", x), options))
             '''.format(unnamed_chunk_label=chunk_label))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")


### PR DESCRIPTION
After the upgrade to pelican 4, I got warnings that told me to use {static} instead of {filename}. This change makes these warnings disappear as far as they were caused by my rmd articles.