### PR TITLE
Fixing liquid_tags plugin tests

### DIFF
--- a/liquid_tags/test_audio.py
+++ b/liquid_tags/test_audio.py
@@ -1,6 +1,12 @@
-from . import audio
-import pytest
 import re
+import sys
+import unittest
+import pytest
+from . import audio
+
+
+if 'nosetests' in sys.argv[0]:
+    raise unittest.SkipTest('Those tests are pytest-compatible only')
 
 
 @pytest.mark.parametrize('input,expected', [

--- a/liquid_tags/test_flickr.py
+++ b/liquid_tags/test_flickr.py
@@ -1,12 +1,17 @@
-from . import flickr
+import os
+import re
+import sys
+import unittest
 try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
-import os
 import pytest
-import re
+from . import flickr
 
+
+if 'nosetests' in sys.argv[0]:
+    raise unittest.SkipTest('Those tests are pytest-compatible only')
 
 PLUGIN_DIR = os.path.dirname(__file__)
 TEST_DATA_DIR = os.path.join(PLUGIN_DIR, 'test_data')

--- a/liquid_tags/test_generation.py
+++ b/liquid_tags/test_generation.py
@@ -32,8 +32,8 @@ class TestFullRun(unittest.TestCase):
         rmtree(self.temp_cache)
         os.chdir(PLUGIN_DIR)
 
-    @pytest.mark.skipif(IPYTHON_VERSION >= 3,
-                        reason="output must be created with ipython version 2")
+    @unittest.skipIf(IPYTHON_VERSION != 3,
+                     reason="output must be created with ipython version 2")
     def test_generate_with_ipython3(self):
         '''Test generation of site with the plugin.'''
 
@@ -64,15 +64,14 @@ class TestFullRun(unittest.TestCase):
         #                   os.path.join(self.temp_path,
         #                                'test-ipython-notebook.html'))
 
-    @pytest.mark.skipif(IPYTHON_VERSION < 3,
-                        reason="output must be created with ipython version 3")
+    @unittest.skipIf(IPYTHON_VERSION != 2,
+                     reason="output must be created with ipython version 2")
     def test_generate_with_ipython2(self):
         '''Test generation of site with the plugin.'''
 
         base_path = os.path.dirname(os.path.abspath(__file__))
         base_path = os.path.join(base_path, 'test_data')
         content_path = os.path.join(base_path, 'content')
-        output_path = os.path.join(base_path, 'output')
         settings_path = os.path.join(base_path, 'pelicanconf.py')
         settings = read_settings(path=settings_path,
                                  override={'PATH': content_path,

--- a/liquid_tags/test_giphy.py
+++ b/liquid_tags/test_giphy.py
@@ -1,11 +1,16 @@
-from . import giphy
+import os
+import sys
+import unittest
 try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
-import os
 import pytest
+from . import giphy
 
+
+if 'nosetests' in sys.argv[0]:
+    raise unittest.SkipTest('Those tests are pytest-compatible only')
 
 PLUGIN_DIR = os.path.dirname(__file__)
 TEST_DATA_DIR = os.path.join(PLUGIN_DIR, 'test_data')

--- a/liquid_tags/test_notebook.py
+++ b/liquid_tags/test_notebook.py
@@ -1,4 +1,9 @@
 import re
+import sys
+import unittest
+
+if 'nosetests' in sys.argv[0]:
+    raise unittest.SkipTest('Those tests are pytest-compatible only')
 
 import pytest
 pytest.skip("Test is currently broken, see pelican pr #1618", allow_module_level=True)

--- a/liquid_tags/test_soundcloud.py
+++ b/liquid_tags/test_soundcloud.py
@@ -1,6 +1,10 @@
-from . import soundcloud
+import unittest
+import sys
 import pytest
+from . import soundcloud
 
+if 'nosetests' in sys.argv[0]:
+    raise unittest.SkipTest('Those tests are pytest-compatible only')
 
 @pytest.mark.parametrize('input,expected', [
     ('https://soundcloud.com/forss/in-paradisum',


### PR DESCRIPTION
Tested with:
```
$ nosetests --with-summary-report --summary-report-on=module-path liquid_tags
...
Summary:
             module-path | success
   ----------------------------------
liquid_tags.test_generic |       1
----------------------------------------------------------------------
Ran 8 tests in 1.740s

OK (SKIP=7)

$ pytest liquid_tags
============================================== 28 passed, 3 skipped, 8 warnings in 4.33s ==============================================
```