### PR TITLE
Adds Feed Filter plugin

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -89,6 +89,8 @@ Events                    Add event start, duration, and location info to post m
 
 Extract table of content  Extracts table of contents (ToC) from ``article.content``
 
+Feed Filter               Filter elements from feeds according to custom rules.
+
 Figure References         Provides a system to number and references figures
 
 Filetime from Git         Uses Git commit to determine page date
@@ -233,7 +235,7 @@ Random article            Generates a html file which redirect to a random artic
 
 Read More link            Inserts an inline "read more" or "continue" link into the last html element of the object summary
 
-Readtime                  Adds article estimated read time calculator to the site, in the form of '<n> minutes'. 
+Readtime                  Adds article estimated read time calculator to the site, in the form of '<n> minutes'.
 
 Related posts             Adds the ``related_posts`` variable to the article's context
 

--- a/feed_filter/README.md
+++ b/feed_filter/README.md
@@ -1,0 +1,88 @@
+# Feed Filter Plugin
+
+This plugin allows to filter elements in feeds.
+
+## Requirements
+None.
+
+## Settings
+
+### `FEED_FILTER = {}`
+Define feed paths and include/exclude filters to apply to matching feeds. Both feed paths and filters are matched using [Unix shell-stye wildcards][1].
+
+Filters are defined as:
+* `include.item attribute`
+* `exclude.item_attribute`
+
+where `item_attribute` can be any [feed item attribute][2], ie. `title`, `link`, `author_name`, `categories`, ...
+
+You can also match `pubdate` and `updateddate` item attributes as strings formatted with the following format: `%a, %d %b %Y %H:%M:%S` (e.g. 'Thu, 28 Jun 2001 14:17:15')
+
+**Filter priorities**
+
+If an inclusion filter is defined, only feed elements that match the filter will be included in the feed.
+
+If an exclusion filter is defined, all feed elements except those which match the filter will be included in the feed.
+
+If both include and exclude filters are defined, all feed elements except those which match some exclusion filter but no inclusion filter, will be included in the feed.
+
+## Examples
+* Include only posts in some categories into the global feed:
+```
+#
+FEED_ATOM = 'feed/atom'
+FEED_RSS = 'feed/rss'
+FEED_FILTER = {
+    'feed/*': {
+        'include.categories': ('software-development', 'programming')
+    }
+}
+```
+
+* Exclude an author from a category feed:
+```
+CATEGORY_FEED_ATOM = 'feed/{slug}.atom'
+CATEGORY_FEED_RSS = 'feed/{slug}.rss'
+FEED_FILTER = {
+    'feed/a-category-slug.*': {
+        'exclude.author_name': 'An Author name'
+    }
+}
+```
+
+* Exclude an author from all category feeds:
+```
+CATEGORY_FEED_ATOM = 'feed/{slug}.atom'
+CATEGORY_FEED_RSS = 'feed/{slug}.rss'
+FEED_FILTER = {
+    'feed/*.*': {
+        'exclude.author_name': 'An Author name'
+    }
+}
+```
+
+* In the global feed, exclude all posts in a category, except if written by a given author:
+```
+FEED_ATOM = 'feed/atom'
+FEED_RSS = 'feed/rss'
+FEED_FILTER = {
+    'feed/*': {
+        'include.author_name': 'An Author name',
+        'exclude.category': 'software-development'
+    }
+}
+```
+
+* In the global feed, exclude all posts whose title starts with "Review":
+```
+FEED_ATOM = 'feed/atom'
+FEED_RSS = 'feed/rss'
+FEED_FILTER = {
+    'feed/*': {
+        'exclude.title': 'Review*'
+    }
+}
+```
+
+[1]: https://docs.python.org/3/library/fnmatch.html "Fnmatch Python module"
+[2]: https://github.com/getpelican/feedgenerator/blob/master/feedgenerator/django/utils/feedgenerator.py#L132 "Feed item attributes"

--- a/feed_filter/README.md
+++ b/feed_filter/README.md
@@ -26,6 +26,8 @@ If an exclusion filter is defined, all feed elements except those which match th
 
 If both include and exclude filters are defined, all feed elements except those which match some exclusion filter but no inclusion filter, will be included in the feed.
 
+If multiple inclusion/exclusion filters are defined for the same feed path, a single match is enough to include the item in the feed.
+
 ## Examples
 * Include only posts in some categories into the global feed:
 ```
@@ -34,7 +36,7 @@ FEED_ATOM = 'feed/atom'
 FEED_RSS = 'feed/rss'
 FEED_FILTER = {
     'feed/*': {
-        'include.categories': ('software-development', 'programming')
+        'include.categories': ['software-*', 'programming']
     }
 }
 ```
