### PR TITLE
[asciidoc-reader] Make metadata parsing regex less restrictive

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -98,7 +98,7 @@ class AsciiDocReader(BaseReader):
                         metadata['title'] = self.process_metadata('title', title)
 
                 # Parse for other metadata.
-                regexp = re.compile(r"^:[A-z]+:\s*\w")
+                regexp = re.compile(r"^:\w+:")
                 if regexp.search(line):
                     toks = line.split(":", 2)
                     key = toks[1].strip().lower()


### PR DESCRIPTION
Currently, the metadata parsing regex look like this:

```py
regexp = re.compile(r"^:[A-z]+:\s*\w")
```

The `\w` part is quite restrictive on allowed values. For example, if I start a metadata value with a period, the metadata will be ignored (which is how I discovered this). I don't see any good reason to make it restrictive at all - why care what characters people want to put in the metadata value?

This regex just accepts whatever until the end of the line:

```py
regexp = re.compile(r"^:[A-z]+:\s*.*$")
```

Given that this isn't capturing anything, just matching, why not simplify even further:

```py
regexp = re.compile(r"^:\w+:")
```