### PR TITLE
liquid_tags/youtube: embed linked thumbnail

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -81,6 +81,23 @@ are not specified, then the dimensions will be 640 (wide) by 390 (tall).
 If you experience issues with code generation (e.g., missing closing tags),
 add `SUMMARY_MAX_LENGTH = None` to your settings file.
 
+### Embedding just thumbnail
+
+If you do not want to add over megabyte of JS code to page you can embed linked
+thumbnail instead. To use that feature set `YOUTUBE_THUMB_ONLY` variable in your
+settings file. `YOUTUBE_THUMB_SIZE` variable controls dimensions of thumbnail
+with 4 sizes available:
+
+name  | xres | yres
+------|------|-----
+maxres| 1280 | 720
+sd    |  640 | 480
+hq    |  480 | 360
+mq    |  320 | 180
+
+Embedded thumbnails have CSS class 'youtube_video' which can be used to add
+'play' button above.
+
 ## Vimeo Tag
 To insert a Vimeo video into your content, enable the `liquid_tags.vimeo`
 plugin and add the following to your source document:

--- a/liquid_tags/test_youtube.py
+++ b/liquid_tags/test_youtube.py
@@ -1,0 +1,44 @@
+from . import youtube
+import pytest
+
+
+class configs:
+    def __init__(self):
+        self.config = {}
+
+    def setConfig(self, name, value):
+        self.config[name] = value
+
+    def getConfig(self, name):
+        try:
+            out = self.config[name]
+        except KeyError:
+            out = ''
+
+        return out
+
+
+class fake_proc:
+    def __init__(self):
+        self.configs = configs()
+
+
+@pytest.mark.parametrize('input,expected', [
+    ('v78_WujMnVk', """<a
+                    href="https://www.youtube.com/watch?v=v78_WujMnVk"
+                class="youtube_video" alt="YouTube Video"
+                title="Click to view on YouTube">
+                    <img width="1280" height="720"
+                        src="https://img.youtube.com/vi/v78_WujMnVk/maxresdefault.jpg">
+                </a>""")])
+def test_youtube(input, expected):
+    fake_preproc = fake_proc()
+
+    fake_preproc.configs.setConfig('YOUTUBE_THUMB_ONLY', True)
+    fake_preproc.configs.setConfig('YOUTUBE_THUMB_SIZE', 'maxres')
+
+    print(fake_preproc.configs.config)
+
+    out = youtube.youtube(fake_preproc, '', input)
+
+    assert out == expected

--- a/liquid_tags/youtube.py
+++ b/liquid_tags/youtube.py
@@ -17,8 +17,9 @@ Output
 
 <span class="videobox">
     <iframe
-        width="640" height="480" src="https://www.youtube.com/embed/dQw4w9WgXcQ"
-        frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen>
+        width="640" height="480"
+        src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0"
+        webkitAllowFullScreen mozallowfullscreen allowFullScreen>
     </iframe>
 </span>
 
@@ -38,6 +39,26 @@ def youtube(preprocessor, tag, markup):
     height = 390
     youtube_id = None
 
+    config_thumb_only = preprocessor.configs.getConfig('YOUTUBE_THUMB_ONLY')
+    config_thumb_size = preprocessor.configs.getConfig('YOUTUBE_THUMB_SIZE')
+
+    thumb_sizes = {
+        'maxres': [1280, 720],
+        'sd': [640, 480],
+        'hq': [480, 360],
+        'mq': [320, 180]
+    }
+
+    if config_thumb_only:
+        if not config_thumb_size:
+            config_thumb_size = 'sd'
+
+        try:
+            width = thumb_sizes[config_thumb_size][0]
+            height = thumb_sizes[config_thumb_size][1]
+        except KeyError:
+            pass
+
     match = YOUTUBE.search(markup)
     if match:
         groups = match.groups()
@@ -46,15 +67,31 @@ def youtube(preprocessor, tag, markup):
         height = groups[3] or height
 
     if youtube_id:
-        youtube_out = """
-            <span class="videobox">
-                <iframe width="{width}" height="{height}"
-                    src='https://www.youtube.com/embed/{youtube_id}'
-                    frameborder='0' webkitAllowFullScreen mozallowfullscreen
-                    allowFullScreen>
-                </iframe>
-            </span>
-        """.format(width=width, height=height, youtube_id=youtube_id).strip()
+        if config_thumb_only:
+            thumb_url = 'https://img.youtube.com/vi/{youtube_id}'.format(
+                youtube_id=youtube_id)
+
+            youtube_out = """<a
+                    href="https://www.youtube.com/watch?v={youtube_id}"
+                class="youtube_video" alt="YouTube Video"
+                title="Click to view on YouTube">
+                    <img width="{width}" height="{height}"
+                        src="{thumb_url}/{size}default.jpg">
+                </a>""".format(width=width, height=height,
+                               youtube_id=youtube_id,
+                               size=config_thumb_size,
+                               thumb_url=thumb_url)
+        else:
+            youtube_out = """
+                <span class="videobox">
+                    <iframe width="{width}" height="{height}"
+                        src='https://www.youtube.com/embed/{youtube_id}'
+                        frameborder='0' webkitAllowFullScreen
+                        mozallowfullscreen allowFullScreen>
+                    </iframe>
+                </span>
+            """.format(width=width, height=height,
+                       youtube_id=youtube_id).strip()
     else:
         raise ValueError("Error processing input, "
                          "expected syntax: {0}".format(SYNTAX))
@@ -63,5 +100,5 @@ def youtube(preprocessor, tag, markup):
 
 
 # ---------------------------------------------------
-# This import allows image tag to be a Pelican plugin
+# This import allows youtube tag to be a Pelican plugin
 from liquid_tags import register  # noqa


### PR DESCRIPTION
Adding <iframe> adds 1.2MB of javascript to webpage. And tracking
cookies.

Instead we can add thumbnail of video and link it to YouTube page. So
user can click to watch movie and is not tracked on our site.

YOUTUBE_THUMB_ONLY liquid config flag enables this mode
YOUTUBE_THUMB_SIZE allows to select one of YT thumbnails - there are
four of them defined:

- maxres: 1280x720
- sd:      640x360
- hq:      480x360
- mq:      320x180

'sd' one is used if not defined in LIQUID_CONFIGS variable.