@@ -79,6 +81,19 @@ FEED_ATOM = 'feed/atom'
 FEED_RSS = 'feed/rss'
 FEED_FILTER = {
     'feed/*': {
+        'exclude.title': 'Review*'
+    }
+}
+```
+
+* In the global feed, include all posts written by a given author OR in a certain category, except if the title starts with "Review":
+```
+FEED_ATOM = 'feed/atom'
+FEED_RSS = 'feed/rss'
+FEED_FILTER = {
+    'feed/*': {
+        'include.author_name': 'An Author name',
+        'include.category': 'software-development'
         'exclude.title': 'Review*'
     }
 }

--- a/feed_filter/__init__.py
+++ b/feed_filter/__init__.py
@@ -1,0 +1,1 @@
+from .feed_filter import *

--- a/feed_filter/feed_filter.py
+++ b/feed_filter/feed_filter.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from fnmatch import fnmatch
 from urllib.parse import urlparse
 from logging import warning
-from pelican import signals, utils
+from pelican import signals
 from pelican.settings import DEFAULT_CONFIG
 
 FEED_FILTER_VERSION = '0.1'
@@ -45,6 +45,7 @@ def get_path_from_feed_url(feed):
         return ''
     return feed_path
 
+
 def apply_filters_to_feed(feed, filters):
     if len(feed.items) == 0:
         return
@@ -67,10 +68,7 @@ def apply_filters_to_feed(feed, filters):
 
     new_items = []
     for item in feed.items:
-        if len(exclusion) > 0:
-            add_it = True
-        else:
-            add_it = False
+        add_it = True if len(exclusion) > 0 else False
         for attr, value_pattern in exclusion.items():
             if attribute_match(item[attr], value_pattern):
                 add_it = False
@@ -84,7 +82,11 @@ def apply_filters_to_feed(feed, filters):
 
 def attribute_match(attr, value):
     attr = attr if not isinstance(attr, str) else [attr]
-    attr = [attr.strftime('%a, %d %b %Y %H:%M:%S')] if isinstance(attr, datetime) else attr
+    attr = (
+        [attr.strftime('%a, %d %b %Y %H:%M:%S')]
+        if isinstance(attr, datetime)
+        else attr
+    )
     value = value if not isinstance(value, str) else [value]
     for a in attr:
         for v in value:

