### PR TITLE
fix section number plugin to handle html title with attribut

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Markdown
 nose
 nose-exclude
 nose-summary-report
+beautifulsoup4


### PR DESCRIPTION
Hello,

I propose this fix to support title numbering of html title tag containing attributs. Actually there is weak parsing which does not handle this case, see the following [section_number/section_number.py#L12](https://github.com/getpelican/pelican-plugins/blob/master/section_number/section_number.py#L12). I have replaced the current parsing with a call to beautifulsoup parser and some logic to number titles and subtitles. As a result, the code is more compact, readable and solves this problem.

Sorry I don't have the time to incorporate this fix in the new plugin system, because that would mean writing a plugin via the new path, that's why I propose the fix on this repository. You are free to accept it.