### PR TITLE
Image process pypi warnings

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -129,7 +129,7 @@ I18N Sub-sites            Extends the translations functionality by creating int
 
 ical                      Looks for and parses an ``.ics`` file if it is defined in a given page's ``calendar`` metadata.
 
-Image Process             Automates the processing of images based on their class attributes
+Image Process             Automates the processing of images based on their class attributes. Make suer to check the readme.
 
 Interlinks                Lets you add frequently used URLs to your markup using short keywords
 

--- a/Readme.rst
+++ b/Readme.rst
@@ -129,7 +129,7 @@ I18N Sub-sites            Extends the translations functionality by creating int
 
 ical                      Looks for and parses an ``.ics`` file if it is defined in a given page's ``calendar`` metadata.
 
-Image Process             Automates the processing of images based on their class attributes. Make suer to check the readme.
+Image Process             Automates the processing of images. This version is depricated. Use `the PyPi version <https://pypi.org/project/pelican-image-process/>`_ instead.
 
 Interlinks                Lets you add frequently used URLs to your markup using short keywords
 
@@ -233,7 +233,7 @@ Random article            Generates a html file which redirect to a random artic
 
 Read More link            Inserts an inline "read more" or "continue" link into the last html element of the object summary
 
-Readtime                  Adds article estimated read time calculator to the site, in the form of '<n> minutes'. 
+Readtime                  Adds article estimated read time calculator to the site, in the form of '<n> minutes'.
 
 Related posts             Adds the ``related_posts`` variable to the article's context
 


### PR DESCRIPTION
Image process is now available on Pypi and the commit referenced in this project is outdated. 
By updating the reference to a commit with a warning and by updating the readme I hope to make sure that all users can transition smoothly to the next version. 

Let me know if everything is fine like this or whether adjustments are necessary. 