### PR TITLE
Sitemap: Fix info log message exception

### DIFF
--- a/sitemap/sitemap.py
+++ b/sitemap/sitemap.py
@@ -218,7 +218,7 @@ class SitemapGenerator(object):
         for article in self.context['articles']:
             pages += article.translations
 
-        info('writing {0}'.format(path))
+        log.info('writing {0}'.format(path))
 
         with open(path, 'w', encoding='utf-8') as fd:
 


### PR DESCRIPTION
This fixes:

```
CRITICAL: NameError: name 'info' is not defined
Traceback (most recent call last):
  File "/home/basti/PycharmProjects/venv/blog-py3/bin/pelican", line 10, in <module>
    sys.exit(main())
  File "/home/basti/PycharmProjects/venv/blog-py3/lib/python3.8/site-packages/pelican/__init__.py", line 570, in main
    pelican.run()
  File "/home/basti/PycharmProjects/venv/blog-py3/lib/python3.8/site-packages/pelican/__init__.py", line 137, in run
    p.generate_output(writer)
  File "/home/basti/PycharmProjects/blog/pelican-plugins/sitemap/sitemap.py", line 221, in generate_output
    info('writing {0}'.format(path))
NameError: name 'info' is not defined
```