### PR TITLE
[pelican_comment_system] Fix _get_writer() call

### DIFF
--- a/pelican_comment_system/pelican_comment_system.py
+++ b/pelican_comment_system/pelican_comment_system.py
@@ -85,7 +85,7 @@ def initialize(article_generator):
     # Reset old states (autoreload mode)
     global _all_comments
     global _pelican_writer
-    _pelican_writer = _pelican_obj.get_writer()
+    _pelican_writer = _pelican_obj._get_writer()
     _all_comments = []
 
 def warn_on_slug_collision(items):


### PR DESCRIPTION
## Goal

This pull request fix the following error with the `pelican_comment_system` plugin:
```
CRITICAL: 'Pelican' object has no attribute 'get_writer'
```

## Explanation

Since https://github.com/getpelican/pelican/pull/2821 `get_writer()` is renamed `_get_writer()`, this pull request only rename this function call.