### PR TITLE
fix the python 3.7 CRITICAL StopIteration bug for the next() fuction

### DIFF
--- a/neighbors/neighbors.py
+++ b/neighbors/neighbors.py
@@ -11,7 +11,10 @@ from pelican import signals
 def iter3(seq):
     it = iter(seq)
     nxt = None
-    cur = next(it)
+    try:
+        cur = next(it)
+    except StopIteration:
+        return
     for prv in it:
         yield nxt, cur, prv
         nxt, cur = cur, prv


### PR DESCRIPTION
When updating to python 3,7,
neighbor plugin got the runtime error:
```
CRITICAL: RuntimeError: generator raised StopIteration
Traceback (most recent call last):
  File "/Chinese/HongKong/Disneyland/pelican-plugins/neighbors/neighbors.py", line 14, in iter3
    cur = next(it)
StopIteration
```
This is the [py37 bug](https://stackoverflow.com/questions/51700960/runtimeerror-generator-raised-stopiteration-every-time-i-try-to-run-app).
