### PR TITLE
[representative_image] Also process draft & hidden articles & pages

### DIFF
--- a/representative_image/representative_image.py
+++ b/representative_image/representative_image.py
@@ -1,4 +1,5 @@
 import six
+from itertools import chain
 from bs4 import BeautifulSoup
 
 from pelican import signals
@@ -43,12 +44,12 @@ def images_extraction(instance):
 def run_plugin(generators):
     for generator in generators:
         if isinstance(generator, ArticlesGenerator):
-            for article in generator.articles:
+            for article in chain(generator.articles, generator.hidden_articles, generator.drafts):
                 images_extraction(article)
                 for translation in article.translations:
                     images_extraction(translation)
         elif isinstance(generator, PagesGenerator):
-            for page in generator.pages:
+            for page in chain(generator.pages, generator.hidden_pages, generator.draft_pages):
                 images_extraction(page)
                 for translation in page.translations:
                     images_extraction(translation)


### PR DESCRIPTION
I have a few hidden pages on a my website, and I could not figure why the representative image was incorrect.

This very short PR simply aims to generate representative images for ALL kind of articles & pages.

I tested it on my own blog, and it works fine.