### PR TITLE
rmd_reader: Make set_initoptions() compatible with rpy2 v3

### DIFF
--- a/rmd_reader/rmd_reader.py
+++ b/rmd_reader/rmd_reader.py
@@ -22,8 +22,12 @@ def startr():
     logger.debug('STARTING R')
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        import rpy2.rinterface
-        rpy2.rinterface.set_initoptions((b'rpy2', b'--no-save', b'--vanilla', b'--quiet'))
+        try:
+            import rpy2.rinterface
+            rpy2.rinterface.set_initoptions((b'rpy2', b'--no-save', b'--vanilla', b'--quiet'))
+        except AttributeError:
+            from rpy2.rinterface_lib import embedded
+            embedded.set_initoptions(("rpy2", "--no-save", "--vanilla", "--quiet"))
         import rpy2.robjects as R_OBJECTS
         from rpy2.robjects.packages import importr
     KNITR = importr('knitr')


### PR DESCRIPTION
Fixes #1132.

rpy2 changed its API for 3.0, and moved `set_initoptions()` from `rpy2.rinterface` to `rpy2.rinterface_lib.embedded`. It also changed the argument from a tuple of bytes to a tuple of strings. This PR tries to run it as rpy2 v2, and if the method lookup fails, it tries the rpy2 v3 setup. I've tested this with both rpy2==3.0.2 and rpy2==2.9.5.