### PR TITLE
Add Shortcodes plugin

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -248,6 +248,8 @@ Series                    Groups related articles into a series
 
 Share post                Creates share URLs of article
 
+Shortcodes                Easy and explicit inline jinja2 macros
+
 Show Source               Place a link to the source text of your posts.
 
 Similar Posts             Adds a list of similar posts to every article's context.

--- a/shortcodes/README.md
+++ b/shortcodes/README.md
@@ -1,0 +1,61 @@
+# pelican-shortcodes
+
+This plugin allows to define macros called shortcodes in content pages that will be expanded as jinja2 templates.
+
+_inspired by [lektor-shortcodes](https://github.com/skorokithakis/lektor-shortcodes)_
+
+The purpose of this plugin is to allow explicit and quick jinja2 templating in your content without compromising markdown/rst.
+
+# Example
+
+    #pelicanconf.py
+
+    SHORTCODES = {
+        'image': "<img src=/images/{{src}}>{{desc|title}}<img>"""
+    }
+
+Then in your content:
+
+    [% image src=foo.png desc="this is a test" %]
+
+will become:
+
+    <img src=/images/foo.png>This Is A Test<img>
+
+# Rules
+
+Shortcode patterns follows:
+
+    [% shortcode_name kwarg=value kwarg="value" kwarg='value' %]
+
+Shortcode pattern rules:
+
+* shortcodes must be single line
+* spaces are important, i.e. there should be space after `[%` and before `%]`
+* shortcode_name cannot contain spaces
+* kwargs are separated by a space
+* kwargs can be surrounded by quotes but not necessary
+
+# Recipes
+
+Some shortcode examples:
+
+    SHORTCODES = {
+        # image with caption
+        'image': "<img src=/images/{{src}} title={{desc}}></img><figcaption>{{desc}}</figcatpion>"
+
+        # embed looping mp4 gifs
+        'mp4gif': " <video width="480" height="240" autoplay loop muted title="{{title}}"><source src="/gifs/{{gif}}" type="video/mp4"></video>
+    }
+
+## Install
+
+    #pelicanconf.py    
+    PLUGINS = ['shortcodes']
+    SHORTCODES = {
+        # your shortcodes go here
+        # shortcode_name: jinja2 template string
+        'image': "<img src=/images/{{src}}>{{desc|title}}<img>"""
+    }
+    
+    

--- a/shortcodes/__init__.py
+++ b/shortcodes/__init__.py
@@ -1,0 +1,1 @@
+from .shortcodes import *

--- a/shortcodes/shortcodes.py
+++ b/shortcodes/shortcodes.py
@@ -1,7 +1,7 @@
 """
 shortcodes.py
 =============
-Copyright: GPLv3 <Bernardas Ališauskas @ bernardas.alisauskas@pm.me>
+Copyright: AGPLv3 <Bernardas Ališauskas @ bernardas.alisauskas@pm.me>
 
 This plugin allows to define macros called shortcodes in content pages that will be expanded as jinja2 templates.
 The purpose of this plugin is to allow explicit and quick jinja2 templating in your content without compromising markdown/rst.

--- a/shortcodes/shortcodes.py
+++ b/shortcodes/shortcodes.py
@@ -1,0 +1,35 @@
+import re
+from typing import Match, Dict
+
+from jinja2 import Template
+from pelican import signals
+from pelican.contents import Content
+
+SETTINGS_NAME = 'SHORTCODES'
+
+
+def expand_shortcodes(text: str, shortcodes: Dict[str, str]) -> str:
+    def repl(group: Match):
+        """replace shortocodes with evaluated templates"""
+        match = group.groups()[0]
+        func, args = match.split(' ', 1)
+        args = re.split('(\w+=)', args)
+        args = [a.strip("""'" """) for a in args if a]
+        kwargs = {args[i].strip('='): args[i + 1] for i in range(0, len(args), 2)}
+        try:
+            return Template(shortcodes[func]).render(**kwargs)
+        except KeyError:
+            raise KeyError('shortcode {} not found'.format(func))
+
+    return re.sub(r'\[% (.+?) %\]', repl, text)
+
+
+def content_object_init(instance: Content):
+    shortcodes = instance.settings.get(SETTINGS_NAME)
+    if not shortcodes or not instance._content:
+        return
+    instance._content = expand_shortcodes(instance._content, shortcodes)
+
+
+def register():
+    signals.content_object_init.connect(content_object_init)

--- a/shortcodes/shortcodes.py
+++ b/shortcodes/shortcodes.py
@@ -1,3 +1,27 @@
+"""
+shortcodes.py
+=============
+Copyright: GPLv3 <Bernardas Ališauskas @ bernardas.alisauskas@pm.me>
+
+This plugin allows to define macros called shortcodes in content pages that will be expanded as jinja2 templates.
+The purpose of this plugin is to allow explicit and quick jinja2 templating in your content without compromising markdown/rst.
+
+Example:
+
+    #pelicanconf.py
+
+    SHORTCODES = {
+        'image': "<img src=/images/{{src}}>{{desc|title}}<img>"
+    }
+
+Then in your content:
+
+    [% image src=foo.png desc="this is a test" %]
+
+will become:
+
+    <img src=/images/foo.png>This Is A Test<img>
+"""
 import re
 from typing import Match, Dict
 

--- a/shortcodes/test_shortcodes.py
+++ b/shortcodes/test_shortcodes.py
@@ -1,0 +1,35 @@
+import pytest
+
+from .shortcodes import expand_shortcodes
+
+
+def test_expand_shortcodes():
+    shortcode_map = {
+        'image': """<img src={{src}} title={{title}}> {{desc}}</img>"""
+    }
+    text = """
+    This is a test foo
+
+    {} 
+    
+    more text
+    """
+
+    expected = {
+        """[% image src="image_nice.png" desc='meow meow' title=woof %]""":
+            "<img src=image_nice.png title=woof> meow meow</img>",
+        """[% image src=src desc=desc title=title %]""":
+            "<img src=src title=title> desc</img>",
+        """[% image src="src " desc=" desc" title=''' title ''' %]""":
+            "<img src=src title=title> desc</img>",
+    }
+    for short_code, exp in expected.items():
+        assert expand_shortcodes(text.format(short_code), shortcode_map) == text.format(exp)
+
+    expected_errors = {
+        """[% short_code_not_there src="src " desc=" desc" title=''' title ''' %]""":
+        KeyError,
+    }
+    with pytest.raises(KeyError):
+        for short_code, exp in expected_errors.items():
+            assert expand_shortcodes(text.format(short_code), shortcode_map)


### PR DESCRIPTION
This plugin allows to define macros called shortcodes in content pages that will be expanded as jinja2 templates.
The purpose of this plugin is to allow explicit and quick jinja2 templating in your content without compromising markdown/rst.

Example:

    #pelicanconf.py

    SHORTCODES = {
        'image': "<img src=/images/{{src}}>{{desc|title}}<img>"
    }

Then in your content:

    [% image src=foo.png desc="this is a test" %]

will become:

    <img src=/images/foo.png>This Is A Test<img>