### PR TITLE
Add regex to better guess if there is a math class

### DIFF
--- a/render_math/math.py
+++ b/render_math/math.py
@@ -32,6 +32,7 @@ the math.  See README for more details.
 
 import os
 import sys
+import re
 
 from pelican import signals, generators
 
@@ -326,7 +327,7 @@ def rst_add_mathjax(content):
 
     # If math class is present in text, add the javascript
     # note that RST hardwires mathjax to be class "math"
-    if 'class="math"' in content._content:
+    if re.search("class=(((\"|')(.*? )?math( .*?)?\3)|(math[ />]))", content._content):
         content._content += "<script type='text/javascript'>%s</script>" % rst_add_mathjax.mathjax_script
 
 def process_rst_and_summaries(content_generators):


### PR DESCRIPTION
When using simple_footnotes plugin the HTML is rewritten omitting quotes where possible.
This cause the test `'class="math"' in content._content` to fail.

This pull request use a regex to make a better guess whether to include the Mathjax script or not.

It should work with single quotes, double quotes, no quotes and multiple classes.
Not a perfect approach but it should cover most cases.