### PR TITLE
asciidoc-reader: support multiline AsciiDoc attributes

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -85,7 +85,8 @@ class AsciiDocReader(BaseReader):
         metadata = {}
         with open(source_path, encoding='utf-8') as fi:
             prev = ""
-            for line in fi.readlines():
+            lines = iter(fi.readlines())
+            for line in lines:
                 # Parse for doc title.
                 if 'title' not in metadata.keys():
                     title = ""
@@ -102,6 +103,11 @@ class AsciiDocReader(BaseReader):
                     toks = line.split(":", 2)
                     key = toks[1].strip().lower()
                     val = toks[2].strip()
+                    # Support for soft-wrapped attributes:
+                    # https://docs.asciidoctor.org/asciidoc/latest/attributes/wrap-values/#soft-wrap-attribute-values
+                    while val.endswith("\\"):
+                        line = next(lines)
+                        val = val[:-1] + line.strip()
                     metadata[key] = self.process_metadata(key, val)
                 prev = line
         logger.debug('AsciiDocReader: Found metadata: %s', metadata)

--- a/asciidoc_reader/test_asciidoc_reader.py
+++ b/asciidoc_reader/test_asciidoc_reader.py
@@ -65,6 +65,29 @@ class AsciiDocReaderTest(unittest.TestCase):
         expected = "".join(expected.splitlines())
         self.assertEqual(actual, expected)
 
+    def test_article_with_asc_multiline(self):
+        # test to ensure that multiline metadata is correctly parsed
+        page = self.read_file(path="article_with_asc_multiline.asc")
+        expected = [
+            '<div id="preamble">',
+            '<div class="sectionbody">',
+            '<div class="paragraph">',
+            '<p>Content starts here!</p>',
+            '</div>',
+            '</div>',
+            '</div>',
+        ]
+        actual = "".join(page.content.splitlines())
+        expected = "".join(expected)
+        self.assertEqual(actual, expected)
+
+        expected = {
+            'author': 'Jane Doe',
+            'description': 'A very long and descriptive description!',
+        }
+        for key, value in expected.items():
+            self.assertEqual(value, page.metadata[key])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/asciidoc_reader/test_data/article_with_asc_multiline.asc
+++ b/asciidoc_reader/test_data/article_with_asc_multiline.asc
@@ -1,0 +1,8 @@
+Test AsciiDoc File Header
+=========================
+:Description: A very \
+    long and descriptive \
+    description!
+:Author: Jane Doe
+
+Content starts here!


### PR DESCRIPTION
According to the Asciidoctor reference [1], multiline attributes are supported by ending the previous line with a backslash. This can be useful for long attributes, such as the description, and it matches what you can already do with reStructuredText.

[1]: https://docs.asciidoctor.org/asciidoc/latest/attributes/wrap-values/