### PR TITLE
better_figures_and_images: Accept the new {static} link syntax

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -60,6 +60,8 @@ def content_object_init(instance):
             elif img_path.startswith(('{filename}', '|filename|')):
                 # Strip off {filename}, |filename| or /static
                 img_path = img_path[10:]
+            elif img_path.startswith('{static}'):
+                img_path = img_path[8:]
             elif img_path.startswith('/static'):
                 img_path = img_path[7:]
             elif img_path.startswith('data:image'):
@@ -73,7 +75,7 @@ def content_object_init(instance):
                     src = image_output_location
                     logger.info('{src} located in output, missing from content.'.format(src=img_filename))
                 else:
-                    logger.warning('Better Fig. Error: img_path should start with either {attach}, {filename}, |filename| or /static')
+                    logger.warning('Better Fig. Error: img_path should start with either {attach}, {filename}, |filename|, {static} or /static')
 
             if src is None:
                 # search src path list


### PR DESCRIPTION
This modification enables the better_figures_and_images plugin to accept the new {static} link syntax in place of the old {filename} which raises warnings when used with static content.