### PR TITLE
add setup config to install via pip and pipenv

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -16,6 +16,14 @@ The easiest way to install and use these plugins is to clone this repo::
 
     git clone --recursive https://github.com/getpelican/pelican-plugins
 
+Or via Pip::
+
+    pip install git+https://github.com/getpelican/pelican-plugins
+
+Of course equivalently via `pipenv <https://github.com/pypa/pipenv>`_::
+
+    pipenv install git+https://github.com/getpelican/pelican-plugins
+
 and activate the ones you want in your settings file::
 
     PLUGIN_PATHS = ['path/to/pelican-plugins']
@@ -233,7 +241,7 @@ Random article            Generates a html file which redirect to a random artic
 
 Read More link            Inserts an inline "read more" or "continue" link into the last html element of the object summary
 
-Readtime                  Adds article estimated read time calculator to the site, in the form of '<n> minutes'. 
+Readtime                  Adds article estimated read time calculator to the site, in the form of '<n> minutes'.
 
 Related posts             Adds the ``related_posts`` variable to the article's context
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+"""minimum config to enable distribution via pip and pipenv."""
+
+import setuptools
+
+with open('README.rst', 'r') as fh:
+    LONG_DESCRIPTION = fh.read()
+
+setuptools.setup(
+    name='pelican-plugins',
+    version='0.0.1',
+    description='A collection of plugins for the Pelican static site generator.',
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/x-rst',
+    url='https://github.com/getpelican/pelican-plugins',
+    packages=setuptools.find_packages(),
+    license='License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+    classifiers=[
+        'Framework :: Pelican :: Plugins',
+    ],
+)


### PR DESCRIPTION
hoping to relieve the following problem by adding the minimum of a `setup.py` config. if this works, will also be a good launching point for the issue at https://github.com/getpelican/pelican-plugins/issues/425.

```
> pipenv install git+ssh://github.com/getpelican/pelican-plugins
Installing git+ssh://github.com/getpelican/pelican-plugins…
WARNING: pipenv requires an #egg fragment for version controlled dependencies. Please install remote dependency in the form git+ssh://github.com/getpelican/pelican-plugins#egg=<package-name>.
✘ Installation Failed 
```

Things that I could use input from primary contributors:

1. even though this project has been around for a while, there aren't any releases listed in the [github releases](https://github.com/getpelican/pelican-plugins/releases) tab, would you like to start at semver `0.0.1`?
2. I referenced `pelican-plugins`'s [LICENSE](https://github.com/getpelican/pelican-plugins/blob/master/LICENSE) file for equivalent pypi [classifier](https://pypi.org/classifiers/) string. If you'd like this to be 3+ etc, or instead link directly to the file or such that may be important to you.
3. I'm not qualified to add authors etc. Please take those portions over during this PR or after. 

Things to do after this:

* register project with pypi via twine
  * https://pypi.org/project/twine/
* while youre at it, whomever has that token/creds, make a PR for automatic releases on git tags (or whatever criteria you want).
  * https://docs.travis-ci.com/user/deployment/pypi/
* after this is done, can change the instructions from referencing the github repo url, to the registered pypi project name
  * https://pip.pypa.io/en/stable/user_guide/#requirements-files
