### PR TITLE
add amtag_cloud plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,6 @@
 [submodule "similar_posts"]
 	path = similar_posts
 	url = https://github.com/davidlesieur/similar_posts.git
+[submodule "amtag_cloud"]
+	path = amtag_cloud
+	url = https://github.com/drJabber/amtag_cloud.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -40,6 +40,8 @@ Ace Editor                Replace default **<code>** by an Ace__ code editor wit
 
 Always modified           Copy created date metadata into modified date for easy "latest updates" indexes
 
+amtag_cloud               Produces tag cloud using Amcharts framework  
+
 AsciiDoc reader           Use AsciiDoc to write your posts.
 
 Asset management          Use the Webassets module to manage assets such as CSS and JS files.


### PR DESCRIPTION
This plugin uses [Amcharts](https://www.amcharts.com/) framework to generate tag cloud.