### PR TITLE
Add Pelican settings as Jinja2 global variables and strftime as Jinja2  filter

### DIFF
--- a/jinja2content/jinja2content.py
+++ b/jinja2content/jinja2content.py
@@ -10,7 +10,7 @@ from jinja2 import Environment, FileSystemLoader, ChoiceLoader
 import os
 from pelican import signals
 from pelican.readers import MarkdownReader, HTMLReader, RstReader
-from pelican.utils import pelican_open
+from pelican.utils import pelican_open, DateFormatter
 from tempfile import NamedTemporaryFile
 
 class JinjaContentMixin:
@@ -37,7 +37,8 @@ class JinjaContentMixin:
         self.env = Environment(
             loader=ChoiceLoader(loaders),
             **jinja_environment)
-        self.env.globals = self.settings
+        self.env.globals.update(self.settings)
+        self.env.filters.update({'strftime': DateFormatter()})
 
 
     def read(self, source_path):

--- a/jinja2content/jinja2content.py
+++ b/jinja2content/jinja2content.py
@@ -37,6 +37,7 @@ class JinjaContentMixin:
         self.env = Environment(
             loader=ChoiceLoader(loaders),
             **jinja_environment)
+        self.env.globals = self.settings
 
 
     def read(self, source_path):


### PR DESCRIPTION
Hello,

Pelican settings are availables in template but not in articles or pages. This commit changes that. 
Using the jinja2content plugin, you can now access all your Pelican settings such as SITEURL or RSS in your articles or pages. Yay!

EDIT: Also add strftime as a Jinja2 filter.