### PR TITLE
[more_categories] Fix category slug substitutions

### DIFF
--- a/more_categories/README.md
+++ b/more_categories/README.md
@@ -1,8 +1,8 @@
-#Subcategory Plugin
+# Subcategory Plugin
 This plugin adds support for multiple categories per article, and for nested
 categories. It requires Pelican 4.0.0 or newer.
 
-##Multiple categories
+## Multiple categories
 To indicate that an article belongs to multiple categories, use a
 comma-separated string:
 
@@ -10,7 +10,7 @@ comma-separated string:
 
 This will add the article to the categories `foo`, `bar` and `bazz`.
 
-###Templates
+### Templates
 Existing themes that use `article.category` will display only the first of
 these categories, `foo`. This plugin adds `article.categories` that you can
 loop over instead. To accomodate this plugin in a theme whether it is present
@@ -20,7 +20,7 @@ or not, use:
         <a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a>{{ ', ' if not loop.last }}
     {% endfor %}
 
-##Nested categories
+## Nested categories
 (This is a reimplementation of the `subcategory` plugin.)
 
 To indicate that a category is a child of another category, use a
@@ -31,7 +31,7 @@ slash-separated string:
 This will add the article to the categories `foo/bar/bazz`, `foo/bar` and
 `foo`.
 
-###Templates
+### Templates
 Existing themes that use `article.category` will display the full path to the
 most specific of these categories, `foo/bar/bazz`. For any category `cat`, this
 plugin adds `cat.shortname`, which in this case is `bazz`, `cat.parent`, which
@@ -47,13 +47,13 @@ case this plugin in present, use:
 Likewise, `category.shortname`, `category.parent` and `category.ancestors` can
 also be used on the category template.
 
-###Slug
+### Slug
 The slug of a category is generated recursively by slugifying the shortname of
 the category and its ancestors, and preserving slashes:
 
     slug-of-(foo/bar/baz) := slug-of-foo/slug-of-bar/slug-of-baz
 
-###Category folders
+### Category folders
 To specify categories using the directory structure, you can configure
 `PATH_METADATA` to extract the article path into the `category` metadata. The
 following settings would use the entire structure:
@@ -65,7 +65,7 @@ ignore for this purpose, use:
 
     PATH_METADATA = 'articles/(?P<category>.*)/.*'
 
-###Categories in templates
+### Categories in templates
 The list `categories` of all pairs of categories with their corresponding
 articles, which is available in the context and can be used in templates (e.g.
 to make a menu of available categories), is ordered lexicographically, so

--- a/more_categories/README.md
+++ b/more_categories/README.md
@@ -1,6 +1,6 @@
 #Subcategory Plugin
 This plugin adds support for multiple categories per article, and for nested
-categories. It requires Pelican 3.8 or newer.
+categories. It requires Pelican 4.0.0 or newer.
 
 ##Multiple categories
 To indicate that an article belongs to multiple categories, use a

--- a/more_categories/more_categories.py
+++ b/more_categories/more_categories.py
@@ -36,10 +36,12 @@ class Category(URLWrapper):
     @property
     def slug(self):
         if self._slug is None:
-            substitutions = self.settings.get('SLUG_SUBSTITUTIONS', ())
-            substitutions += tuple(self.settings.get('CATEGORY_SUBSTITUTIONS',
-                                                     ()))
-            self._slug = slugify(self.shortname, substitutions)
+            if 'CATEGORY_REGEX_SUBSTITUTIONS' in self.settings:
+                subs = self.settings['CATEGORY_REGEX_SUBSTITUTIONS']
+            else:
+                subs = self.settings.get('SLUG_REGEX_SUBSTITUTIONS', [])
+            self._slug = slugify(self.shortname, regex_subs=subs)
+            print(self._slug)
             if self.parent:
                 self._slug = self.parent.slug + '/' + self._slug
         return self._slug

--- a/more_categories/test_data/article_with_multiple_categories.rst
+++ b/more_categories/test_data/article_with_multiple_categories.rst
@@ -1,6 +1,6 @@
 Article with multiple and nested categories
 ===========================================
 :date: 2018-11-04
-:category: foo/bar, foo/baz
+:category: foo/bar, foo/b#az
 
 This is an article with multiple categories

--- a/more_categories/test_more_categories.py
+++ b/more_categories/test_more_categories.py
@@ -31,8 +31,15 @@ class TestArticlesGenerator(unittest.TestCase):
         including ancestor categories"""
 
         cats_generated = [cat.name for cat, _ in self.generator.categories]
-        cats_expected = ['default', 'foo', 'foo/bar', 'foo/baz',]
+        cats_expected = ['default', 'foo', 'foo/bar', 'foo/b#az',]
         self.assertEqual(sorted(cats_generated), sorted(cats_expected))
+
+    def test_categories_slug(self):
+        """Test whether category slug substitutions are used"""
+
+        slugs_generated = [cat.slug for cat, _ in self.generator.categories]
+        slugs_expected = ['default', 'foo', 'foo/bar', 'foo/baz',]
+        self.assertEqual(sorted(slugs_generated), sorted(slugs_expected))
 
     def test_assign_articles_to_categories(self):
         """Test whether articles are correctly assigned to categories,


### PR DESCRIPTION
Fixes https://github.com/getpelican/pelican/issues/2565

The slug substitution settings changed in Pelican 4, and this wasn't yet reflected in this plugin. The plugin already only worked with Pelican >= 4, so backwards compatibility is not affected.