### PR TITLE
[asciidoc_reader] use `shutil.which` to detect available binaries

### DIFF
--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -13,7 +13,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import tempfile
 
 import logging

--- a/asciidoc_reader/asciidoc_reader.py
+++ b/asciidoc_reader/asciidoc_reader.py
@@ -11,6 +11,7 @@ from pelican.readers import BaseReader
 from pelican import signals
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -37,7 +38,7 @@ def call(cmd):
 def default():
     """Attempt to find the default AsciiDoc utility."""
     for cmd in ALLOWED_CMDS:
-        if len(call(cmd + " --help")):
+        if shutil.which(cmd):
             logger.debug('AsciiDocReader: Using cmd: %s', cmd)
             return cmd
 


### PR DESCRIPTION
`shutil.which` is a standard and multiplatform solution to perform checks like this.

This solves the issue described in #1401.