### PR TITLE
[i18n_subsites] Allow merging the base settings with the translations settings.

### DIFF
--- a/Contributing.rst
+++ b/Contributing.rst
@@ -22,10 +22,6 @@ explanations and usage details into the ``ReadMe`` file.
 
 ``__init__.py`` should contain a single line with ``from .my_plugin import *``.
 
-Place tests for your plugin in the same folder inside ``test_my_plugin.py``.
-If you need content or templates in your tests, you can use the main
-``test_data`` folder for that purpose.
-
 **Note:** Each plugin can contain a LICENSE file stating the license it's
 released under. If there is an absence of LICENSE then it defaults to the
 *GNU AFFERO GENERAL PUBLIC LICENSE Version 3*. Please refer to the ``LICENSE``
@@ -37,3 +33,22 @@ order) and providing a brief description.
 
 .. _guidelines: http://docs.getpelican.com/en/latest/contribute.html#using-git-and-github
 .. _docs: http://docs.getpelican.com/en/latest/plugins.html#how-to-create-plugins
+
+
+Automated testing
+-----------------
+
+Place tests for your plugin in the same folder inside ``test_my_plugin.py``.
+If you need content or templates in your tests, you can use the main
+``test_data`` folder for that purpose.
+
+Tests for various plugins might fail as they lack dependencies or are not
+maintained for the latest pelican version.
+To run the test you will need at least the basic pelican packages installed
+as a dependency::
+
+   pip install pelican
+
+To run the test for your pluging run::
+
+   python -m unittest i18n_subsites/test_i18n_subsites.py

--- a/i18n_subsites/README.rst
+++ b/i18n_subsites/README.rst
@@ -145,6 +145,7 @@ to link to the main site.
 This short `howto <./implementing_language_buttons.rst>`_ shows two
 example implementations of language buttons.
 
+
 Usage notes
 ===========
 - It is **mandatory** to specify ``lang`` metadata for each article
@@ -158,8 +159,12 @@ Usage notes
   give articles e.g. ``name`` metadata and use it in ``ARTICLE_URL =
   '{name}.html'``.
 
+
 Development
 ===========
 
 - A demo and a test site is in the ``gh-pages`` branch and can be seen
   at http://smartass101.github.io/pelican-plugins/
+- A demo site used for automated end to end testing is defined in
+  i18n_subsites/test_data.
+- Run the tests using `python -m unittest i18n_subsites/test_i18n_subsites.py`

--- a/i18n_subsites/test_data/localized_theme/templates/base.html
+++ b/i18n_subsites/test_data/localized_theme/templates/base.html
@@ -1,6 +1,10 @@
 {% extends "!simple/base.html" %}
 
-{% block title %}{% trans %}Welcome to our{% endtrans %} {{ SITENAME }}{% endblock %}
+{% block title %}
+{% trans %}Welcome to our{% endtrans %} {{ L10N.SITE_NAME }} | {{ L10N.COMPANY.NAME }} {{ L10N.COMPANY.INCORPORATION }}
+{% endblock %}
+
+
 {% block head %}
 {{ super() }}
 <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/style.css" />

--- a/i18n_subsites/test_data/pelicanconf.py
+++ b/i18n_subsites/test_data/pelicanconf.py
@@ -2,15 +2,9 @@
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
 
-AUTHOR = 'The Tester'
-SITENAME = 'Testing site'
 SITEURL = 'http://example.com/test'
-
 # to make the test suite portable
 TIMEZONE = 'UTC'
-
-DEFAULT_LANG = 'en'
-LOCALE = 'en_US.UTF-8'
 
 # Generate only one feed
 FEED_ALL_ATOM = 'feeds_all.atom.xml'
@@ -38,15 +32,40 @@ from blinker import signal
 tmpsig = signal('tmpsig')
 I18N_FILTER_SIGNALS = [tmpsig]
 
