### PR TITLE
YUI Compressor additional options

### DIFF
--- a/yuicompressor/README.md
+++ b/yuicompressor/README.md
@@ -32,6 +32,13 @@ By default, this plugin expects the YUI Compressor executable to be named
 YUICOMPRESSOR_EXECUTABLE = 'yui-compressor'
 ```
 
+Additional options can be passed to YUI Compressor by setting list
+`YUICOMPRESSOR_EXTRA_OPTIONS` in `pelicanconf.py`:
+
+```python
+YUICOMPRESSOR_EXTRA_OPTIONS = ['--disable-optimizations']
+```
+
 # Licence
 
 GNU AFFERO GENERAL PUBLIC LICENSE Version 3

--- a/yuicompressor/yuicompressor.py
+++ b/yuicompressor/yuicompressor.py
@@ -18,12 +18,13 @@ def minify(pelican):
       :param pelican: The Pelican instance
     """
     executable = pelican.settings.get('YUICOMPRESSOR_EXECUTABLE', 'yuicompressor')
+    extra_options = pelican.settings.get('YUICOMPRESSOR_EXTRA_OPTIONS', [])
     for dirpath, _, filenames in os.walk(pelican.settings['OUTPUT_PATH']):
         for name in filenames:
             if os.path.splitext(name)[1] in ('.css','.js'):
                 filepath = os.path.join(dirpath, name)
                 logger.info('minify %s', filepath)
-                check_call([executable, '--charset', 'utf-8', filepath, '-o', filepath])
+                check_call([executable] + extra_options + ['--charset', 'utf-8', filepath, '-o', filepath])
 
 def register():
     signals.finalized.connect(minify)


### PR DESCRIPTION
Some JS and/or CSS can be broken after compression with default setup of YUI Compressor. Sometimes it can be fixed, for example, by adding `--disable-optimizations` option. This patch adds generic `YUICOMPRESSOR_EXTRA_OPTIONS` option support in `pelicanconf.py` to pass additional arguments to  YUI Compressor.