### PR TITLE
Theme config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,6 @@
 [submodule "similar_posts"]
 	path = similar_posts
 	url = https://github.com/davidlesieur/similar_posts.git
+[submodule "theme_config"]
+	path = theme_config
+	url = https://github.com/openwall-com-au/pelican-plugins-theme_config.git

--- a/Readme.rst
+++ b/Readme.rst
@@ -279,6 +279,8 @@ tag_cloud                 Provides a tag_cloud
 
 Textile Reader            Adds support for Textile markup
 
+`Theme Configuration`_    Allows themes to change Pelican's configuration settings via ``themeconf.py`` inside the theme directory
+
 Thumbnailer               Creates thumbnails for all of the images found under a specific directory
 
 Tipue Search              Serializes generated HTML to JSON that can be used by jQuery plugin - Tipue Search
@@ -301,6 +303,7 @@ Yuicompressor             Minify CSS and JS files on building step
 ========================  ===========================================================
 
 __ https://ace.c9.io
+.. _Theme Configuration: theme_config/
 
 Please refer to the ``Readme`` file in a plugin's folder for detailed information about
 that plugin.

--- a/Readme.rst
+++ b/Readme.rst
@@ -303,7 +303,7 @@ Yuicompressor             Minify CSS and JS files on building step
 ========================  ===========================================================
 
 __ https://ace.c9.io
-.. _Theme Configuration: theme_config/
+.. _Theme Configuration: https://github.com/openwall-com-au/pelican-plugins-theme_config
 
 Please refer to the ``Readme`` file in a plugin's folder for detailed information about
 that plugin.


### PR DESCRIPTION
Adding the theme_config plugin which gives theme authors the power to create self-contained themes with the only requirement from the end user to include this plugin in their `pelicanconf.py`.