### PR TITLE
Add :hideall: tag for liquid_tags.include_code plugin

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -151,7 +151,8 @@ If using `:hidefilename:`, a title must be provided as indicated above.
 This example will show the first ten lines of the file while hiding the actual
 filename.
 
-If you would like to hide both title and Download link use `:hideall:`.
+You can also hide download link and leave only filename with `:hidelink:`. If
+you would like to hide both title and Download link use `:hideall:`.
 
 The script must be in the `code` subdirectory of your content folder;
 the default location can be changed by specifying the directory in your

--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -151,6 +151,8 @@ If using `:hidefilename:`, a title must be provided as indicated above.
 This example will show the first ten lines of the file while hiding the actual
 filename.
 
+If you would like to hide both title and Download link use `:hideall:`.
+
 The script must be in the `code` subdirectory of your content folder;
 the default location can be changed by specifying the directory in your
 settings file thusly:

--- a/liquid_tags/content/test_data/main.c
+++ b/liquid_tags/content/test_data/main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(int argc, char** argv){
+    printf("Hello world!");
+
+    return 0;
+}

--- a/liquid_tags/content/test_data/main_cz.c
+++ b/liquid_tags/content/test_data/main_cz.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(int argc, char** argv){
+    printf("Dobrý");
+
+    return 0;
+}

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -95,7 +95,10 @@ def include_code(preprocessor, tag, markup):
     if not os.path.exists(code_path):
         raise ValueError("File {0} could not be found".format(code_path))
 
-    with open(code_path) as fh:
+    if not codec:
+        codec = 'utf-8'
+
+    with open(code_path, encoding=codec) as fh:
         if lines:
             code = fh.readlines()[first_line - 1: last_line]
             code[-1] = code[-1].rstrip()

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -53,10 +53,12 @@ FORMAT = re.compile(r"""
 (?:(?:lines:)(?P<lines>\d+-\d+))?  # Optional lines
 (?:\s+)?                           # Whitespace
 (?P<hidefilename>:hidefilename:)?  # Hidefilename flag
+(?:\s+)?                           # Whitespace
 (?P<hidelink>:hidelink:)?          # Hide download link
+(?:\s+)?                           # Whitespace
 (?P<hideall>:hideall:)?            # Hide title and download link
 (?:\s+)?                           # Whitespace
-(?:(?:codec:)(?P<codec>\S+))?        # Optional language
+(?:(?:codec:)(?P<codec>\S+))?      # Optional language
 (?:\s+)?                           # Whitespace
 (?P<title>.+)?$                    # Optional title
 """, re.VERBOSE)

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -108,10 +108,9 @@ def include_code(preprocessor, tag, markup):
     open_tag = ''
     close_tag = ''
 
+    open_tag = "<figure class='code'>\n<figcaption>"
+    close_tag = "</figure>"
     if not hide_all:
