### PR TITLE
Summary: Replace regex tag stripping with BeautifulSoup parsing

### DIFF
--- a/summary/Readme.rst
+++ b/summary/Readme.rst
@@ -1,3 +1,10 @@
+Requirements
+------------
+
+This plugin requires beautifulsoup4 to ensure correctness of the extracted markup::
+
+    pip install pillow beautifulsoup4
+
 Summary
 -------
 

--- a/summary/Readme.rst
+++ b/summary/Readme.rst
@@ -3,7 +3,7 @@ Requirements
 
 This plugin requires beautifulsoup4 to ensure correctness of the extracted markup::
 
-    pip install pillow beautifulsoup4
+    pip install beautifulsoup4
 
 Summary
 -------

--- a/summary/requirements.txt
+++ b/summary/requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -7,6 +7,7 @@ body of your articles.
 """
 
 from __future__ import unicode_literals
+from bs4 import BeautifulSoup
 from pelican import signals
 from pelican.generators import ArticlesGenerator, StaticGenerator, PagesGenerator
 import re
@@ -77,8 +78,7 @@ def extract_summary(instance):
         if end_summary:
             content = content.replace(end_marker, '', 1)
 
-    summary = re.sub(r"<div.*>", "", summary)
-    summary = re.sub(r"</div>", "", summary)
+    summary = str(BeautifulSoup(summary, 'html.parser'))
 
     instance._content = content
     # default_status was added to Pelican Content objects after 3.7.1.

--- a/summary/test_summary.py
+++ b/summary/test_summary.py
@@ -91,6 +91,20 @@ class TestSummary(unittest.TestCase):
         self.assertEqual(page.summary, TEST_SUMMARY)
         self.assertEqual(page.content, '<p>' + TEST_SUMMARY + '</p>' + TEST_CONTENT)
 
+    def test_correct_malformed_markup(self):
+        page_kwargs = self._copy_page_kwargs()
+        del page_kwargs['metadata']['summary']
+        malformed = '<article><div><h2>Title</h2><p>Some content</article>'
+        wellformed = (
+            '<article><div><h2>Title</h2>'
+            '<p>Some content</p></div></article>')
+        page_kwargs['content'] = (
+            '<!-- PELICAN_BEGIN_SUMMARY -->' + malformed +
+            '<!-- PELICAN_END_SUMMARY -->')
+        page = Page(**page_kwargs)
+        summary.extract_summary(page)
+        self.assertEqual(page.summary, wellformed)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This resolves #1203, ensuring well-formed markup (the intent of #758).