### PR TITLE
Adds figure numbers to better_figures_and_images

### DIFF
--- a/better_figures_and_images/README.rst
+++ b/better_figures_and_images/README.rst
@@ -1,7 +1,7 @@
 Requirements
 ------------
 
-* pip install pillow beautifulsoup4 pysvg-py3
+* pip install beautifulsoup4 cssutils pillow pysvg-py3
 
 Summary
 =======
@@ -16,6 +16,7 @@ This plug-in:
 
 - Corrects Alt text: If an img ``alt`` attribute equals the image filename, it sets it to ""
 
+- Inserts figure numbers into figure captions, if FIGURE_NUMBERS == True in global config, or figure_numbers exists in article metadata.
 
 Assuming that the image is 250px wide, it turns this::
 
@@ -52,3 +53,17 @@ or this, if ``RESPONSIVE_IMAGES = True``::
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
   </div>
+
+or this, if FIGURE_NUMBERS is also True::
+
+  <div class="figure" style="width: 250px; max-width: 100%; height: auto;">
+    <img style="width: 250px; max-width: 100%; height: auto;" alt="" src="/static/images/image.jpg" />
+    <p class="caption">
+        <span class="fig_num" id="fig_1">Figure 1: </span>This is the caption of the figure.
+    </p>
+    <div class="legend">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+</div>
+


### PR DESCRIPTION
PR #114 has minor differences that make patching from that commit
impossible. This commit fixed those differences.

Reordered required pip packages to an alphabetical order and added one
missing package, in README.rst

Fixes #114

Signed-off-by: Manuel Torrinha <manuel.torrinha@tecnico.ulisboa.pt>