### PR TITLE
liquid_tags: Add optional ratio for Speakerdeck viewer

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -94,10 +94,22 @@ If you experience issues with code generation (e.g., missing closing tags),
 add `SUMMARY_MAX_LENGTH = None` to your settings file.
 
 ## Speakerdeck Tag
-To insert a Speakerdeck viewer into your content, enable the
-`liquid_tags.speakerdeck` plugin and add the following to your source document:
 
-    {% speakerdeck speakerdeck_id %}
+To insert a Speakerdeck viewer into your content, follow these steps:
+
+1. Enable the `liquid_tags.soundcloud` plugin
+2. Add the following to your source document:
+
+  ```html
+  {% speakerdeck speakerdeck_id [ratio] %}
+  ```
+
+### Note
+
+- The ratio is a decimal number and is optional.
+- Ratio accept decimal number and digit after decimal is optional.
+- If ratio is not specified, then it will be `1.33333333333333` (4/3).
+- An example value for the ration can be `1.77777777777777` (16/9).
 
 ## Video Tag
 To insert HTML5-friendly video into your content, enable the `liquid_tags.video`

--- a/liquid_tags/speakerdeck.py
+++ b/liquid_tags/speakerdeck.py
@@ -13,23 +13,44 @@ Example
 
 Output
 ------
-<script async class="speakerdeck-embed" data-id="82b209c0f181013106da6eb14261a8ef"
- data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>
+<script
+    async
+    class="speakerdeck-embed"
+    data-id="82b209c0f181013106da6eb14261a8ef"
+    data-ratio="1.33333333333333"
+    src="//speakerdeck.com/assets/embed.js">
+</script>
 """
+import re
+
 from .mdx_liquid_tags import LiquidTags
 
-SYNTAX = "{% speakerdeck id %}"
+SYNTAX = "{% speakerdeck id [ratio] %}"
+
+REGEX = re.compile(r'([\S]+)(\s+(\d*\.?\d*))?')
+
 
 @LiquidTags.register('speakerdeck')
 def speakerdeck(preprocessor, tag, markup):
-    speakerdeck_out = """
+    ratio = 1.33333333333333
+    id = None
+    match = REGEX.search(markup)
+    if match:
+        groups = match.groups()
+        id = groups[0]
+        ratio = groups[2] or ratio
+    if id:
+        speakerdeck_out = """
 <script async class="speakerdeck-embed" data-id="{id}"
-data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>
-        """.format(id=markup)
-
+data-ratio="{ratio}" src="//speakerdeck.com/assets/embed.js"></script>
+        """.format(id=id, ratio=ratio)
+    else:
+        raise ValueError(
+            "Error processing input, expected syntax: {0}".format(SYNTAX)
+        )
     return speakerdeck_out
 
 
 # ---------------------------------------------------
 # This import allows speakerdeck tag to be a Pelican plugin
-from liquid_tags import register  # noqa
+from liquid_tags import register  # noqa # isort:skip


### PR DESCRIPTION
Add an optional ratio for speakedeck viewer in Liquid tags plugin.