### PR TITLE
`bootstrap-rst`: Math header is an array, so should be joined not appended

### DIFF
--- a/bootstrap-rst/bootstrap.py
+++ b/bootstrap-rst/bootstrap.py
@@ -266,7 +266,7 @@ class HTMLTranslator(PelicanHTMLTranslator):
         self.meta.insert(0, self.content_type % self.settings.output_encoding)
         self.head.insert(0, self.content_type % self.settings.output_encoding)
         if self.math_header:
-            self.head.append(self.math_header)
+            self.head += self.math_header
         # skip content-type meta tag with interpolated charset value:
         self.html_head.extend(self.head[1:])
         # self.body_prefix.append(self.starttag(node, 'div', CLASS='document'))


### PR DESCRIPTION
bootstrap-rst was crashing with recent docutils, issue was the handling of math_header which caused an excpetion in `docutils/writers/_html_base.py`:
```
                    ", line 167, in interpolation_dict
                        subs[attr] = ''.join(getattr(self,
                    attr)).rstrip('\n')
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                    TypeError: sequence item 2: expected str instance,
                    list found
```