+DEFAULT_LANG = 'en'
+
+# Base setting used to render the theme.
+AUTHOR = 'The Tester'
+
+LOCALE = 'en_US.UTF-8'
+# Having all the translatable values in a root dict help organize
+# the translation and coordinate with the development and
+# the translation teams.
+L10N = {
+    'SITE_NAME': 'Testing site',
+    'COMPANY': {
+        # This is not translated to test deep merge.
+        'NAME': 'Acme',
+        # This is translated.
+        'INCORPORATION': 'Ltd'
+        },
+}
+
+# Translation for pelicanconf.py settings.
 I18N_SUBSITES = {
     'de': {
-        'SITENAME': 'Testseite',
         'AUTHOR': 'Der Tester',
+        'L10N': {
+            'SITE_NAME': 'Testseite',
+            'COMPANY': {'INCORPORATION': 'AG'}
+        },
         'LOCALE': 'de_DE.UTF-8',
         },
     'cz': {
-        'SITENAME': 'Testovací stránka',
         'AUTHOR': 'Test Testovič',
+        'L10N': {
+            'SITE_NAME': 'Testovací stránka',
+        },
         'I18N_UNTRANSLATED_PAGES': 'remove',
         'I18N_UNTRANSLATED_ARTICLES': 'keep',
         },

--- a/i18n_subsites/test_i18n_subsites.py
+++ b/i18n_subsites/test_i18n_subsites.py
@@ -155,5 +155,5 @@ class TestFullRun(unittest.TestCase):
             )
 
         # Check jinja2 translation.
-        self.assertIn('Welcome to our Testing site', root_index)
-        self.assertIn('Willkommen Sie zur unserer Testseite', de_index)
+        self.assertIn('Welcome to our Testing site | Acme Ltd', root_index)
+        self.assertIn('Willkommen Sie zur unserer Testseite | Acme AG', de_index)

--- a/i18n_subsites/test_i18n_subsites.py
+++ b/i18n_subsites/test_i18n_subsites.py
@@ -42,12 +42,12 @@ class TestSettingsManipulation(unittest.TestCase):
         self.settings['PELICAN_CLASS'] = object
         cls = i18ns.get_pelican_cls(self.settings)
         self.assertIs(cls, object)
-        
+
     def test_get_pelican_cls_str(self):
         '''Test that we get correct class given by string'''
         cls = i18ns.get_pelican_cls(self.settings)
         self.assertIs(cls, Pelican)
-        
+
 
 class TestSitesRelpath(unittest.TestCase):
     '''Test relative path between sites generation'''
@@ -72,7 +72,7 @@ class TestSitesRelpath(unittest.TestCase):
         self.assertEqual(i18ns.relpath_to_site('en', 'de'), 'de')
         self.assertEqual(i18ns.relpath_to_site('de', 'en'), '..')
 
-        
+
 class TestRegistration(unittest.TestCase):
     '''Test plugin registration'''
 
@@ -91,49 +91,69 @@ class TestRegistration(unittest.TestCase):
             self.assertIn(id(handler), sig.receivers)
             # clean up
             sig.disconnect(handler)
-        
+
 
 class TestFullRun(unittest.TestCase):
     '''Test running Pelican with the Plugin'''
 
-    def setUp(self):
-        '''Create temporary output and cache folders'''
-        self.temp_path = mkdtemp(prefix='pelicantests.')
-        self.temp_cache = mkdtemp(prefix='pelican_cache.')
+    def cleanDirs(self, dirs):
+        """
+        Recursive delete each path from `dirs`.
+        """
+        for path in dirs:
+            rmtree(path)
 
-    def tearDown(self):
-        '''Remove output and cache folders'''
-        rmtree(self.temp_path)
-        rmtree(self.temp_cache)
+    def getContent(self, base, target):
+        """
+        Return the text content of file.
+        """
+        path = os.path.join(base, target)
+        with open(path, 'r') as stream:
+            return stream.read()
 
     def test_sites_generation(self):
