### PR TITLE
[Migration] Flag Tipue Search as migrated

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -318,7 +318,7 @@ Sitemap                                                           `✔  <https:/
 
 Thumbnailer                                                       `✔  <https://github.com/pelican-plugins/thumbnailer>`_                    Creates thumbnails for all of the images found under a specific directory
 
-`Tipue Search <./tipue_search>`_                                                                                                            Serializes generated HTML to JSON that can be used by jQuery plugin - Tipue Search
+Tipue Search                                                      `✔  <https://github.com/pelican-plugins/tipue-search>`_                   Serializes generated HTML to JSON that can be used by jQuery plugin - Tipue Search
 
 `Touch <./touch>`_                                                                                                                          Does a touch on your generated files using the date metadata from the content
 

--- a/tipue_search/README.md
+++ b/tipue_search/README.md
@@ -1,6 +1,10 @@
 Tipue Search
 ============
 
+**NOTE:** [This plugin has been moved to its own repository](https://github.com/pelican-plugins/tipue-search). Please file any issues/PRs there. Once all plugins have been migrated to the [new Pelican Plugins organization](https://github.com/pelican-plugins), this monolithic repository will be archived.
+
+-------------------------------------------------------------------------------
+
 A Pelican plugin to serialize generated HTML to a JS variable that can be used by jQuery plugin - Tipue Search.
 
 Copyright (c) Talha Mansoor


### PR DESCRIPTION
`tipue_search` plugin has been moved to its own repository. Add disclaimers in the same spirit as https://github.com/getpelican/pelican-plugins/pull/1289 and https://github.com/getpelican/pelican-plugins/pull/1292.

Relates to https://github.com/getpelican/pelican-plugins/issues/1290.

Depends on https://github.com/pelican-plugins/tipue-search/pull/1.