### PR TITLE
Add css-html-js-minify plugin

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -73,6 +73,8 @@ Collate content           Makes categories of content available to the template 
 
 Creole reader             Allows you to write your posts using the wikicreole syntax
 
+CSS HTML JS Minify        Minifies all CSS, HTML and JavaScript files in the output path after site generation.
+
 Custom article URLs       Adds support for defining different default URLs for different categories
 
 CTags generator           Generates a "tags" file following the CTags in the "content/" directory, to provide autocompletion for code editors that support it.

--- a/css-html-js-minify/__init__.py
+++ b/css-html-js-minify/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .css_html_js_minify import *

--- a/css-html-js-minify/css_html_js_minify.py
+++ b/css-html-js-minify/css_html_js_minify.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+css-html-js-minify wrapper for Pelican
+"""
+
+import glob
+import os
+import sys
+
+from css_html_js_minify import (
+    process_single_css_file,
+    process_single_html_file,
+    process_single_js_file,
+)
+from pelican import signals
+
+def main(pelican):
+    for f in glob.iglob(pelican.output_path + '/**/*.htm*', recursive=True):
+        process_single_html_file(f, overwrite=True)
+    for f in glob.iglob(pelican.output_path + '/**/*.css', recursive=True):
+        process_single_css_file(f, overwrite=True)
+    for f in glob.iglob(pelican.output_path + '/**/*.js', recursive=True):
+        process_single_js_file(f, overwrite=True)
+
+def register():
+    signals.finalized.connect(main)

--- a/css-html-js-minify/readme.rst
+++ b/css-html-js-minify/readme.rst
@@ -1,0 +1,9 @@
+css-html-js-minify wrapper for Pelican
+======================================
+
+This plugin simply finds all css, html and javascript files in the pelican
+output folder and minifies them in place using `css-html-js-minify`_.
+
+`css-html-js-minify`_ needs to be installed separately and importable.
+
+.. _`css-html-js-minify`: https://github.com/juancarlospaco/css-html-js-minify


### PR DESCRIPTION
Hello,

This PR adds another plugin, pelican-cssmin, as a submodule.

It is essentially [this](https://github.com/zacharyvoase/cssmin), which is a Python-only port of the YUI css compressor. The key differences between the pre-existing yuicompressor plugin is that this version doesn't have the original compressor as a dependency and is fully contained with the relatively small plugin.

I figured I should add this to the pile in case others wanted to use it!