### PR TITLE
new Legacy branch

### DIFF
--- a/Readme-legacy.rst
+++ b/Readme-legacy.rst
@@ -1,26 +1,34 @@
-Pelican Plugins
-###############
+----------------------------------------------------------------------------
 
-**Important note:** We are in the process of migrating plugins from this monolithic repository to their own individual repositories under the new `Pelican Plugins`_ organization, a place for plugin authors to collaborate more broadly with Pelican maintainers and other members of the community. The intention is for all the plugins under the new organization to be in the new “namespace plugin” format, which means these plugins can easily be Pip-installed and recognized immediately by Pelican 4.5+ — without having to explicitly enable them.
+*This fork is a prototype to demo an alternate way of organizing and
+presenting the pelican-plugins repo in way that is easier to track and
+understand the difference between pre- and and post- Pelican v4.5 plugins.*
 
-This transition process will take some time, so we appreciate your patience in the interim. If you would like to help speed up this transition, the following would be very helpful:
+*The default branch has been renamed to ``main`` from ``master`` to ensure
+people learn about the post-v4.5 migration and only use legacy plugins on purpose.*
 
-* **If you find a plugin here that has not yet been migrated to the new organization**, create a new issue under this repository and communicate which plugin you would like to help migrate, after which a Pelican maintainer will guide you through the process.
+*To make this demo 'real' search and replace ``github.com/maphew`` with 
+``github.com/getpelican`` and delete these paragraphs before merging
+the Pull Request.*
 
-* **If you have come here to submit a pull request to add your plugin**, please consider instead moving your plugin under the `Pelican Plugins`_ organization. To get started, create a new issue under this repository with the details of your plugin, after which a Pelican maintainer will guide you through the process.
+----------------------------------------------------------------------------
 
-Whether you are creating a new plugin or migrating an existing plugin, please use the provided `Cookiecutter template <https://github.com/getpelican/cookiecutter-pelican-plugin>`_ to generate a scaffolded namespace plugin that conforms to community conventions. Have a look at the `Simple Footnotes <https://github.com/pelican-plugins/simple-footnotes>`_ repository to see an example of a migrated plugin.
+Legacy Pelican Plugins
+######################
 
-The rest of the information below is relevant for legacy plugins but not for the new namespace plugins found at the `Pelican Plugins`_ organization.
+This is the readme for legacy plugins prior to release of Pelican v4.5. Please see
+main plugins `Readme`_ for 4.5+ and the new namespace plugins found at the
+`Pelican Plugins`_ organization.
 
+.. _Readme: Readme.rst
 .. _Pelican Plugins: https://github.com/pelican-plugins
 
 How to use plugins
 ==================
 
-The easiest way to install and use these plugins is to clone this repo::
+To install and use these plugins clone this repo and branch::
 
-    git clone --recursive https://github.com/getpelican/pelican-plugins
+    git clone --branch legacy --recursive https://github.com/maphew/pelican-plugins
 
 and activate the ones you want in your settings file::
 

--- a/Readme.rst
+++ b/Readme.rst
@@ -1,0 +1,42 @@
+Pelican Plugins
+###############
+
+**Important note:** We are in the process of migrating plugins from this monolithic repository to their own individual repositories under the new `Pelican Plugins`_ organization, a place for plugin authors to collaborate more broadly with Pelican maintainers and other members of the community. The intention is for all the plugins under the new organization to be in the new “namespace plugin” format, which means these plugins can easily be Pip-installed and recognized immediately by Pelican 4.5+ — without having to explicitly enable them.
+
+This transition process will take some time, so we appreciate your patience in the interim. If you would like to help speed up this transition, the following would be very helpful:
+
+* **If you find a plugin here that has not yet been migrated to the new organization**, create a new issue under this repository and communicate which plugin you would like to help migrate, after which a Pelican maintainer will guide you through the process.
+
+* **If you have come here to submit a pull request to add your plugin**, please consider instead moving your plugin under the `Pelican Plugins`_ organization. To get started, create a new issue under this repository with the details of your plugin, after which a Pelican maintainer will guide you through the process.
+
+Whether you are creating a new plugin or migrating an existing plugin, please use the provided `Cookiecutter template <https://github.com/getpelican/cookiecutter-pelican-plugin>`_ to generate a scaffolded namespace plugin that conforms to community conventions. Have a look at the `Simple Footnotes <https://github.com/pelican-plugins/simple-footnotes>`_ repository to see an example of a migrated plugin.
+
+The rest of the information below is relevant for legacy plugins but not for the new namespace plugins found at the `Pelican Plugins`_ organization.
+
+.. _Pelican Plugins: https://github.com/pelican-plugins
+
+Legacy plugins
+==================
+
+Legacy plugins are in the **legacy** branch and will probably not work with
+Pelican v4.5 and newer without changes.
+
+To install and use these plugins clone this repo and the legacy branch::
+
+    git clone --branch legacy --recursive https://github.com/maphew/pelican-plugins
+
+And then refer to ``Readme-legacy`` document at top of the ``pelican-plugins``
+folder.
+
+----------------------------------------------------------------------------
+
+*This fork is a prototype to demo an alternate way of organizing and
+presenting the pelican-plugins repo in way that is easier to track and
+understand the difference between pre- and and post- Pelican v4.5 plugins.*
+
+*The default branch has been renamed to ``main`` from ``master`` to ensure
+people learn about the post-v4.5 migration and only use legacy plugins on purpose.*
+
+*To make this demo 'real' search and replace ``github.com/maphew`` with 
+``github.com/getpelican`` and delete these footer paragraphs before merging
+the Pull Request.*

--- a/disqus_static/README.rst
+++ b/disqus_static/README.rst
@@ -58,3 +58,8 @@ Usage
         </ul>
     </div>
     {% endif %}
+    
+Issues
+-----
+If you run into an error: "No module named 'httplib'" then please see the following.
+https://github.com/disqus/disqus-python/issues/34

--- a/github_activity/Readme.rst
+++ b/github_activity/Readme.rst
@@ -32,4 +32,4 @@ variable, as in this example::
 ``github_activity`` is a list of lists. The first element is the title,
 and the second element is the raw HTML from GitHub.
 
-.. _feedparser: https://crate.io/packages/feedparser/
+.. _feedparser: https://pypi.org/project/feedparser/

--- a/liquid_tags/Readme.md
+++ b/liquid_tags/Readme.md
@@ -17,7 +17,7 @@ can be added as follows.
 
 First, in your pelicanconf.py file, add the plugins you want to use:
 
-    PLUGIN_PATH = '/path/to/pelican-plugins'
+    PLUGIN_PATHS = ['/path/to/pelican-plugins']
     PLUGINS = ['liquid_tags.img', 'liquid_tags.video',
                'liquid_tags.youtube', 'liquid_tags.vimeo',
                'liquid_tags.include_code', 'liquid_tags.notebook']


### PR DESCRIPTION
See #1379. PR 2 of 2. 

Changes: 
- Rename Readme to Readme-Legacy, clarify checkout branch instructions, 90% unchanged
- Add the Readme from the new Main branch