### PR TITLE
Fix w3c_validate plugin for Python 3

### DIFF
--- a/ctags_generator/README.md
+++ b/ctags_generator/README.md
@@ -4,8 +4,7 @@ This plugin generates a `tags` file following the [CTags format](http://ctags.so
 to provide autocompletion for code editors that support it.
 
 
-Installation
-------------
+## Installation
 
 To enable, add the following to your settings.py:
 
@@ -13,3 +12,10 @@ To enable, add the following to your settings.py:
     PLUGINS = ['ctags_generator']
 
 `PLUGIN_PATH` can be a path relative to your settings file or an absolute path.
+
+
+## Tests
+
+To execute them:
+
+    nosetests -w ctags_generator

--- a/ctags_generator/ctags_generator.py
+++ b/ctags_generator/ctags_generator.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 
 from pelican import signals

--- a/ctags_generator/test_ctags_generator.py
+++ b/ctags_generator/test_ctags_generator.py
@@ -1,6 +1,5 @@
-#!/bin/sh
+# -*- coding: utf-8 -*-
 import os, shutil
-from tempfile import mkdtemp
 
 from pelican.generators import ArticlesGenerator
 from pelican.tests.support import get_settings, unittest
@@ -9,10 +8,11 @@ from pelican.writers import Writer
 from ctags_generator import generate_ctags
 
 
-TEST_CONTENT_DIR = './test_content/'
+CUR_DIR = os.path.dirname(__file__)
+TEST_CONTENT_DIR = os.path.join(CUR_DIR, 'test_content')
 
 
-class TestCtagsGenerator(unittest.TestCase):
+class CtagsGeneratorTest(unittest.TestCase):
 
     def test_generate_ctags(self):
         settings = get_settings(filenames={})
@@ -36,7 +36,3 @@ class TestCtagsGenerator(unittest.TestCase):
                 self.assertEqual(['bar', 'bar', 'foo', 'foo', 'foobar', 'foobar', 'マック', 'パイソン'], ctags)
         finally:
             os.remove(output_path)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/w3c_validate/README.md
+++ b/w3c_validate/README.md
@@ -27,7 +27,8 @@ validated.
 
 Add `w3c_validate` to your config file's plugins after installing dependencies - `PLUGINS = ['w3c_validate']`
 
-## TODO
+## Tests
 
-[ ] - add tests
+To execute them:
 
+    nosetests -w w3c_validate

--- a/w3c_validate/test_content/getpelican.html
+++ b/w3c_validate/test_content/getpelican.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+        <meta charset="utf-8">
+        <title>Pelican Static Site Generator, Powered by Python</title>
+        <link rel="stylesheet" href="/theme/css/A.main.css.pagespeed.cf.zFbdR40MwZ.css" type="text/css"/>
+        <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Pelican Development Blog Atom Feed"/>
+
+        <!--[if IE]>
+            <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+        <![endif]-->
+</head>
+
+<body id="index" class="home">
+        <header id="banner" class="body">
+                <h1><a href="/">Pelican Development Blog </a></h1>
+                <nav><ul>
+                    <li><a href="https://docs.getpelican.com">documentation</a></li>
+                    <li><a href="https://donate.getpelican.com">contribute</a></li>
+                    <li><a href="/category/news.html">news</a></li>
+                </ul></nav>
+        </header><!-- /#banner -->
+        
+<section id="content" class="body">    
+    <h1 class="entry-title">Pelican Static Site Generator, Powered by Python</h1>
+    
+    <p>Maintained by <a class="reference external" href="https://justinmayer.com/">Justin Mayer</a> (<a class="reference external" href="https://twitter.com/jmayer">&#64;jmayer</a>), Pelican is a static site generator
+that requires no database or server-side logic.</p>
+<p>Some of the features include:</p>
+<ul class="simple">
+<li>Write content in <a class="reference external" href="http://docutils.sourceforge.net/rst.html">reStructuredText</a> or <a class="reference external" href="http://daringfireball.net/projects/markdown/">Markdown</a> markup</li>
+<li>Completely static output is easy to host anywhere</li>
+<li><a class="reference external" href="https://github.com/getpelican/pelican-themes">Themes</a> that can be customized via <a class="reference external" href="http://jinja.pocoo.org/">Jinja</a> templates</li>
+<li>Publish content in multiple languages</li>
+<li>Atom/RSS feeds</li>
+<li>Code syntax highlighting</li>
+<li>Import from WordPress, RSS feeds, and other services</li>
+<li>Modular plugin system and corresponding <a class="reference external" href="https://github.com/getpelican/pelican-plugins">plugin repository</a></li>
+</ul>
+<p>… and many other features.</p>
+<div class="section" id="next-steps">
+<h2>Next Steps</h2>
+<p>Learn more about the Pelican static site generator via:</p>
+<ul class="simple">
+<li><a class="reference external" href="http://blog.getpelican.com/category/news.html">Pelican news</a></li>
+<li>the extensive <a class="reference external" href="http://docs.getpelican.com/">documentation</a></li>
+<li><a class="reference external" href="https://github.com/getpelican/pelican">source code on GitHub</a></li>
+<li><a class="reference external" href="https://twitter.com/getpelican">Pelican on Twitter</a></li>
+</ul>
+</div>
+<div class="section" id="support-pelican-development">
+<h2>Support Pelican Development</h2>
+<p>Following are ways you can support Pelican’s development:</p>
+<ul class="simple">
+<li><a class="reference external" href="https://donate.getpelican.com">donate</a> to Pelican Dev Team</li>
+<li>follow <a class="reference external" href="https://twitter.com/jmayer">&#64;jmayer</a> and <a class="reference external" href="https://twitter.com/getpelican">Pelican on Twitter</a></li>
+<li>contribute pull requests, help triage issues, and improve documentation</li>
+</ul>
+<p><a class="reference external" href="https://donate.getpelican.com"><img alt="donate-fosspay" src="https://badgen.net/badge/fosspay/donate/yellow"/></a> <a class="reference external" href="https://liberapay.com/Pelican/donate"><img alt="donate-liberapay" src="https://badgen.net/badge/liberapay/donate/yellow"/></a></p>
+</div>
+
+</section>
+        <section id="extras" class="body">
+                <div class="blogroll">
+                        <h2>links</h2>
+                        <ul>
+                            <li><a href="https://docs.getpelican.com/">Pelican Docs</a></li>
+                            <li><a href="https://donate.getpelican.com/">Support Pelican</a></li>
+                            <li><a href="https://justinmayer.com/">Justin Mayer</a></li>
+                        </ul>
+                </div><!-- /.blogroll -->
+                <div class="social">
+                        <h2>follow</h2>
+                        <ul>
+                            <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
+
+                            <li><a href="https://twitter.com/getpelican">twitter</a></li>
+                            <li><a href="https://twitter.com/jmayer">@jmayer</a></li>
+                            <li><a href="https://github.com/getpelican">github</a></li>
+                        </ul>
+                </div><!-- /.social -->
+        </section><!-- /#extras -->
+
+        <footer id="contentinfo" class="body">
+                <address id="about" class="vcard body">
+                Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
+                </address><!-- /#about -->
+
+                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+        </footer><!-- /#contentinfo -->
+
+</body>
+</html>

--- a/w3c_validate/test_wc3_validate.py
+++ b/w3c_validate/test_wc3_validate.py
@@ -1,0 +1,24 @@
+import os
+
+from pelican.tests.support import unittest
+
+from w3c_validate import validate_files
+
+
+CUR_DIR = os.path.dirname(__file__)
+TEST_CONTENT_DIR = os.path.join(CUR_DIR, 'test_content')
+
+
+class W3CValidateTest(unittest.TestCase):
+
+    def test_generate_ctags(self):
+        with self.assertLogs('w3c_validate.wc3_validate', level='INFO') as logs:
+            validate_files(PelicanMock({'OUTPUT_PATH': TEST_CONTENT_DIR}))
+
+        self.assertEqual(logs.output, ['INFO:w3c_validate.wc3_validate:Validating: {}/getpelican.html'.format(TEST_CONTENT_DIR)])
+
+
+class PelicanMock:
+    'A dummy class exposing the only attribute needed by w3c_validate.validate_files'
+    def __init__(self, settings):
+        self.settings = settings

--- a/w3c_validate/wc3_validate.py
+++ b/w3c_validate/wc3_validate.py
@@ -30,10 +30,13 @@ def validate(filename):
     Use W3C validator service: https://bitbucket.org/nmb10/py_w3c/ .
     :param filename: the filename to validate
     """
-    import HTMLParser
+    try:
+        from html.parser import HTMLParser
+    except ImportError:  # fallback for Python 2:
+        from HTMLParser import HTMLParser
     from py_w3c.validators.html.validator import HTMLValidator
 
-    h = HTMLParser.HTMLParser()  # for unescaping WC3 messages
+    h = HTMLParser()  # for unescaping WC3 messages
 
     vld = HTMLValidator()
     LOG.info("Validating: {0}".format(filename))
@@ -43,12 +46,16 @@ def validate(filename):
 
     # display errors and warning
     for err in vld.errors:
+        line = err.get('line') or err['lastLine']
+        col = err.get('col') or '{}-{}'.format(err['firstColumn'], err['lastColumn'])
         LOG.error(u'line: {0}; col: {1}; message: {2}'.
-                  format(err['line'], err['col'], h.unescape(err['message']))
+                  format(line, col, h.unescape(err['message']))
                   )
     for err in vld.warnings:
+        line = err.get('line') or err['lastLine']
+        col = err.get('col') or '{}-{}'.format(err['firstColumn'], err['lastColumn'])
         LOG.warning(u'line: {0}; col: {1}; message: {2}'.
-                    format(err['line'], err['col'], h.unescape(err['message']))
+                    format(line, col, h.unescape(err['message']))
                     )
 
 


### PR DESCRIPTION
This plugin currently does not work with Python 3

This commit fixes that while staying fully backward-compatible.
It also adds a unit test for this plugin and fixes the one for the `ctags_generator` so that it will be invoked by Travis CI