### PR TITLE
[representative_image] Avoid a CRITICAL error in case of <img> without "src" attribute

### DIFF
--- a/representative_image/representative_image.py
+++ b/representative_image/representative_image.py
@@ -31,7 +31,7 @@ def images_extraction(instance):
         if not representativeImage:
             soup = BeautifulSoup(instance._content, 'html.parser')
             imageTag = soup.find('img')
-            if imageTag:
+            if imageTag and 'src' in imageTag:
                 representativeImage = imageTag['src']
 
         # Set the attribute to content instance


### PR DESCRIPTION
Without this fix, when an article contains an `<img>` with no `src` attribute, Pelican crashes:
```
Traceback (most recent call last):
  File "~/.local/share/virtualenvs/ludochaordic/lib/python3.10/site-packages/pelican/__init__.py", line 679, in main
    pelican.run()
  File "~/.local/share/virtualenvs/ludochaordic/lib/python3.10/site-packages/pelican/__init__.py", line 133, in run
    signals.all_generators_finalized.send(generators)
  File "~/.local/share/virtualenvs/ludochaordic/lib/python3.10/site-packages/blinker/base.py", line 307, in send
    result = receiver(sender, **kwargs)
  File "~/pelican-plugins/representative_image/representative_image.py", line 48, in run_plugin
    images_extraction(article)
  File "~/pelican-plugins/representative_image/representative_image.py", line 35, in images_extraction
    representativeImage = imageTag['src']
  File "~/.local/share/virtualenvs/ludochaordic/lib/python3.10/site-packages/bs4/element.py", line 2206, in __getitem__
    return self.attrs[key]
KeyError: 'src'
[15:38:22] CRITICAL [15:38:22] [pelican] CRITICAL KeyError: 'src'
```