### PR TITLE
Have simple_bookmarks always quote attributes

### DIFF
--- a/simple_footnotes/simple_footnotes.py
+++ b/simple_footnotes/simple_footnotes.py
@@ -82,7 +82,7 @@ def parse_for_footnotes(article_or_page_generator):
                     ol.appendChild(li)
                     e.parentNode.removeChild(e)
                 dom.getElementsByTagName(u"body")[0].appendChild(ol)
-                s = html5lib.serializer.HTMLSerializer(omit_optional_tags=False, quote_attr_values='legacy')
+                s = html5lib.serializer.HTMLSerializer(omit_optional_tags=False, quote_attr_values='always')
                 output_generator = s.serialize(
                     html5lib.treewalkers.getTreeWalker(u"dom")(dom.getElementsByTagName(u"body")[0]))
                 article._content = u"".join(list(output_generator)).replace(

--- a/simple_footnotes/test_simple_footnotes.py
+++ b/simple_footnotes/test_simple_footnotes.py
@@ -19,9 +19,9 @@ class TestFootnotes(unittest.TestCase):
 
     def test_simple(self):
         self._expect('words[ref]footnote[/ref]end',
-        ('words<sup id=sf-article-1-back><a href=#sf-article-1 class=simple-footnote title=footnote>1</a></sup>end'
-         '<ol class=simple-footnotes>'
-         u'<li id=sf-article-1>footnote <a href=#sf-article-1-back class=simple-footnote-back>\u21a9</a></li>'
+        ('words<sup id="sf-article-1-back"><a href="#sf-article-1" class="simple-footnote" title="footnote">1</a></sup>end'
+         '<ol class="simple-footnotes">'
+         u'<li id="sf-article-1">footnote <a href="#sf-article-1-back" class="simple-footnote-back">\u21a9</a></li>'
          '</ol>'))
 
     def test_no_footnote_inside_code(self):


### PR DESCRIPTION
The regex in `Content._get_intrasite_link_regex()` expects attributes to be quoted. When `quote_attr_values` has the value `legacy` when serialising the parsed HTML with html5lib, it ends up omitting the quotes expected, which breaks intrasite links. Changing this to `always` ensures that the quotes remain present if simple_bookmarks processes the page.

I expect this will also fix #1240.