### PR TITLE
Flag similar-posts plugin as migrated

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -296,7 +296,7 @@ Series                                                            `✔  <https:/
 
 `Show Source <./show_source>`_                                                                                                              Place a link to the source text of your posts.
 
-Similar Posts                                                     `❓ <https://github.com/davidlesieur/similar_posts>`_                     Adds a list of similar posts to every article's context.
+Similar Posts                                                     `✔  <https://github.com/pelican-plugins/similar-posts>`_                  Adds a list of similar posts to every article's context.
 
 Simple footnotes                                                  `✔  <https://github.com/pelican-plugins/simple-footnotes>`_               Adds footnotes to blog posts
 


### PR DESCRIPTION
Similar Posts plugin is about to be release as an independent Python package for the first time, and can be flagged as migrated.

This PR depends on https://github.com/pelican-plugins/similar-posts/pull/5