-        '''Test generation of sites with the plugin
+        """
+        It will generate multiple copies of the site.
 
-        Compare with recorded output via ``git diff``.
-        To generate output for comparison run the command
-        ``pelican -o test_data/output -s test_data/pelicanconf.py \
-        test_data/content``
-        Remember to remove the output/ folder before that.
-        '''
+        Once copy is the default language, and the others are copies for each
+        enabled language in I18N_SUBSITES
+        from i18n_subsites/test_data/pelicanconf.py
+        """
+        output_path = mkdtemp(prefix='pelicantests.')
+        cache_path = mkdtemp(prefix='pelican_cache.')
+        self.addCleanup(self.cleanDirs, [output_path, cache_path])
+
         base_path = os.path.dirname(os.path.abspath(__file__))
         base_path = os.path.join(base_path, 'test_data')
         content_path = os.path.join(base_path, 'content')
-        output_path = os.path.join(base_path, 'output')
         settings_path = os.path.join(base_path, 'pelicanconf.py')
         settings = read_settings(path=settings_path, override={
             'PATH': content_path,
-            'OUTPUT_PATH': self.temp_path,
-            'CACHE_PATH': self.temp_cache,
+            'OUTPUT_PATH': output_path,
+            'CACHE_PATH': cache_path,
             'PLUGINS': [i18ns],
             }
         )
         pelican = Pelican(settings)
         pelican.run()
 
-        # compare output
-        out, err = subprocess.Popen(
-            ['git', 'diff', '--no-ext-diff', '--exit-code', '-w', output_path,
-             self.temp_path], env={'PAGER': ''},
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-        self.assertFalse(out, 'non-empty `diff` stdout:\n{}'.format(out))
-        self.assertFalse(err, 'non-empty `diff` stderr:\n{}'.format(err))
+        root_deploy = os.listdir(output_path)
+        self.assertIn('de', root_deploy)
+        self.assertIn('cz', root_deploy)
+
+        root_index = self.getContent(output_path, 'index.html')
+        de_index = self.getContent(output_path, 'de/index.html')
+
+        # Check pelicanconf,py translation.
+        self.assertIn(
+            'example.com/test/author/the-tester.html">The Tester</a>',
+            root_index
+            )
+        self.assertIn(
+            'example.com/test/de/author/der-tester.html">Der Tester</a>',
+            de_index
+            )
+
+        # Check jinja2 translation.
+        self.assertIn('Welcome to our Testing site', root_index)
+        self.assertIn('Willkommen Sie zur unserer Testseite', de_index)


### PR DESCRIPTION
To help organize the translations any text from pelicanconf.py that is presented on the site is put in a common dictionary 

I have simplified the tests.

to run the tests
```
virtualenv venv
. venv/bin/activate
pip install pelican
python -m unittest i18n_subsites/test_i18n_subsites.py
```

--------------

An example

```
L10N = {
    'author': 'Pro:Atria Team',
    'company': 'Pro:Atria Ltd',
    'company_number': '4213930',
    'product': 'SFTPPlus',
    'email': {
        'contact': 'contact@proatria.com',
        'sales': 'sales@proatria.com',
        'support': 'support@proatria.com',
        },
    'menu': [
        # Text, URL, category.
        ('Product', '/product/', 'product'),
        ('Support', '/support/', 'support'),
        ('Contact', '/about/contact.html', 'contact'),
        ],
    }

I18N_SUBSITES = { 'de': 'L10N': {
    'company': 'Pro:Atria Ag',
    # The other emails are kept as in the main site.
    'email': {'sale': 'sales@proatria.de'},
    'menu': [
        # Text, URL, category.
        ('Produkt', '/de/product/', 'product'),
        ('Support', '/de/support/', 'support'),
        ('Kontakt', '/de/about/contact.html', 'contact'),
        ],
}}
```