### PR TITLE
[events] fixed: populate events-list template variable with the Article() objects

### DIFF
--- a/events/events.py
+++ b/events/events.py
@@ -131,9 +131,9 @@ def generate_ical_file(generator):
     for e in curr_events:
         ie = icalendar.Event(
             summary=e.metadata['summary'],
-            dtstart=e.event_plugin_data["dtstart"],
-            dtend=e.event_plugin_data["dtend"],
-            dtstamp=e.metadata['date'],
+            dtstart=e.event_plugin_data["dtstart"].isoformat(),
+            dtend=e.event_plugin_data["dtend"].isoformat(),
+            dtstamp=e.metadata['date'].isoformat(),
             priority=5,
             uid=e.metadata['title'] + e.metadata['summary'],
         )

--- a/events/events.py
+++ b/events/events.py
@@ -76,6 +76,10 @@ field in the '%s' event.""" % (c, metadata['title']))
     return timedelta(**tdargs)
 
 
+def basic_isoformat(datetime_value):
+    return datetime_value.strftime("%Y%m%dT%H%M%S")
+
+
 def parse_article(content):
     """Collect articles metadata to be used for building the event calendar
 
@@ -131,9 +135,9 @@ def generate_ical_file(generator):
     for e in curr_events:
         ie = icalendar.Event(
             summary=e.metadata['summary'],
-            dtstart=e.event_plugin_data["dtstart"].isoformat(),
-            dtend=e.event_plugin_data["dtend"].isoformat(),
-            dtstamp=e.metadata['date'].isoformat(),
+            dtstart=basic_isoformat(e.event_plugin_data["dtstart"]),
+            dtend=basic_isoformat(e.event_plugin_data["dtend"]),
+            dtstamp=basic_isoformat(e.metadata['date']),
             priority=5,
             uid=e.metadata['title'] + e.metadata['summary'],
         )

--- a/events/events_list.html
+++ b/events/events_list.html
@@ -7,26 +7,26 @@
 
     {% if events_list %}
     <ul class="post-list">
-    {% for evstart, evend, event in events_list %}
+    {% for event in events_list %}
       <li>
         <p>
-          <a href="../{{event.slug}}.html">
-            <b>{{event['title']}}</b>
+          <a href="{{ SITEURL }}/{{ event.url }}">
+            <b>{{ event.metadata["title"] }}</b>
           </a>
         </p>
         <p>
-        {% if evstart.date() == evend.date() %}
-        From {{evstart}} to {{evend.time()}}
+        {% if event.event_plugin_data["dtstart"].date() == event.event_plugin_data["dtend"].date() %}
+        From {{ event.event_plugin_data["dtstart"] }} to {{ event.event_plugin_data["dtend"].time() }}
         {% else %}
-        From {{evstart}} to {{evend}}
+        From {{ event.event_plugin_data["dtstart"] }} to {{ event.event_plugin_data["dtend"] }}
         {% endif %}
         </p>
 
         {% if event.location %}
-        <p>Location: {{event.location}}</p>
+        <p>Location: {{ event.metadata["location"] }}</p>
         {% endif %}
 
-        <p>{{event['summary']}}</p>
+        <p>{{ event.metadata["summary"] }}</p>
 
       </li>
     {% endfor %}


### PR DESCRIPTION
… instead of just lightweight Event()-objects. This enables the template to place links to the real article url. Pages therefore do not need to have a slug header anymore for these links to work.