### PR TITLE
Fix MathJax availableFonts, prefferedFont rendering issue

### DIFF
--- a/render_math/mathjax_script_template
+++ b/render_math/mathjax_script_template
@@ -33,7 +33,8 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
         "        preview: '{latex_preview}'," +
         "    }}, " +
         "    'HTML-CSS': {{ " +
-        "        fonts: [{font_list}]," +
+        "        availableFonts: {font_list}," +
+        "        preferredFont: 'STIX'," +
         "        styles: {{ '.MathJax_Display, .MathJax .mo, .MathJax .mi, .MathJax .mn': {{color: '{color} ! important'}} }}," +
         "        linebreaks: {{ automatic: "+ linebreak +", width: '90% container' }}," +
         "    }}, " +


### PR DESCRIPTION
I have opened an issue with MathJax for a rendering issue with render_math as a result of `preferredFont` and `availableFonts` not being set properly in MathJax.Hub.config["HTML-CSS"] section in `mathjax_script_template`. We were able to determine the following changes would fix the issue. Please see the below open issues.

https://github.com/mathjax/MathJax/issues/2148

https://github.com/getpelican/pelican-plugins/issues/1145