### PR TITLE
Fix TypeError in tests: expected str, bytes or os.PathLike object, not NoneType

### DIFF
--- a/ctags_generator/test_ctags_generator.py
+++ b/ctags_generator/test_ctags_generator.py
@@ -18,12 +18,15 @@ class CtagsGeneratorTest(unittest.TestCase):
         settings = get_settings(filenames={})
         settings['GENERATE_CTAGS'] = True
 
+        context = settings.copy()
+        context['generated_content'] = dict()
+        context['static_links'] = set()
         generator = ArticlesGenerator(
-            context=settings.copy(), settings=settings,
-            path=TEST_CONTENT_DIR, theme=settings['THEME'], output_path=None)
+            context=context, settings=settings,
+            path=TEST_CONTENT_DIR, theme=settings['THEME'], output_path=TEST_CONTENT_DIR)
         generator.generate_context()
 
-        writer = Writer(None, settings=settings)
+        writer = Writer(TEST_CONTENT_DIR, settings=settings)
         generate_ctags(generator, writer)
 
         output_path = os.path.join(TEST_CONTENT_DIR, 'tags')

--- a/more_categories/test_more_categories.py
+++ b/more_categories/test_more_categories.py
@@ -2,6 +2,8 @@
 
 import os
 import unittest
+from shutil import rmtree
+from tempfile import mkdtemp
 
 from . import more_categories
 from pelican.generators import ArticlesGenerator
