### PR TITLE
[neighbors] Fix iter3() error on Python 3.7 and pass flake8

### DIFF
--- a/neighbors/neighbors.py
+++ b/neighbors/neighbors.py
@@ -8,14 +8,19 @@ variables to the article's context
 """
 from pelican import signals
 
+
 def iter3(seq):
-    it = iter(seq)
-    nxt = None
-    cur = next(it)
-    for prv in it:
-        yield nxt, cur, prv
+    """Generate one triplet per element in 'seq' following PEP-479."""
+    nxt, cur = None, None
+    for prv in seq:
+        if cur:
+            yield nxt, cur, prv
         nxt, cur = cur, prv
-    yield nxt, cur, None
+    # Don't yield anything if empty seq
+    if cur:
+        # Yield last element in seq (also if len(seq) == 1)
+        yield nxt, cur, None
+
 
 def get_translation(article, prefered_language):
     if not article:
@@ -25,6 +30,7 @@ def get_translation(article, prefered_language):
             return translation
     return article
 
+
 def set_neighbors(articles, next_name, prev_name):
     for nxt, cur, prv in iter3(articles):
         exec("cur.{} = nxt".format(next_name))
@@ -32,27 +38,29 @@ def set_neighbors(articles, next_name, prev_name):
 
         for translation in cur.translations:
             exec(
-            "translation.{} = get_translation(nxt, translation.lang)".format(
-                next_name))
+                "translation.{} = get_translation(nxt, translation.lang)"
+                .format(next_name))
             exec(
-            "translation.{} = get_translation(prv, translation.lang)".format(
-                prev_name))
+                "translation.{} = get_translation(prv, translation.lang)"
+                .format(prev_name))
+
 
 def neighbors(generator):
     set_neighbors(generator.articles, 'next_article', 'prev_article')
 
     for category, articles in generator.categories:
-        articles.sort(key=(lambda x: x.date), reverse=(True))
+        articles.sort(key=lambda x: x.date, reverse=True)
         set_neighbors(
             articles, 'next_article_in_category', 'prev_article_in_category')
 
     if hasattr(generator, 'subcategories'):
         for subcategory, articles in generator.subcategories:
-            articles.sort(key=(lambda x: x.date), reverse=(True))
+            articles.sort(key=lambda x: x.date, reverse=True)
             index = subcategory.name.count('/')
             next_name = 'next_article_in_subcategory{}'.format(index)
             prev_name = 'prev_article_in_subcategory{}'.format(index)
             set_neighbors(articles, next_name, prev_name)
+
 
 def register():
     signals.article_generator_finalized.connect(neighbors)


### PR DESCRIPTION
Fixes #1160 

Tested with tests in #1184 which reproduced the bug.

**Problem description**: Relying on `StopIteration` exceptions bubbling out of generator functions is incorrect since Python 3.7, because these are transformed into `RuntimeError` exceptions. [More info on PEP 479](https://www.python.org/dev/peps/pep-0479/#explanation-of-generators-iterators-and-stopiteration).