### PR TITLE
i18n_subsites: Replace JINJA_EXTENSIONS with JINJA_ENVIRONMENT in docs

### DIFF
--- a/i18n_subsites/localizing_using_jinja2.rst
+++ b/i18n_subsites/localizing_using_jinja2.rst
@@ -6,11 +6,13 @@ Localizing themes with Jinja2
 ---------------------
 
 To enable the |ext| extension in your templates, you must add it to
-``JINJA_EXTENSIONS`` in your Pelican configuration
+``JINJA_ENVIRONMENT`` in your Pelican configuration
 
 .. code-block:: python
 
-  JINJA_EXTENSIONS = ['jinja2.ext.i18n', ...]
+  JINJA_ENVIRONMENT = {
+    'extensions': ['jinja2.ext.i18n', ...]
+  }
 
 Then follow the `Jinja2 templating documentation for the I18N plugin
 <http://jinja.pocoo.org/docs/templates/#i18n>`_ to make your templates


### PR DESCRIPTION
The instructions about how to localize templates with Jinja2 are very confusing because if you follow the guide you would get the next error:

```
WARNING: JINJA_EXTENSIONS setting has been deprecated, moving it to JINJA_ENVIRONMENT setting.
CRITICAL: KeyError: 'JINJA_ENVIRONMENT'
```

For that I think it would be better to have it fixed and updated with the current system. The example codes are fine, they were replaced when it changed. If I am not wrong, it is the only file where this persists.