### PR TITLE
Command description in readme must use quotation

### DIFF
--- a/asciidoc_reader/README.rst
+++ b/asciidoc_reader/README.rst
@@ -21,7 +21,7 @@ Settings
 ========================================  =======================================================
 Setting name (followed by default value)  What does it do?
 ========================================  =======================================================
-``ASCIIDOC_CMD = 'asciidoc'``               Selects which utility to use for rendering. Will
+``ASCIIDOC_CMD = 'asciidoc'``             Selects which utility to use for rendering. Will
                                           autodetect utility if not provided.
 ``ASCIIDOC_OPTIONS = []``                 A list of options to pass to AsciiDoc. See the `manpage
                                           <http://www.methods.co.nz/asciidoc/manpage.html>`_.

--- a/asciidoc_reader/README.rst
+++ b/asciidoc_reader/README.rst
@@ -21,7 +21,7 @@ Settings
 ========================================  =======================================================
 Setting name (followed by default value)  What does it do?
 ========================================  =======================================================
-``ASCIIDOC_CMD = asciidoc``               Selects which utility to use for rendering. Will
+``ASCIIDOC_CMD = 'asciidoc'``               Selects which utility to use for rendering. Will
                                           autodetect utility if not provided.
 ``ASCIIDOC_OPTIONS = []``                 A list of options to pass to AsciiDoc. See the `manpage
                                           <http://www.methods.co.nz/asciidoc/manpage.html>`_.


### PR DESCRIPTION
If you omit the quotation when using the setting, the following error
occurs:

....
$ make devserver

CRITICAL: NameError: name 'asciidoc' is not defined
make: *** [Makefile:71: devserver] Fehler 1
....