### PR TITLE
Add disclaimer for migrated plugins.

### DIFF
--- a/related_posts/Readme.rst
+++ b/related_posts/Readme.rst
@@ -1,6 +1,10 @@
 Related posts
 -------------
 
+**NOTE:** `This plugin has been moved to its own repository <https://github.com/pelican-plugins/related-posts>`_. Please file any issues/PRs there. Once all plugins have been migrated to the `new Pelican Plugins organization <https://github.com/pelican-plugins>`_, this monolithic repository will be archived.
+
+-------------------------------------------------------------------------------
+
 This plugin adds the ``related_posts`` variable to the article's context.
 By default, up to 5 articles are listed. You can customize this value by 
 defining ``RELATED_POSTS_MAX`` in your settings file::

--- a/thumbnailer/Readme.md
+++ b/thumbnailer/Readme.md
@@ -1,6 +1,10 @@
 Thumbnail Creation of images
 ============================
 
+**NOTE:** `This plugin has been moved to its own repository <https://github.com/pelican-plugins/thumbnailer>`_. Please file any issues/PRs there. Once all plugins have been migrated to the `new Pelican Plugins organization <https://github.com/pelican-plugins>`_, this monolithic repository will be archived.
+
+-------------------------------------------------------------------------------
+
 This plugin creates thumbnails for all of the images found under a specific directory, in various thumbnail sizes.
 It requires `PIL` to function properly since `PIL` is used to resize the images, and the thumbnail will only be re-built
 if it doesn't already exist (to save processing time).


### PR DESCRIPTION
`related_posts` and `thumbnailer` plugins have been moved to their own repository. Add disclaimers in the same spirit as https://github.com/getpelican/pelican-plugins/pull/1289.

Relates to https://github.com/getpelican/pelican-plugins/issues/1290.