### PR TITLE
[Migration] Flag Liquid Tags plugin as migrated

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -168,7 +168,7 @@ Lightbox                                                          `❓ <https://
 
 `Linker <./linker>`_                                                                                                                        Allows the definition of custom linker commands in analogy to the builtin ``{filename}``, ``{attach}``, ``{category}``, ``{tag}``, ``{author}``, and ``{index}`` syntax
 
-`Liquid-style tags <./liquid_tags>`_                                                                                                        Allows liquid-style tags to be inserted into markdown within Pelican documents
+`Liquid-style tags <./liquid_tags>`_                              `✔  <https://github.com/pelican-plugins/liquid-tags>`_                    Allows liquid-style tags to be inserted into markdown within Pelican documents
 
 Load CSV                                                          `❓ <https://github.com/e9t/pelican-loadcsv>`_                            Adds ``csv`` Jinja tag to display the contents of a CSV file as an HTML table
 

--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -1,4 +1,9 @@
 # Liquid-style Tags
+
+**NOTE:** [This plugin has been moved to its own repository](https://github.com/pelican-plugins/liquid-tags). Please file any issues/PRs there. Once all plugins have been migrated to the [new Pelican Plugins organization](https://github.com/pelican-plugins), this monolithic repository will be archived.
+
+ -------------------------------------------------------------------------------
+
 *Author: Jake Vanderplas <jakevdp@cs.washington.edu>*
 
 This plugin allows liquid-style tags to be inserted into Markdown within


### PR DESCRIPTION
Depends on https://github.com/pelican-plugins/liquid-tags/issues/1