### PR TITLE
Asciidoc: Fix "NameError: global name 'tempfile' is not defined"

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 
 def call(cmd):
     """Calls a CLI command and returns the stdout as string."""


### PR DESCRIPTION
https://github.com/getpelican/pelican/issues/2694#issuecomment-621894352

> That said, I reviewed this thread and made what I surmised to be the relevant changes to the plugin via [getpelican/pelican-plugins@22831d1](https://github.com/getpelican/pelican-plugins/commit/22831d1da399ef54d732c395b0c6a28767622542), so hopefully that fixes the reported problem. If it doesn't, or I screwed it up and broke something horribly, [...]

Well, it does cause `NameError: name 'tempfile' is not defined`. :thinking: 

> [...] by all means please submit a PR in the repository where the plugins actually live. #YOLO

Here you go, @justinmayer :smiley: