### PR TITLE
Simplify Webring plugin HTTPS support

### DIFF
--- a/webring/README.md
+++ b/webring/README.md
@@ -24,17 +24,6 @@ WEBRING_FEED_URLS = []
 A list of web feeds in the form of a URL or local file.
 
 ```
-WEBRING_SUPPORT_HTTPS = True
-```
-Support HTTPS. It's enabled by default because most websites currently use HTTPS.
-
-_Nevertheless, you must be aware of the fact that this setting works by
-creating a global unverified https context. This means that any other
-http request made by pelican core and pelican plugins will not fail in case of
-an invalid SSL certificate. This is due to
-[a limitation in the feedparser module](https://github.com/kurtmckee/feedparser/issues/84)._
-
-```
 WEBRING_MAX_ARTICLES = 3
 ```
 The maximum number of articles.

--- a/webring/test_webring.py
+++ b/webring/test_webring.py
@@ -48,8 +48,8 @@ class WebringTest(unittest.TestCase):
         # Contents will be duplicated but still different, as they come from
         # two different feed URLs.
         self.settings[webring.WEBRING_FEED_URLS_STR] = [
-            os.path.join(test_data_path, 'pelican-rss.xml'),
-            os.path.join(test_data_path, 'pelican-atom.xml'),
+            'file://' + os.path.join(test_data_path, 'pelican-rss.xml'),
+            'file://' + os.path.join(test_data_path, 'pelican-atom.xml'),
         ]
 
     def get_fetched_articles(self):
@@ -94,6 +94,13 @@ class WebringTest(unittest.TestCase):
         webring.fetch_feeds(self.generators)
         articles = self.get_fetched_articles()
         self.assertTrue(not any(a.summary.endswith('...') for a in articles))
+
+    def test_malformed_url(self):
+        self.settings[webring.WEBRING_FEED_URLS_STR] = [
+            '://pelican-atom.xml',
+        ]
+        webring.fetch_feeds(self.generators)
+        self.assertEqual(len(self.get_fetched_articles()), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
After reading that [feedparser will remove its internal HTTP client in following releases](https://github.com/kurtmckee/feedparser/pull/178), it makes sense to stop using it.

This has the added benefit of removing the need to use a global unverified HTTPS context, which could be seen as a security risk.

The _Requests_ library was not used because the requirements were pretty simple and also to avoid another dependency.