### PR TITLE
asciidoc_reader: Don't process content twice

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -60,7 +60,6 @@ class AsciiDocReader(BaseReader):
             logger.debug('AsciiDocReader: Reading: %s', source_path)
             optlist = self.settings.get('ASCIIDOC_OPTIONS', []) + self.default_options
             options = " ".join(optlist)
-            content = call("%s %s -o - \"%s\"" % (cmd, options, source_path))
             # Beware! # Don't use tempfile.NamedTemporaryFile under Windows: https://bugs.python.org/issue14243
             # Also, use mkstemp correctly (Linux and Windows): https://www.logilab.org/blogentry/17873
             fd, temp_name = tempfile.mkstemp()


### PR DESCRIPTION
We process the content twice, once on line 63, then again on 67 - just keep the last one.