### PR TITLE
photos: skip multiprocessing queue for single-threaded processing

### DIFF
--- a/photos/photos.py
+++ b/photos/photos.py
@@ -296,19 +296,26 @@ def resize_photos(generator, writer):
     else:
         debug = False
 
-    pool = multiprocessing.Pool(generator.settings['PHOTO_RESIZE_JOBS'])
-    logger.debug('Debug Status: {}'.format(debug))
-    for resized, what in DEFAULT_CONFIG['queue_resize'].items():
-        resized = os.path.join(generator.output_path, resized)
-        orig, spec = what
-        if (not os.path.isfile(resized) or os.path.getmtime(orig) > os.path.getmtime(resized)):
-            if debug:
-                resize_worker(orig, resized, spec, generator.settings)
-            else:
-                pool.apply_async(resize_worker, (orig, resized, spec, generator.settings))
+    if generator.settings['PHOTO_RESIZE_JOBS'] > 1:
+        pool = multiprocessing.Pool(generator.settings['PHOTO_RESIZE_JOBS'])
+        logger.debug('Debug Status: {}'.format(debug))
+        for resized, what in DEFAULT_CONFIG['queue_resize'].items():
+            resized = os.path.join(generator.output_path, resized)
+            orig, spec = what
+            if (not os.path.isfile(resized) or os.path.getmtime(orig) > os.path.getmtime(resized)):
+                if debug:
+                    resize_worker(orig, resized, spec, generator.settings)
+                else:
+                    pool.apply_async(resize_worker, (orig, resized, spec, generator.settings))
 
-    pool.close()
-    pool.join()
+        pool.close()
+        pool.join()
+    else:
+        for resized, what in DEFAULT_CONFIG['queue_resize'].items():
+            resized = os.path.join(generator.output_path, resized)
+            orig, spec = what
+            if (not os.path.isfile(resized) or os.path.getmtime(orig) > os.path.getmtime(resized)):
+                resize_worker(orig, resized, spec, generator.settings)
 
 
 def detect_content(content):


### PR DESCRIPTION
AWS Lambda executions don't include [/dev/shm which is required for multiprocessing.Queue](https://aws.amazon.com/blogs/compute/parallel-processing-in-python-with-aws-lambda/).

Skipping its use when operating sequentially allows this plugin to be used on AWS Lambda, CodeBuild, etc.