### PR TITLE
Fix photos plugin tests by excluding pandoc_reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
 # We need to exclude the multimarkdown_reader plugin,
 # otherwise its MmdReader class will be loaded by pelican.readers.Readers,
 # and override the default .md one:
-script: nosetests --exclude-dir=multimarkdown_reader --with-summary-report
+script: nosetests --exclude-dir=multimarkdown_reader --exclude-dir=pandoc_reader --with-summary-report


### PR DESCRIPTION
This plugin reader caused urlescaping of curly braces,
which broke tests "test_filename_article_body" & "test_photo_article_body"