### PR TITLE
fix(liquid_tags.include_code): do not put code inside figcaption. Add CSS classes

### DIFF
--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -120,7 +120,6 @@ plugin and add the following to your source document:
 The width and height are in pixels and are optional. If they are not specified,
 then the native video size will be used. The poster image is a preview image
 that is shown prior to initiating video playback.
-
 To link to a video file, make sure it is in a static directory, transmitted
 to your server, and available at the specified URL.
 
@@ -144,15 +143,21 @@ your source document:
     {% include_code /path/to/code.py [lang:python] [lines:X-Y] [:hidefilename:] [title] %}
 
 All arguments are optional but must be specified in the order shown above.
-If using `:hidefilename:`, a title must be provided as indicated above.
+
+    {% include_code /path/to/code.py lines:1-10 Test Example %}
+
+This example will show the first ten lines of the file.
+
+To hide filename, use `:hidefilename:`. If using `:hidefilename:`, a title must
+be provided.
+
+You can hide download link with `:hidelink:`. 
+
+If you would like to hide all three, i.e. title, filename and download link, use `:hideall:`.
+
+Following examples hides the filename.
 
     {% include_code /path/to/code.py lines:1-10 :hidefilename: Test Example %}
-
-This example will show the first ten lines of the file while hiding the actual
-filename.
-
-You can also hide download link and leave only filename with `:hidelink:`. If
-you would like to hide both title and Download link use `:hideall:`.
 
 The script must be in the `code` subdirectory of your content folder;
 the default location can be changed by specifying the directory in your

--- a/liquid_tags/include_code.py
+++ b/liquid_tags/include_code.py
@@ -111,24 +111,29 @@ def include_code(preprocessor, tag, markup):
         raise ValueError("Either title must be specified or filename must "
                          "be available")
 
-    open_tag = ''
-    close_tag = ''
-
-    open_tag = "<figure class='code'>\n<figcaption>"
+    open_tag = "<figure class='code'>\n"
     close_tag = "</figure>"
-    if not hide_all:
-        if not hide_filename:
-            title += " %s" % os.path.basename(src)
-            if lines:
-                title += " [Lines %s]" % lines
-            title = title.strip()
 
-            open_tag += "<span>{title}</span> ".format(title=title)
+    if not hide_all:
+        open_tag+= "<figcaption>"
+
+        if title:
+            open_tag += "<span class=\"liquid-tags-code-title\">{title}</span>".format(title=title.strip())
+
+        if not hide_filename:
+            filename = "%s" % os.path.basename(src)
+            open_tag += "<span class=\"liquid-tags-code-filename\">{filename}</span>".format(filename=filename.strip())
+
+        if lines:
+            lines = " [Lines %s]" % lines
+            open_tag += "<span class=\"liquid-tags-code-lines\">{lines}</span>".format(lines=lines.strip())
 
         if not hide_link:
             url = '/{0}/{1}'.format(code_dir, src)
             url = re.sub('/+', '/', url)
             open_tag += "<a href='{url}'>download</a>".format(url=url)
+
+        open_tag += "</figcaption>"
 
     # store HTML tags in the stash.  This prevents them from being
     # modified by markdown.


### PR DESCRIPTION
A regression was introduced few patches ago, which placed code inside
the `figcaption` tag. This is not correct.

The original version has this layout

```
figure
  figcaption
  code
```

This patch fixes this issue. It also encloses metadata,

1. title
2. filename
3. line number

inside CSS classes. This let's themes improve the look of the
figcaption. Previously, all the metadata was piled into one `<span>`.