### PR TITLE
i18n_subsites redirects to navigator's wanted language (if available)

### DIFF
--- a/i18n_subsites/README.rst
+++ b/i18n_subsites/README.rst
@@ -56,6 +56,7 @@ dictionary must be given (but can be empty) in the ``I18N_SUBSITES`` dictionary
 You must also have the following in your pelican configuration
 
 .. code-block:: python
+
     JINJA_ENVIRONMENT = {
         'extensions': ['jinja2.ext.i18n'],
     }
@@ -144,6 +145,42 @@ to link to the main site.
 
 This short `howto <./implementing_language_buttons.rst>`_ shows two
 example implementations of language buttons.
+
+
+Automatically redirect to browser's default language
+====================================================
+
+If you implemented language buttons as explained above, you can also setup some
+JavaScript to automatically reload a page using the browser's accepted lang.
+
+You need to copy the ``accept-lang.js`` file to your ``static/js`` folder and
+load it via your ``base.html`` template adding this line somewhere at the
+bottom:
+
+.. code-block:: html
+
+    <script src="/theme/js/accept-lang.js"></script>
+
+If your default language is not english, you also have to declare a JavaScript
+variable ``default_lang`` *before* the line that loads ``accept-lang.js``:
+
+.. code-block:: html
+
+    <script type="text/javascript">var default_lang = "{{DEFAULT_LANG}}"; </script>
+
+How language redirection works
+------------------------------
+
+The script checks the lang only at the first page of a navigation on the
+website (i.e. if there is no referrer or if the referrer does not contain your
+website's domain). This way, if the user clicks on a particular lang via the
+language buttons, he will stick to the choosen language.
+
+The script then compares the current website lang and the browser's wanted
+lang. If it's not a match, the script tries to find a link to the correct
+translation in the page. If at least one corresponding link is found, it clicks
+on the first one, and that's why it needs language buttons.
+
 
 Usage notes
 ===========

--- a/i18n_subsites/accept-lang.js
+++ b/i18n_subsites/accept-lang.js
@@ -1,0 +1,59 @@
+/**
+ *
+ * @source: https://github.com/getpelican/pelican-plugins/raw/master/i18n_subsites/accept-lang.js
+ *
+ * @licstart  The following is the entire license notice for the
+ *  JavaScript code in this page.
+ *
+ * Copyright (C) 2018  Simon Descarpentries
+ *
+ *
+ * The JavaScript code in this page is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU
+ * General Public License (GNU GPL) as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.  The code is distributed WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
+ *
+ * As additional permission under GNU GPL version 3 section 7, you
+ * may distribute non-source (e.g., minimized or compacted) forms of
+ * that code without the copy of the GNU GPL normally required by
+ * section 4, provided you include this license notice and a URL
+ * through which recipients can access the Corresponding Source.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this page.
+ *
+ */
+// name   : accept-lang.js
+// author : Simon Descarpentries, simon /\ acoeuro [] com
+// date   : 2018-01
+// licence: GPLv3
+//
+
+(function (){
+	'use strict'
+	const FOUND = 0
+	var default_lang = default_lang || 'en'
+	var page_lang = document.documentElement.lang
+	var nav_lang = navigator.language.slice(0,2)
+	var domain_part = document.URL.split('/').slice(0,3).join('/')
+	if (document.referrer.indexOf(domain_part) == FOUND || page_lang == nav_lang) {
+		console.log('No need to change lang')
+		return
+	}
+	console.info('Should change lang from '+page_lang+' to '+nav_lang)
+	var slice_nb = page_lang != default_lang ? 4 : 3  // default_lang has no lang prefix
+	var page_part = document.URL.split('/').slice(slice_nb).join('/')
+	var lang_link = domain_part
+	lang_link += nav_lang != default_lang ? '/'+nav_lang : ''
+	lang_link += page_part ? '/'+page_part : ''  // avoid slash if index/no page_part
+	var lang_sel = 'a[href="'+lang_link+'"]'
+	console.log('Search for '+lang_sel+' to click on')
+	var lang_node = document.querySelector(lang_sel)
+	if (lang_node)
+		lang_node.click()
+	else
+		console.error('Link '+lang_sel+' not found')
+}())


### PR DESCRIPTION
New clean version of https://github.com/getpelican/pelican-plugins/issues/975

Add an accept-lang.js file and the associated documentation to allow users to get the visitor's browsers redirected to it's language (when available).

It checks if the current i18n sub-sites is the one corresponding to the browsers wanted language, if not it searchs for a link to this wanted i18n sub-sites and clicks on it.