### PR TITLE
md_inline_extension: Fix for Python 3 compatibility

### DIFF
--- a/md_inline_extension/pelican_inline_markdown_extension.py
+++ b/md_inline_extension/pelican_inline_markdown_extension.py
@@ -29,7 +29,7 @@ class PelicanInlineMarkdownExtensionPattern(markdown.inlinepatterns.Pattern):
         if isinstance(tag_attributes, tuple):
             tag_style = tag_attributes[0]
             tag_class = tag_attributes[1] if len(tag_attributes) > 1 else ''
-        elif isinstance(tag_attributes, basestring):
+        elif isinstance(tag_attributes, str):
             tag_class = tag_attributes
 
         if tag_class != '':


### PR DESCRIPTION
substitute basestring with str to work with python3 venv