@@ -12,6 +14,7 @@ class TestArticlesGenerator(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.temp_path = mkdtemp(prefix='pelicantests.')
         more_categories.register()
         settings = get_settings()
         settings['DEFAULT_CATEGORY'] = 'default'
@@ -23,8 +26,12 @@ class TestArticlesGenerator(unittest.TestCase):
         test_data_path = os.path.join(base_path, 'test_data')
         cls.generator = ArticlesGenerator(
             context=context, settings=settings,
-            path=test_data_path, theme=settings['THEME'], output_path=None)
+            path=test_data_path, theme=settings['THEME'], output_path=cls.temp_path)
         cls.generator.generate_context()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.temp_path)
 
     def test_generate_categories(self):
         """Test whether multiple categories are generated correctly,

--- a/neighbors/test_neighbors.py
+++ b/neighbors/test_neighbors.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from os.path import dirname, join
+from tempfile import TemporaryDirectory
 
 from pelican.generators import ArticlesGenerator
 from pelican.tests.support import get_settings, unittest
@@ -12,14 +13,16 @@ CUR_DIR = dirname(__file__)
 
 class NeighborsTest(unittest.TestCase):
     def test_neighbors_basic(self):
-        generator = _build_article_generator(join(CUR_DIR, '..', 'test_data'))
-        neighbors(generator)
+        with TemporaryDirectory() as tmpdirname:
+            generator = _build_article_generator(join(CUR_DIR, '..', 'test_data'), tmpdirname)
+            neighbors(generator)
     def test_neighbors_with_single_article(self):
-        generator = _build_article_generator(join(CUR_DIR, 'test_data'))
-        neighbors(generator)
+        with TemporaryDirectory() as tmpdirname:
+            generator = _build_article_generator(join(CUR_DIR, 'test_data'), tmpdirname)
+            neighbors(generator)
 
 
-def _build_article_generator(content_path):
+def _build_article_generator(content_path, output_path):
     settings = get_settings(filenames={})
     settings['PATH'] = content_path
     context = settings.copy()
@@ -27,6 +30,6 @@ def _build_article_generator(content_path):
     context['static_links'] = set()
     article_generator = ArticlesGenerator(
         context=context, settings=settings,
-        path=settings['PATH'], theme=settings['THEME'], output_path=None)
+        path=settings['PATH'], theme=settings['THEME'], output_path=output_path)
     article_generator.generate_context()
     return article_generator

--- a/render_math/test_render_math.py
+++ b/render_math/test_render_math.py
@@ -19,8 +19,9 @@ class RenderMathTest(unittest.TestCase):
         settings = get_settings(filenames={})
         settings['PATH'] = join(CUR_DIR, '..', 'test_data')
         pelican_init(PelicanMock(settings))
-        generator = _build_article_generator(settings)
-        process_rst_and_summaries([generator])
+        with TemporaryDirectory() as tmpdirname:
+            generator = _build_article_generator(settings, tmpdirname)
+            process_rst_and_summaries([generator])
     def test_ok_on_custom_data(self):
         settings = get_settings(filenames={})
         settings['PATH'] = join(CUR_DIR, 'test_data')
@@ -29,22 +30,22 @@ class RenderMathTest(unittest.TestCase):
         pelican_mock = PelicanMock(settings)
         pelican_init(pelican_mock)
         Pelican.init_plugins(pelican_mock)
-        generator = _build_article_generator(settings)
-        process_rst_and_summaries([generator])
-        for article in generator.articles:
-            if article.source_path.endswith('.rst'):
-                self.assertIn('mathjaxscript_pelican', article.content)
         with TemporaryDirectory() as tmpdirname:
+            generator = _build_article_generator(settings, tmpdirname)
+            process_rst_and_summaries([generator])
+            for article in generator.articles:
+                if article.source_path.endswith('.rst'):
+                    self.assertIn('mathjaxscript_pelican', article.content)
             generator.generate_output(Writer(tmpdirname, settings=settings))
 
 
-def _build_article_generator(settings):
+def _build_article_generator(settings, output_path):
     context = settings.copy()
     context['generated_content'] = dict()
     context['static_links'] = set()
     article_generator = ArticlesGenerator(
         context=context, settings=settings,
-        path=settings['PATH'], theme=settings['THEME'], output_path=None)
+        path=settings['PATH'], theme=settings['THEME'], output_path=output_path)
     article_generator.generate_context()
     return article_generator
 

--- a/shaarli_poster/shaarli_poster.py
+++ b/shaarli_poster/shaarli_poster.py
@@ -98,13 +98,13 @@ def main():
             })
     print(json.dumps(links, indent=4, sort_keys=True))
 
-def build_article_generator(settings, content_path):
+def build_article_generator(settings, content_path, output_path=None):
     context = settings.copy()
     context['generated_content'] = dict()
     context['static_links'] = set()
     article_generator = ArticlesGenerator(
         context=context, settings=settings,
-        path=content_path, theme=settings['THEME'], output_path=None)
+        path=content_path, theme=settings['THEME'], output_path=output_path)
     article_generator.generate_context()
     return article_generator
 

--- a/shaarli_poster/test_shaarli_poster.py
+++ b/shaarli_poster/test_shaarli_poster.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os, shutil
+from tempfile import TemporaryDirectory
 from unittest.mock import patch, Mock
 
 from pelican.tests.support import get_settings, unittest
@@ -20,8 +21,9 @@ class ShaarliPosterTest(unittest.TestCase):
             ResponseMock([{'url': '/other-dummy-article.html'}]),  # get-links
             ResponseMock()  # post-link
         ]
-        upload_new_articles([build_article_generator(get_settings(filenames={}), TEST_CONTENT_DIR)])
-        self.assertEqual(ShaarliClientClassMock.return_value.request.call_count, 2)  # 1 get-links + 1 post-link
+        with TemporaryDirectory() as tmpdirname:
+            upload_new_articles([build_article_generator(get_settings(filenames={}), TEST_CONTENT_DIR, tmpdirname)])
+            self.assertEqual(ShaarliClientClassMock.return_value.request.call_count, 2)  # 1 get-links + 1 post-link
 
 class ResponseMock:
     def __init__(self, json=None):

--- a/sub_parts/test_sub_parts.py
+++ b/sub_parts/test_sub_parts.py
@@ -2,6 +2,8 @@
 from __future__ import unicode_literals
 
 import os
+from shutil import rmtree
+from tempfile import mkdtemp
 
 from pelican.generators import ArticlesGenerator
 from pelican.tests.support import unittest, get_settings
@@ -14,6 +16,7 @@ class TestSubParts(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.temp_path = mkdtemp(prefix='pelicantests.')
         settings = get_settings(filenames={})
         settings['PATH'] = os.path.join(CUR_DIR, 'test_data')
         settings['AUTHOR'] = 'Me'
@@ -27,10 +30,14 @@ class TestSubParts(unittest.TestCase):
         context['static_links'] = set()
         cls.generator = ArticlesGenerator(
             context=context, settings=settings,
-            path=settings['PATH'], theme=settings['THEME'], output_path=None)
+            path=settings['PATH'], theme=settings['THEME'], output_path=cls.temp_path)
         cls.generator.generate_context()
         cls.all_articles = list(cls.generator.articles)
         sub_parts.patch_subparts(cls.generator)
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.temp_path)
 
     def test_all_articles(self):
         self.assertEqual(
@@ -93,6 +100,7 @@ class TestSubPartsPhotos(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.temp_path = mkdtemp(prefix='pelicantests.')
         settings = get_settings(filenames={})
         settings['PATH'] = os.path.join(CUR_DIR, 'test_data')
         settings['AUTHOR'] = 'Me'
@@ -106,12 +114,16 @@ class TestSubPartsPhotos(unittest.TestCase):
         context['static_links'] = set()
         cls.generator = ArticlesGenerator(
             context=context, settings=settings,
-            path=settings['PATH'], theme=settings['THEME'], output_path=None)
+            path=settings['PATH'], theme=settings['THEME'], output_path=cls.temp_path)
         cls.generator.generate_context()
         cls.all_articles = list(cls.generator.articles)
         for a in cls.all_articles:
             a.photo_gallery = [('i.jpg', 'i.jpg', 'it.jpg', '', '')]
         sub_parts.patch_subparts(cls.generator)
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.temp_path)
 
     def test_subphotos(self):
         for a in self.all_articles:

--- a/tag_cloud/test_tag_cloud.py
+++ b/tag_cloud/test_tag_cloud.py
@@ -2,6 +2,8 @@ import unittest
 import os
 import six
 import tag_cloud
+from shutil import rmtree
+from tempfile import mkdtemp
 
 from pelican.generators import ArticlesGenerator
 from pelican.tests.support import get_settings
@@ -15,6 +17,8 @@ class TestTagCloudGeneration(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.temp_path = mkdtemp(prefix='pelicantests.')
+
         cls._settings = get_settings(filenames={})
         cls._settings['DEFAULT_CATEGORY'] = 'Default'
         cls._settings['DEFAULT_DATE'] = (1970, 1, 1)
@@ -27,8 +31,12 @@ class TestTagCloudGeneration(unittest.TestCase):
         context['static_links'] = set()
         cls.generator = ArticlesGenerator(
             context=context, settings=cls._settings,
-            path=CONTENT_DIR, theme=cls._settings['THEME'], output_path=None)
+            path=CONTENT_DIR, theme=cls._settings['THEME'], output_path=cls.temp_path)
         cls.generator.generate_context()
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.temp_path)
 
     def test_tag_cloud_random(self):
         self.generator.settings['TAG_CLOUD_STEPS'] = 10


### PR DESCRIPTION
Tested with:
```
nosetests ctags_generator
nosetests more_categories
nosetests neighbors
nosetests render_math
nosetests shaarli_poster
nosetests sub_parts
nosetests tag_cloud
```