--- a/feed_filter/feed_filter.py
+++ b/feed_filter/feed_filter.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+Feed Filter plugin for Pelican
+==============================
+
+A plugin to filter feed elements using custom filters.
+"""
+from datetime import datetime
+from fnmatch import fnmatch
+from urllib.parse import urlparse
+from logging import warning
+from pelican import signals, utils
+from pelican.settings import DEFAULT_CONFIG
+
+FEED_FILTER_VERSION = '0.1'
+
+
+def register():
+    """Signal registration."""
+    signals.initialized.connect(initialized)
+    signals.feed_generated.connect(filter_feeds)
+
+
+def initialized(pelican):
+    DEFAULT_CONFIG.setdefault('FEED_FILTER', {})
+    if pelican:
+        pelican.settings.setdefault('FEED_FILTER', {})
+
+
+def filter_feeds(context, feed):
+    feed_filters = context['FEED_FILTER']
+    for feed_path_pattern, filters in feed_filters.items():
+        feed_path = get_path_from_feed_url(feed)
+        if fnmatch(feed_path, feed_path_pattern):
+            apply_filters_to_feed(feed, filters)
+
+
+def get_path_from_feed_url(feed):
+    try:
+        feed_path = urlparse(feed.feed['feed_url']).path
+        feed_path = feed_path.strip('/')
+    except ValueError as e:
+        warning('feed_filter plugin: error parsing feed url (%s)',
+                str(e))
+        return ''
+    return feed_path
+
+def apply_filters_to_feed(feed, filters):
+    if len(feed.items) == 0:
+        return
+
+    inclusion, exclusion = dict(), dict()
+    for f, value_pattern in filters.items():
+        f_type, f_attr = f.split('.')
+        if f_attr not in feed.items[0]:
+            warning('feed_filter plugin: invalid filter attribute (%s)', f)
+            continue
+        if f_type == 'include':
+            inclusion[f_attr] = value_pattern
+        elif f_type == 'exclude':
+            exclusion[f_attr] = value_pattern
+        else:
+            warning('feed_filter plugin: invalid filter type (%s)', f)
+
+    if len(inclusion) == 0 and len(exclusion) == 0:
+        return
+
+    new_items = []
+    for item in feed.items:
+        if len(exclusion) > 0:
+            add_it = True
+        else:
+            add_it = False
+        for attr, value_pattern in exclusion.items():
+            if attribute_match(item[attr], value_pattern):
+                add_it = False
+        for attr, value_pattern in inclusion.items():
+            if attribute_match(item[attr], value_pattern):
+                add_it = True
+        if add_it:
+            new_items.append(item)
+    feed.items = new_items
+
+
+def attribute_match(attr, value):
+    attr = attr if not isinstance(attr, str) else [attr]
+    attr = [attr.strftime('%a, %d %b %Y %H:%M:%S')] if isinstance(attr, datetime) else attr
+    value = value if not isinstance(value, str) else [value]
+    for a in attr:
+        for v in value:
+            if fnmatch(a, v):
+                return True
+    return False

--- a/feed_filter/test_feed_filter.py
+++ b/feed_filter/test_feed_filter.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Feed Filter Plugin."""
+import unittest
+from datetime import datetime, timedelta
+
+from pelican.contents import Article, Category, Author
+from pelican.writers import Writer
+from pelican.utils import get_date
+from pelican.tests.support import get_context, get_settings
+
+import feed_filter
+
+
+class FeedFilterTestBase(object):
+    @classmethod
+    def setUpClass(cls):
+        feed_filter.initialized(None)
+        cls.writer = Writer('.', get_settings())
+
+    def setUp(self):
+        self.reset_settings()
+        self.articles = []
+        self.feed = None
+
+    def reset_settings(self):
+        self.context = get_context(get_settings())
+        self.context['SITEURL'] = 'https://somedomain.net'
+        self.context['SITENAME'] = 'Test Sitename'
+
+    def create_articles(self, num):
+        now = datetime.now()
+        for i in range(num, 0, -1):
+            date = now + timedelta(days=-i)
+            self.articles.append(
+                Article(
+                    'Some content',
+                    metadata={
+                        'Title': 'Title ' + '{:02n}'.format(i),
+                        'Date': date,
+                        'Category': Category('Cat', self.context),
+                        'Tags': [
+                            'TagBecomesCategoryInFeed',
+                            'OtherTag',
+                            'Tag ' + '{:02n}'.format(i)
+                        ],
+                        'Author': Author('Author ' + str(i//10), self.context)
+                    }
+                )
+            )
+
+    def create_filtered_feed(self, feed_path):
+        self.create_articles(100)
+        # setup writer attributes required to create the feed
+        self.writer.site_url = self.context['SITEURL']
+        self.writer.feed_url = self.context['SITEURL'] + '/' + feed_path
+        # create feed
+        self.feed = self.writer._create_new_feed(
+            self.feed_type,
+            'Test feed',
+            self.context
+        )
+        # add articles to feed
+        for item in self.articles:
+            self.writer._add_item_to_the_feed(self.feed, item)
+        # simulate call to feed filter plugin
+        feed_filter.filter_feeds(self.context, self.feed)
+
+    def test_unmatched_feed_path_does_nothing(self):
+        self.context['FEED_FILTER'] = {
+            'feed/global': {
+                'include.title': '*1'
+            },
+            'atom': {
+                'include.title': '*1'
+            },
+        }
+        self.create_filtered_feed('feed/' + self.feed_type)
+        # No article was removed from the feed
+        self.assertEqual(100, len(self.feed.items))
+
+    def test_only_matched_feed_paths_are_applied(self):
+        self.context['FEED_FILTER'] = {
+            'feed/global': {  # does not match
+                'include.title': '*02'
+            },
+            'feed/*': {  # match
+                'include.title': '*01'
+            }
+        }
+        self.create_filtered_feed('feed/' + self.feed_type)
+        # Only one article verifies the inclusion filter
+        self.assertEqual(1, len(self.feed.items))
+
+    def test_include_only_by_title(self):
+        self.context['FEED_FILTER'] = {
+            'feed/*': {
+                'include.title': '*05'
+            }
+        }
+        self.create_filtered_feed('feed/' + self.feed_type)
+        # Only one article verifies the inclusion filter
+        self.assertEqual(1, len(self.feed.items))
+
+    def test_exclude_only_by_category(self):
+        self.context['FEED_FILTER'] = {
+            'feed/*': {
+                'exclude.categories': 'Tag 1?'
+            }
+        }
+        self.create_filtered_feed('feed/' + self.feed_type)
+        # Articles with Tag 10, 11, 12, ... 19, are excluded from the feed
+        self.assertEqual(90, len(self.feed.items))
+
+    def test_include_exclude_by_author(self):
+        self.context['FEED_FILTER'] = {
+            'feed/category.*': {
+                'exclude.author_name': 'Author 4', # excludes 10 articles
+                'include.title': 'Title 43', # except the one with this title
+            }
+        }
+        self.create_filtered_feed('feed/category.' + self.feed_type)
+        self.assertEqual(91, len(self.feed.items))
+
+    def test_exclude_yesterday_article(self):
+        self.context['FEED_FILTER'] = {
+            'feed/category.*': {
+                'exclude.pubdate':
+                    (datetime.now() - timedelta(days=1)).strftime('*%d %b*'),
+            }
+        }
+        self.create_filtered_feed('feed/category.' + self.feed_type)
+        self.assertEqual(99, len(self.feed.items))
+
+
+class RssFeedFilterTestCase(FeedFilterTestBase, unittest.TestCase):
+    feed_type = 'rss'
+
+
+class AtomFeedFilterTestCase(FeedFilterTestBase, unittest.TestCase):
+    feed_type = 'atom'

--- a/feed_filter/test_feed_filter.py
+++ b/feed_filter/test_feed_filter.py
@@ -94,12 +94,23 @@ class FeedFilterTestBase(object):
     def test_include_only_by_title(self):
         self.context['FEED_FILTER'] = {
             'feed/*': {
-                'include.title': '*05'
+                'include.title': ['*05', '*06']
             }
         }
         self.create_filtered_feed('feed/' + self.feed_type)
         # Only one article verifies the inclusion filter
-        self.assertEqual(1, len(self.feed.items))
+        self.assertEqual(2, len(self.feed.items))
+
+    def test_multiple_includes(self):
+        self.context['FEED_FILTER'] = {
+            'feed/*': {
+                'include.title': '*05',
+                'include.categories': 'Tag 02',
+            }
+        }
+        self.create_filtered_feed('feed/' + self.feed_type)
+        # Two articles verifies the inclusion filter
+        self.assertEqual(2, len(self.feed.items))
 
     def test_exclude_only_by_category(self):
         self.context['FEED_FILTER'] = {
@@ -111,11 +122,22 @@ class FeedFilterTestBase(object):
         # Articles with Tag 10, 11, 12, ... 19, are excluded from the feed
         self.assertEqual(90, len(self.feed.items))
 
+    def test_multiple_excludes(self):
+        self.context['FEED_FILTER'] = {
+            'feed/*': {
+                'exclude.categories': 'Tag 1?',
+                'exclude.title': '*2?',
+            }
+        }
+        self.create_filtered_feed('feed/' + self.feed_type)
+        # Articles with Tag 10, 11, 12, ... 19, 20, 21, ..., 29 are excluded
+        self.assertEqual(80, len(self.feed.items))
+
     def test_include_exclude_by_author(self):
         self.context['FEED_FILTER'] = {
             'feed/category.*': {
-                'exclude.author_name': 'Author 4', # excludes 10 articles
-                'include.title': 'Title 43', # except the one with this title
+                'exclude.author_name': 'Author 4',  # excludes 10 articles
+                'include.title': 'Title 43',  # except the one with this title
             }
         }
         self.create_filtered_feed('feed/category.' + self.feed_type)
@@ -130,6 +152,18 @@ class FeedFilterTestBase(object):
         }
         self.create_filtered_feed('feed/category.' + self.feed_type)
         self.assertEqual(99, len(self.feed.items))
+
+    def test_multiple_inclusions_and_exclusions(self):
+        self.context['FEED_FILTER'] = {
+            'feed/category.*': {
+                'exclude.author_name': 'Author 4',
+                'exclude.categories': '*3?',
+                'include.title': 'Title 43',
+                'include.categories': '*33',
+            }
+        }
+        self.create_filtered_feed('feed/category.' + self.feed_type)
+        self.assertEqual(82, len(self.feed.items))
 
 
 class RssFeedFilterTestCase(FeedFilterTestBase, unittest.TestCase):


### PR DESCRIPTION
Adds a new plugin named **Feed Filter**, which allows to filter elements from feeds according to some user-configured rules.

The use case that inspired me to develop this plugin was to only include articles from some categories in the global feed.

The user can specify what feeds the rules apply to. The rules can be inclusion rules, exclusion rules or both.

Detailed documentation and tests are provided.