-        open_tag = "<figure class='code'>\n<figcaption>"
-        close_tag = "</figure>"
-
         if not hide_filename:
             title += " %s" % os.path.basename(src)
             if lines:

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -54,7 +54,7 @@ FORMAT = re.compile(r"""
 (?:\s+)?                           # Whitespace
 (?P<hidefilename>:hidefilename:)?  # Hidefilename flag
 (?P<hidelink>:hidelink:)?          # Hide download link
-(?P<hideall>:hideall:)?            # Hide title and download button
+(?P<hideall>:hideall:)?            # Hide title and download link
 (?:\s+)?                           # Whitespace
 (?:(?:codec:)(?P<codec>\S+))?        # Optional language
 (?:\s+)?                           # Whitespace
@@ -76,9 +76,9 @@ def include_code(preprocessor, tag, markup):
         lang = argdict['lang']
         codec = argdict['codec'] or "utf8"
         lines = argdict['lines']
-        hideall = bool(argdict['hideall'])
-        hide_link = bool(argdict['hidelink'])
         hide_filename = bool(argdict['hidefilename'])
+        hide_link = bool(argdict['hidelink'])
+        hide_all = bool(argdict['hideall'])
         if lines:
             first_line, last_line = map(int, lines.split("-"))
         src = argdict['src']
@@ -101,29 +101,29 @@ def include_code(preprocessor, tag, markup):
         else:
             code = fh.read()
 
-    if (not title and hide_filename) and not hideall:
+    if (not title and hide_filename) and not hide_all:
         raise ValueError("Either title must be specified or filename must "
                          "be available")
 
-    if not hideall:
+    open_tag = ''
+    close_tag = ''
+
+    if not hide_all:
+        open_tag = "<figure class='code'>\n<figcaption>"
+        close_tag = "</figure>"
+
         if not hide_filename:
             title += " %s" % os.path.basename(src)
-        if lines:
-            title += " [Lines %s]" % lines
-        title = title.strip()
+            if lines:
+                title += " [Lines %s]" % lines
+            title = title.strip()
 
-        open_tag = "<figure class='code'>\n<figcaption><span>{title}</span> ".format(
-                title=title)
+            open_tag += "<span>{title}</span> ".format(title=title)
 
         if not hide_link:
             url = '/{0}/{1}'.format(code_dir, src)
             url = re.sub('/+', '/', url)
-            open_tag += "<a href='{url}'>download</a>".format(title=title, url=url))
-
-        close_tag = "</figcaption></figure>"
-    else:
-        open_tag = ''
-        close_tag = ''
+            open_tag += "<a href='{url}'>download</a>".format(url=url))
 
     # store HTML tags in the stash.  This prevents them from being
     # modified by markdown.

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -43,7 +43,8 @@ import sys
 from .mdx_liquid_tags import LiquidTags
 
 
-SYNTAX = "{% include_code /path/to/code.py [lang:python] [lines:X-Y] [:hidefilename:] [:hidelink:] [:hideall:] [title] %}"
+SYNTAX = "{% include_code /path/to/code.py [lang:python] [lines:X-Y] "\
+         "[:hidefilename:] [:hidelink:] [:hideall:] [title] %}"
 FORMAT = re.compile(r"""
 ^(?:\s+)?                          # Allow whitespace at beginning
 (?P<src>\S+)                       # Find the path

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -43,7 +43,7 @@ import sys
 from .mdx_liquid_tags import LiquidTags
 
 
-SYNTAX = "{% include_code /path/to/code.py [lang:python] [lines:X-Y] [:hidefilename:] [title] %}"
+SYNTAX = "{% include_code /path/to/code.py [lang:python] [lines:X-Y] [:hidefilename:] [:hidelink:] [:hideall:] [title] %}"
 FORMAT = re.compile(r"""
 ^(?:\s+)?                          # Allow whitespace at beginning
 (?P<src>\S+)                       # Find the path

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -123,7 +123,7 @@ def include_code(preprocessor, tag, markup):
         if not hide_link:
             url = '/{0}/{1}'.format(code_dir, src)
             url = re.sub('/+', '/', url)
-            open_tag += "<a href='{url}'>download</a>".format(url=url))
+            open_tag += "<a href='{url}'>download</a>".format(url=url)
 
     # store HTML tags in the stash.  This prevents them from being
     # modified by markdown.

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -53,6 +53,7 @@ FORMAT = re.compile(r"""
 (?:(?:lines:)(?P<lines>\d+-\d+))?  # Optional lines
 (?:\s+)?                           # Whitespace
 (?P<hidefilename>:hidefilename:)?  # Hidefilename flag
+(?P<hidelink>:hidelink:)?          # Hide download link
 (?P<hideall>:hideall:)?            # Hide title and download button
 (?:\s+)?                           # Whitespace
 (?:(?:codec:)(?P<codec>\S+))?        # Optional language
@@ -76,6 +77,7 @@ def include_code(preprocessor, tag, markup):
         codec = argdict['codec'] or "utf8"
         lines = argdict['lines']
         hideall = bool(argdict['hideall'])
+        hide_link = bool(argdict['hidelink'])
         hide_filename = bool(argdict['hidefilename'])
         if lines:
             first_line, last_line = map(int, lines.split("-"))
@@ -110,13 +112,15 @@ def include_code(preprocessor, tag, markup):
             title += " [Lines %s]" % lines
         title = title.strip()
 
-        url = '/{0}/{1}'.format(code_dir, src)
-        url = re.sub('/+', '/', url)
+        open_tag = "<figure class='code'>\n<figcaption><span>{title}</span> ".format(
+                title=title)
 
-        open_tag = ("<figure class='code'>\n<figcaption><span>{title}</span> "
-                    "<a href='{url}'>download</a></figcaption>".format(title=title,
-                                                                       url=url))
-        close_tag = "</figure>"
+        if not hide_link:
+            url = '/{0}/{1}'.format(code_dir, src)
+            url = re.sub('/+', '/', url)
+            open_tag += "<a href='{url}'>download</a>".format(title=title, url=url))
+
+        close_tag = "</figcaption></figure>"
     else:
         open_tag = ''
         close_tag = ''

--- a/liquid_tags/test_include_code.py
+++ b/liquid_tags/test_include_code.py
@@ -1,0 +1,247 @@
+import re
+import sys
+import unittest
+
+import pytest
+
+from . import include_code
+
+if 'nosetests' in sys.argv[0]:
+    raise unittest.SkipTest('Those tests are pytest-compatible only')
+
+@pytest.mark.parametrize(
+        'input,expected', [
+            (
+                'test_data/main.c',
+                ('test_data/main.c', None, None, None, None, None, None, None)
+            ),
+            (
+                'test_data/main.c lang:c',
+                ('test_data/main.c', 'c', None, None, None, None, None, None)
+            ),
+            (
+                'test_data/main.c lang:c lines:1-10',
+                ('test_data/main.c', 'c', '1-10', None, None, None, None, None)
+            ),
+            (
+                'test_data/main.c lang:c lines:1-10 :hidefilename:',
+                ('test_data/main.c', 'c', '1-10', ':hidefilename:', None, None,
+                 None, None)
+            ),
+            (
+                'test_data/main.c lang:c lines:1-10 :hidefilename: :hidelink:',
+                ('test_data/main.c', 'c', '1-10', ':hidefilename:', ':hidelink:',
+                 None, None, None)
+            ),
+            (
+                'test_data/main.c lang:c lines:1-10 :hidefilename: :hidelink: '\
+                ':hideall:',
+                ('test_data/main.c', 'c', '1-10', ':hidefilename:', ':hidelink:',
+                 ":hideall:", None, None)
+            ),
+            (
+                'test_data/main.c lang:c lines:1-10 :hidefilename: :hidelink: '\
+                ':hideall: codec:iso-8859-1',
+                ('test_data/main.c', 'c', '1-10', ':hidefilename:', ':hidelink:',
+                 ':hideall:', 'iso-8859-1', None)
+            ),
+            (
+                'test_data/main.c lang:c lines:1-10 :hidefilename: :hidelink: '\
+                ':hideall: codec:iso-8859-1 Hello It\'s me - Title',
+                ('test_data/main.c', 'c', '1-10', ':hidefilename:', ':hidelink:',
+                 ':hideall:', 'iso-8859-1', 'Hello It\'s me - Title')
+            ),
+        ]
+)
+def test_regex(input, expected):
+    print(re.match(include_code.FORMAT, input).groups())
+    assert re.match(include_code.FORMAT, input).groups() == expected
+
+class Object:
+    pass
+
+class preprocessor:
+    @classmethod
+    def func(*x, safe=False):
+        return ''.join([str(s) for s in x])
+
+    def __init__(self):
+        self.configs = Object()
+        self.configs.getConfig = lambda x: ''
+        self.configs.htmlStash = Object()
+        self.configs.htmlStash.store = self.func
+
+@pytest.mark.parametrize(
+        'input, expected', [
+            (
+                'test_data/main.c',
+                (
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '<figure class=\'code\'>\n<figcaption>'
+                    '<span>main.c</span> '
+                    '<a href=\'/test_data/main.c\'>download</a>'
+                    '\n'
+                    '\n'
+                    '    #include <stdio.h>\n'
+                    '    \n'
+                    '    int main(int argc, char** argv){\n'
+                    '        printf("Hello world!");\n'
+                    '    \n'
+                    '        return 0;\n'
+                    '    }\n'
+                    '    \n'
+                    '\n'
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '</figure>\n'
+                )
+            ),
+            (
+                'test_data/main.c :hideall:',
+                (
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '<figure class=\'code\'>\n<figcaption>'
+                    '\n'
+                    '\n'
+                    '    #include <stdio.h>\n'
+                    '    \n'
+                    '    int main(int argc, char** argv){\n'
+                    '        printf("Hello world!");\n'
+                    '    \n'
+                    '        return 0;\n'
+                    '    }\n'
+                    '    \n'
+                    '\n'
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '</figure>\n'
+                )
+            ),
+            (
+                'test_data/main.c :hidefilename: C application',
+                (
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '<figure class=\'code\'>\n<figcaption>'
+                    '<a href=\'/test_data/main.c\'>download</a>'
+                    '\n'
+                    '\n'
+                    '    #include <stdio.h>\n'
+                    '    \n'
+                    '    int main(int argc, char** argv){\n'
+                    '        printf("Hello world!");\n'
+                    '    \n'
+                    '        return 0;\n'
+                    '    }\n'
+                    '    \n'
+                    '\n'
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '</figure>\n'
+                )
+            ),
+            (
+                'test_data/main.c :hidelink:',
+                (
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '<figure class=\'code\'>\n<figcaption>'
+                    '<span>main.c</span> '
+                    '\n'
+                    '\n'
+                    '    #include <stdio.h>\n'
+                    '    \n'
+                    '    int main(int argc, char** argv){\n'
+                    '        printf("Hello world!");\n'
+                    '    \n'
+                    '        return 0;\n'
+                    '    }\n'
+                    '    \n'
+                    '\n'
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '</figure>\n'
+                )
+            ),
+            (
+                'test_data/main.c lang:c',
+                (
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '<figure class=\'code\'>\n<figcaption>'
+                    '<span>main.c</span> '
+                    '<a href=\'/test_data/main.c\'>download</a>'
+                    '\n'
+                    '\n'
+                    '    :::c\n'
+                    '    #include <stdio.h>\n'
+                    '    \n'
+                    '    int main(int argc, char** argv){\n'
+                    '        printf("Hello world!");\n'
+                    '    \n'
+                    '        return 0;\n'
+                    '    }\n'
+                    '    \n'
+                    '\n'
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '</figure>\n'
+                )
+            ),
+            (
+                'test_data/main.c lines:4-6',
+                (
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '<figure class=\'code\'>\n<figcaption>'
+                    '<span>main.c [Lines 4-6]</span> '
+                    '<a href=\'/test_data/main.c\'>download</a>'
+                    '\n'
+                    '\n'
+                    '        printf("Hello world!");\n'
+                    '    \n'
+                    '        return 0;\n'
+                    '\n'
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '</figure>\n'
+                )
+            ),
+            (
+                'test_data/main_cz.c codec:iso-8859-1',
+                (
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '<figure class=\'code\'>\n<figcaption>'
+                    '<span>main_cz.c</span> '
+                    '<a href=\'/test_data/main_cz.c\'>download</a>'
+                    '\n'
+                    '\n'
+                    '    #include <stdio.h>\n'
+                    '    \n'
+                    '    int main(int argc, char** argv){\n'
+                    '        printf("Dobrý");\n'
+                    '    \n'
+                    '        return 0;\n'
+                    '    }\n'
+                    '    \n'
+                    '\n'
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '</figure>\n'
+                )
+            ),
+            (
+                'test_data/main.c C Application',
+                (
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '<figure class=\'code\'>\n<figcaption>'
+                    '<span>C Application main.c</span> '
+                    '<a href=\'/test_data/main.c\'>download</a>'
+                    '\n'
+                    '\n'
+                    '    #include <stdio.h>\n'
+                    '    \n'
+                    '    int main(int argc, char** argv){\n'
+                    '        printf("Hello world!");\n'
+                    '    \n'
+                    '        return 0;\n'
+                    '    }\n'
+                    '    \n'
+                    '\n'
+                    '<class \'liquid_tags.test_include_code.preprocessor\'>'
+                    '</figure>\n'
+                )
+            ),
+        ]
+)
+def test_create_html(input, expected):
+    assert include_code.include_code(preprocessor(), 'include_code', input) == expected


### PR DESCRIPTION
There is possibility to hide filename but there is no possibility to hide all elements (title + download link)
The following code:
```
{% include_code buffering/cat1.c lang:c :hideall: %}
```
Will produce something like this:
![image](https://user-images.githubusercontent.com/8555162/64723267-80297f00-d4d0-11e9-8140-1e9c1e61ed21.png)